### PR TITLE
Add Vercel deployment config

### DIFF
--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -16,7 +16,7 @@ import {
   Line,
 } from 'recharts';
 import { db } from '../db/db';
-import type { ReviewLog, Sentence } from '../db/schema';
+import type { ReviewLog } from '../db/schema';
 
 interface DayBucket {
   date: string;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/(.*)", "destination": "/" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `vercel.json` with SPA rewrite rule — all routes fall back to `index.html` so React Router handles `/browse`, `/review`, etc.
- Fix unused `Sentence` import in StatsPage that broke `tsc` build

## To deploy
1. Go to [vercel.com](https://vercel.com) → Add New Project → Import `sboshar/mandao`
2. Vercel auto-detects Vite — defaults are correct (build: `npm run build`, output: `dist`)
3. Click Deploy

Every push to `main` will auto-deploy after this.

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)