### PR TITLE
Fix page headers overlapping fixed nav on mobile

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -132,6 +132,7 @@ function App() {
           </button>
           <ThemeToggle />
         </div>
+        <div className="h-10" />
         {step === 0 && <IntroModal onDone={advance} />}
         <Routes>
           <Route


### PR DESCRIPTION
## Summary
- Add a top spacer (`h-10`) so all page content clears the fixed Synced / Sign out / theme toggle bar
- Fixes overlap on Stats, Browse, and all other pages on mobile

## Test plan
- [ ] Stats page title no longer overlaps with Synced/Sign out
- [ ] Browse page Back/title/Delete All no longer overlap with top controls
- [ ] Dashboard still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)