### PR TITLE
Remove tutorial sentences from DB on finish/skip

### DIFF
--- a/src/services/ingestion.ts
+++ b/src/services/ingestion.ts
@@ -392,6 +392,30 @@ export async function updateSentenceTags(sentenceId: string, tags: string[]): Pr
   await db.sentences.update(sentenceId, { tags });
 }
 
+/** Delete all tutorial sentences and their associated tokens and SRS cards */
+export async function deleteTutorialSentences(): Promise<void> {
+  const tutorialSentences = await db.sentences
+    .where('source')
+    .equals('tutorial')
+    .toArray();
+
+  if (tutorialSentences.length === 0) return;
+
+  const sentenceIds = tutorialSentences.map((s) => s.id);
+
+  await db.transaction(
+    'rw',
+    [db.sentences, db.sentenceTokens, db.srsCards],
+    async () => {
+      for (const id of sentenceIds) {
+        await db.sentenceTokens.where('sentenceId').equals(id).delete();
+        await db.srsCards.where('sentenceId').equals(id).delete();
+      }
+      await db.sentences.where('source').equals('tutorial').delete();
+    }
+  );
+}
+
 /** Get all meanings that share the same pinyin (for pinyin card) */
 export async function getMeaningsByPinyin(
   pinyinNumeric: string

--- a/src/stores/tutorialStore.ts
+++ b/src/stores/tutorialStore.ts
@@ -1,4 +1,5 @@
 import { create } from 'zustand';
+import { deleteTutorialSentences } from '../services/ingestion';
 
 /**
  * Tutorial steps:
@@ -35,10 +36,12 @@ export const useTutorialStore = create<TutorialState>((set) => ({
     set((s) => {
       const next = Math.min(s.step + 1, MAX_STEP) as TutorialStep;
       localStorage.setItem(STORAGE_KEY, String(next));
+      if (s.step === 6) deleteTutorialSentences();
       return { step: next };
     }),
   skipAll: () => {
     localStorage.setItem(STORAGE_KEY, String(MAX_STEP));
+    deleteTutorialSentences();
     set({ step: MAX_STEP as TutorialStep });
   },
 }));


### PR DESCRIPTION
## Summary
- Adds `deleteTutorialSentences()` in `ingestion.ts` that removes all sentences with `source: 'tutorial'` along with their tokens and SRS cards
- Calls it from `tutorialStore` when the user clicks "Finish tutorial" (step 6→7) or "Skip tutorial"

Closes #29

## Test plan
- [ ] Complete the tutorial normally — verify tutorial sentences are removed from Browse page
- [ ] Reset tutorial (clear localStorage), start again, click "Skip tutorial" — verify sentences are removed
- [ ] Verify non-tutorial sentences are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)