### PR TITLE
Make app mobile-responsive

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -72,10 +72,10 @@ function App() {
   return (
     <BrowserRouter>
       <div className="min-h-screen" style={{ background: 'var(--bg-base)' }}>
-        <div className="fixed top-3 right-4 z-40 flex items-center gap-2">
+        <div className="fixed top-3 right-3 sm:right-4 z-40 flex items-center gap-1.5 sm:gap-2">
           <button
             onClick={signOut}
-            className="px-2.5 py-1 rounded-md text-xs transition-colors"
+            className="px-2 sm:px-2.5 py-1 rounded-md text-xs transition-colors"
             style={{ color: 'var(--text-tertiary)' }}
           >
             Sign out

--- a/src/components/IntroModal.tsx
+++ b/src/components/IntroModal.tsx
@@ -56,9 +56,9 @@ export function IntroModal({ onDone }: { onDone: () => void }) {
 
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center" style={{ background: 'rgba(0,0,0,0.5)' }}>
-      <div className="rounded-2xl shadow-xl max-w-lg w-full mx-4 max-h-[90vh] overflow-y-auto surface">
+      <div className="rounded-2xl shadow-xl max-w-lg w-full mx-3 sm:mx-4 max-h-[90vh] overflow-y-auto surface">
         {page === 0 && (
-          <div className="p-8">
+          <div className="p-5 sm:p-8">
             <h2 className="text-2xl font-bold mb-4">Welcome to Mandao</h2>
             <p className="mb-4" style={{ color: 'var(--text-secondary)' }}>
               Mandao is built around one idea: <strong>learn Mandarin through whole sentences,
@@ -109,7 +109,7 @@ export function IntroModal({ onDone }: { onDone: () => void }) {
         )}
 
         {page === 1 && (
-          <div className="p-8">
+          <div className="p-5 sm:p-8">
             <h2 className="text-2xl font-bold mb-2">How Sentences Look</h2>
             <p className="text-sm mb-3" style={{ color: 'var(--text-tertiary)' }}>
               Each sentence displays three layers of information:
@@ -156,7 +156,7 @@ export function IntroModal({ onDone }: { onDone: () => void }) {
         )}
 
         {page === 2 && (
-          <div className="p-8">
+          <div className="p-5 sm:p-8">
             <h2 className="text-2xl font-bold mb-4">Let's Add Your First Sentence</h2>
             <p className="mb-4" style={{ color: 'var(--text-secondary)' }}>
               We'll walk you through adding the first example sentence step by step.
@@ -174,7 +174,7 @@ export function IntroModal({ onDone }: { onDone: () => void }) {
         )}
 
         {/* Navigation */}
-        <div className="px-8 pb-6 flex items-center justify-between">
+        <div className="px-5 sm:px-8 pb-6 flex items-center justify-between">
           <div className="text-sm" style={{ color: 'var(--text-tertiary)' }}>
             {page + 1} / {totalPages}
           </div>

--- a/src/components/MeaningCard.tsx
+++ b/src/components/MeaningCard.tsx
@@ -71,8 +71,8 @@ function MeaningContent() {
 
   return (
     <>
-      <div className="p-6 text-center">
-        <div className="text-5xl mb-2">
+      <div className="p-4 sm:p-6 text-center">
+        <div className="text-4xl sm:text-5xl mb-2">
           {headwordChars.map((char, i) => (
             <ClickableChar
               key={i}
@@ -325,7 +325,7 @@ export function MeaningCard() {
       onClick={(e) => { if (e.target === e.currentTarget) handleClose(); }}
     >
       <div
-        className="surface rounded-lg shadow-xl max-w-lg w-full mx-4 max-h-[80vh] overflow-y-auto"
+        className="surface rounded-lg shadow-xl max-w-lg w-full mx-3 sm:mx-4 max-h-[90vh] sm:max-h-[80vh] overflow-y-auto"
       >
         {/* Header */}
         <div

--- a/src/components/PinyinIMEInput.tsx
+++ b/src/components/PinyinIMEInput.tsx
@@ -67,7 +67,8 @@ export function PinyinIMEInput({ value, onChange, placeholder, readOnly }: Pinyi
   return (
     <div className="relative">
       <div className="flex items-center w-full px-3 py-2 border rounded-lg focus-within:ring-2
-        focus-within:ring-blue-500 focus-within:border-blue-500 bg-white">
+        focus-within:ring-blue-500 focus-within:border-blue-500"
+        style={{ background: 'var(--bg-surface)', borderColor: 'var(--border)' }}>
         {value && <span className="text-lg mr-1" lang="zh">{value}</span>}
         <input
           ref={inputRef}
@@ -84,14 +85,18 @@ export function PinyinIMEInput({ value, onChange, placeholder, readOnly }: Pinyi
       </div>
 
       {candidates.length > 0 && (
-        <div className="absolute z-50 mt-1 w-full bg-white border rounded-lg shadow-lg
-          max-h-64 overflow-y-auto">
+        <div className="absolute z-50 mt-1 w-full border rounded-lg shadow-lg
+          max-h-48 sm:max-h-64 overflow-y-auto"
+          style={{ background: 'var(--bg-surface)', borderColor: 'var(--border)' }}>
           {candidates.map((entry, i) => (
             <button
               key={`${entry.simplified}-${i}`}
               onClick={() => selectCandidate(entry)}
-              className={`w-full text-left px-3 py-2 flex items-center gap-3 text-sm
-                hover:bg-blue-50 ${i === selectedIndex ? 'bg-blue-50' : ''}`}
+              className={`w-full text-left px-3 py-2 min-h-[44px] flex items-center gap-3 text-sm
+                transition-colors`}
+              style={{
+                background: i === selectedIndex ? 'var(--bg-inset)' : 'transparent',
+              }}
             >
               <span className="text-xl" lang="zh">{entry.simplified}</span>
               <span className="text-gray-400 text-xs">{entry.pinyin}</span>

--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -71,7 +71,7 @@ export function ReviewCard() {
       </div>
 
       {/* Card */}
-      <div className="surface rounded-xl shadow-lg p-8 min-h-[300px] flex flex-col">
+      <div className="surface rounded-xl shadow-lg p-4 sm:p-8 min-h-[250px] sm:min-h-[300px] flex flex-col">
         {/* Front */}
         <div className="flex-1 flex flex-col items-center justify-center">
           {isEnToZh ? (
@@ -186,7 +186,7 @@ export function ReviewCard() {
             </div>
 
             {/* Rating buttons */}
-            <div className="mt-6 grid grid-cols-4 gap-2">
+            <div className="mt-6 grid grid-cols-2 sm:grid-cols-4 gap-2">
               {([
                 { rating: 1 as const, label: 'Again', color: 'var(--rating-again)' },
                 { rating: 2 as const, label: 'Hard', color: 'var(--rating-hard)' },
@@ -196,7 +196,7 @@ export function ReviewCard() {
                 <button
                   key={btn.rating}
                   onClick={() => handleRate(btn.rating)}
-                  className="py-3 rounded-lg font-medium transition-colors"
+                  className="py-3 min-h-[44px] rounded-lg font-medium transition-colors"
                   style={{
                     background: `color-mix(in srgb, ${btn.color} 15%, var(--bg-surface))`,
                     color: btn.color,

--- a/src/pages/AddSentencePage.tsx
+++ b/src/pages/AddSentencePage.tsx
@@ -239,7 +239,7 @@ export function AddSentencePage() {
   };
 
   return (
-    <div className="max-w-2xl mx-auto p-6">
+    <div className="max-w-2xl mx-auto p-4 sm:p-6">
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-2xl font-bold">Add Sentence</h1>
         <button
@@ -481,7 +481,7 @@ export function AddSentencePage() {
                   <summary className="cursor-pointer" style={{ color: 'var(--text-tertiary)' }}>
                     Edit fields
                   </summary>
-                  <div className="mt-2 grid grid-cols-2 gap-2">
+                  <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-2">
                     <div>
                       <label className="block text-xs mb-0.5" style={{ color: 'var(--text-tertiary)' }}>Pinyin (tone numbers)</label>
                       <input
@@ -605,8 +605,8 @@ export function AddSentencePage() {
                   className="flex items-center gap-3 text-sm py-1"
                   style={{ borderBottom: '1px solid var(--border-light)' }}
                 >
-                  <span className="text-lg w-16 text-right">{t.surfaceForm}</span>
-                  <span className="w-24" style={{ color: 'var(--text-secondary)' }}>
+                  <span className="text-lg w-12 sm:w-16 text-right">{t.surfaceForm}</span>
+                  <span className="w-20 sm:w-24" style={{ color: 'var(--text-secondary)' }}>
                     {t.pinyinSandhi || numericStringToDiacritic(t.pinyinNumeric)}
                   </span>
                   <span className="flex-1">{t.english}</span>

--- a/src/pages/BrowsePage.tsx
+++ b/src/pages/BrowsePage.tsx
@@ -91,9 +91,9 @@ export function BrowsePage() {
   };
 
   return (
-    <div className="max-w-2xl mx-auto p-6">
-      <div className="flex items-center justify-between mb-6">
-        <h1 className="text-2xl font-bold">Browse Sentences</h1>
+    <div className="max-w-2xl mx-auto p-4 sm:p-6">
+      <div className="flex items-center justify-between gap-2 mb-6">
+        <h1 className="text-xl sm:text-2xl font-bold">Browse Sentences</h1>
         <div className="flex gap-2">
           {sentences.length > 0 && (
             <button

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -33,7 +33,7 @@ export function DashboardPage() {
   const totalDue = counts.newCount + counts.reviewCount + counts.learningCount;
 
   return (
-    <div className="max-w-xl mx-auto px-6 py-10">
+    <div className="max-w-xl mx-auto px-4 sm:px-6 py-8 sm:py-10">
       <h1 className="text-2xl font-semibold tracking-tight mb-10">ManDao</h1>
 
       <TutorialBanner visibleAt={2}>
@@ -51,7 +51,7 @@ export function DashboardPage() {
       </TutorialBanner>
 
       {/* Stats — subtle inline row */}
-      <div className="flex gap-8 mb-10">
+      <div className="flex gap-4 sm:gap-8 mb-10">
         {[
           { value: totalSentences, label: 'Sentences' },
           { value: totalMeanings, label: 'Meanings' },
@@ -85,7 +85,7 @@ export function DashboardPage() {
       </div>
 
       {/* Quick actions — ghost buttons */}
-      <div className="flex gap-2">
+      <div className="grid grid-cols-3 sm:flex gap-2">
         {[
           { label: '+ Add', path: '/add', onClick: () => navigate('/add') },
           {
@@ -103,7 +103,7 @@ export function DashboardPage() {
           <button
             key={btn.label}
             onClick={btn.onClick}
-            className={`flex-1 py-2 rounded-lg text-sm font-medium transition-colors ${
+            className={`flex-1 py-2 min-h-[44px] rounded-lg text-sm font-medium transition-colors ${
               btn.highlight ? 'ring-1' : ''
             }`}
             style={{
@@ -116,10 +116,10 @@ export function DashboardPage() {
             {btn.label}
           </button>
         ))}
-        <div className="relative flex-1">
+        <div className="relative">
           <button
             onClick={() => navigate('/speak')}
-            className="w-full py-2 rounded-lg text-sm font-medium transition-colors"
+            className="w-full py-2 min-h-[44px] rounded-lg text-sm font-medium transition-colors"
             style={{
               background: 'transparent',
               color: 'var(--text-secondary)',

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -326,7 +326,7 @@ export function GraphPage() {
   return (
     <div className="h-screen flex flex-col bg-slate-950">
       {/* Header */}
-      <div className="flex items-center justify-between px-6 py-3 bg-slate-900/80 backdrop-blur border-b border-slate-800">
+      <div className="flex flex-wrap items-center justify-between gap-2 px-4 sm:px-6 py-3 bg-slate-900/80 backdrop-blur border-b border-slate-800">
         <button
           onClick={() => navigate('/')}
           className="px-3 py-1.5 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-300
@@ -334,10 +334,10 @@ export function GraphPage() {
         >
           &larr; Back
         </button>
-        <h1 className="text-lg font-medium text-slate-200">
+        <h1 className="text-lg font-medium text-slate-200 hidden sm:block">
           MànDào Graph
         </h1>
-        <div className="flex items-center gap-4 text-xs text-slate-500">
+        <div className="flex items-center gap-2 sm:gap-4 text-xs text-slate-500">
           <span className="flex items-center gap-1.5">
             <span
               className="inline-block w-2.5 h-2.5 rounded-full"

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -44,7 +44,7 @@ export function ReviewPage() {
 
   if (!started) {
     return (
-      <div className="p-6 max-w-md mx-auto">
+      <div className="p-4 sm:p-6 max-w-md mx-auto">
         <div className="flex items-center justify-between mb-8">
           <button
             onClick={() => navigate('/')}
@@ -115,7 +115,7 @@ export function ReviewPage() {
             <button
               key={opt.key}
               onClick={() => { setMode(opt.key); startReview(opt.key); }}
-              className="w-full p-4 rounded-lg text-left transition-colors"
+              className="w-full p-3 sm:p-4 rounded-lg text-left transition-colors"
               style={{
                 background: mode === opt.key ? 'var(--bg-inset)' : 'var(--bg-surface)',
                 border: `2px solid ${mode === opt.key ? MODE_COLORS[opt.key] : 'var(--border)'}`,
@@ -131,7 +131,7 @@ export function ReviewPage() {
   }
 
   return (
-    <div className="p-6">
+    <div className="p-4 sm:p-6">
       <div className="flex items-center justify-between mb-6 max-w-2xl mx-auto">
         <button
           onClick={() => { reset(); setStarted(false); }}

--- a/src/pages/SpeakPage.tsx
+++ b/src/pages/SpeakPage.tsx
@@ -416,7 +416,7 @@ export function SpeakPage() {
           ) : (
             <>
               {/* Per-character comparison grid */}
-              <div className="flex justify-center gap-1 mb-4">
+              <div className="flex flex-wrap justify-center gap-1 mb-4">
                 {comparison.map((r, i) => {
                   const color = r.status === 'match' ? 'var(--success)' : 'var(--danger)';
                   const isMismatch = r.status === 'mismatch';

--- a/src/pages/StatsPage.tsx
+++ b/src/pages/StatsPage.tsx
@@ -230,7 +230,7 @@ export function StatsPage() {
   ];
 
   return (
-    <div className="max-w-4xl mx-auto p-6">
+    <div className="max-w-4xl mx-auto p-4 sm:p-6">
       <div className="flex items-center gap-4 mb-8">
         <button
           onClick={() => navigate('/')}
@@ -243,7 +243,7 @@ export function StatsPage() {
       </div>
 
       {/* Summary cards */}
-      <div className="grid grid-cols-4 gap-4 mb-8">
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 sm:gap-4 mb-8">
         {[
           { value: totalReviews, label: 'Total Reviews' },
           { value: todayCount, label: 'Today' },
@@ -281,7 +281,7 @@ export function StatsPage() {
       </div>
 
       {/* Reviews per day */}
-      <div className="surface rounded-lg p-6 mb-6">
+      <div className="surface rounded-lg p-4 sm:p-6 mb-6">
         <h2 className="text-lg font-medium mb-4">Reviews per Day</h2>
         <ResponsiveContainer width="100%" height={250}>
           <BarChart data={daily}>
@@ -305,7 +305,7 @@ export function StatsPage() {
       </div>
 
       {/* Cumulative reviews */}
-      <div className="surface rounded-lg p-6 mb-6">
+      <div className="surface rounded-lg p-4 sm:p-6 mb-6">
         <h2 className="text-lg font-medium mb-4">Cumulative Reviews</h2>
         <ResponsiveContainer width="100%" height={250}>
           <LineChart data={cumulative}>
@@ -332,7 +332,7 @@ export function StatsPage() {
       </div>
 
       {/* Bottom row */}
-      <div className="grid grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-6">
         <div className="surface rounded-lg p-6">
           <h2 className="text-lg font-medium mb-4">Rating Distribution</h2>
           {totalReviews > 0 ? (

--- a/src/services/llmPrompt.ts
+++ b/src/services/llmPrompt.ts
@@ -135,6 +135,10 @@ export function parseLLMResponse(raw: string): LLMResponse {
   cleaned = cleaned.replace(/\s*```$/i, '');
   cleaned = cleaned.trim();
 
+  // Normalize curly/smart quotes to straight quotes (LLMs sometimes produce these)
+  cleaned = cleaned.replace(/[\u201C\u201D\u201E\u201F\u2033\u2036]/g, '"');
+  cleaned = cleaned.replace(/[\u2018\u2019\u201A\u201B\u2032\u2035]/g, "'");
+
   try {
     const parsed = JSON.parse(cleaned);
 


### PR DESCRIPTION
## Summary
- Add Tailwind responsive breakpoints (`sm:`) across all 7 pages and 4 key components so the app works on phones (375px+)
- Fix critical layout breaks: review rating buttons (4-col → 2-col on mobile), stats cards (4-col → 2-col), dashboard actions (flex → 3-col grid), token edit fields (2-col → 1-col)
- Make modals (MeaningCard, IntroModal) near-full-height on mobile with tighter margins
- Add 44px minimum touch targets on interactive elements
- Fix PinyinIMEInput to use theme CSS variables instead of hardcoded `bg-white`/`bg-blue-50`
- Normalize smart/curly quotes in LLM JSON parser

## Test plan
- [ ] Test on iPhone SE (375px) and standard phone (390px) in Chrome DevTools
- [ ] Verify Review page: rating buttons are 2-col, card padding is reduced, "Show Answer" is full-width
- [ ] Verify Dashboard: stats row doesn't overflow, action buttons wrap into grid
- [ ] Verify Stats page: summary cards are 2x2, pie charts stack vertically
- [ ] Verify AddSentence: token edit fields are single column, confirm step token list isn't cramped
- [ ] Verify MeaningCard modal: nearly full-screen on mobile, scrollable
- [ ] Verify Graph page: legend wraps, back button accessible
- [ ] Verify PinyinIME input works in dark mode

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)