### PR TITLE
Replace CEDICT tokenization with LLM-based tokenization

### DIFF
--- a/src/pages/AddSentencePage.tsx
+++ b/src/pages/AddSentencePage.tsx
@@ -4,10 +4,8 @@ import { ingestSentence, type TokenInput, type CharacterInput } from '../service
 import {
   generateAnalysisPrompt,
   parseLLMResponse,
-  getExistingMeaningsForSegments,
+  getExistingMeanings,
 } from '../services/llmPrompt';
-import { tokenizeSentence } from '../services/tokenizer';
-import { loadCedict, isLoaded as cedictLoaded } from '../lib/cedict';
 import { numericStringToDiacritic } from '../services/toneSandhi';
 import { PinyinIMEInput } from '../components/PinyinIMEInput';
 import { TutorialBanner } from '../components/TutorialBanner';
@@ -34,24 +32,14 @@ export function AddSentencePage() {
 
   const [chinese, setChinese] = useState('');
   const [english, setEnglish] = useState('');
-  const [segments, setSegments] = useState<string[]>([]);
   const [tokens, setTokens] = useState<TokenFormData[]>([]);
-  const [step, setStep] = useState<'input' | 'segment' | 'review' | 'confirm'>('input');
+  const [step, setStep] = useState<'input' | 'llm' | 'review' | 'confirm'>('input');
   const [error, setError] = useState('');
   const [saving, setSaving] = useState(false);
-  const [dictLoading, setDictLoading] = useState(false);
   const [llmPasteValue, setLlmPasteValue] = useState('');
   const [promptCopied, setPromptCopied] = useState(false);
   const [usePinyinIME, setUsePinyinIME] = useState(false);
   const [tags, setTags] = useState<string[]>([]);
-
-  // Load dictionary on mount
-  useEffect(() => {
-    if (!cedictLoaded()) {
-      setDictLoading(true);
-      loadCedict().then(() => setDictLoading(false));
-    }
-  }, []);
 
   // Tutorial mode: pre-fill Chinese sentence
   useEffect(() => {
@@ -60,44 +48,21 @@ export function AddSentencePage() {
     }
   }, [isTutorial, tutorialStep, step]);
 
-  // Step 1 → Step 2: Auto-segment with CC-CEDICT
-  const handleSegment = () => {
+  // Step 1 → Step 2: Go to LLM prompt step
+  const handleNext = () => {
     if (!chinese.trim()) {
       setError('Please enter a Chinese sentence.');
       return;
     }
     setError('');
-    const rawTokens = tokenizeSentence(chinese.trim());
-    const segs = rawTokens
-      .map((t) => t.text)
-      .filter((t) => t.trim().length > 0 && !/^[。，！？；：、《》（）""''…·\s]$/.test(t));
-    setSegments(segs);
-    setStep('segment');
+    setStep('llm');
   };
 
-  // Segment editing
-  const handleSplitSegment = (index: number) => {
-    const seg = segments[index];
-    if (seg.length <= 1) return;
-    const chars = Array.from(seg);
-    const newSegs = [...segments];
-    newSegs.splice(index, 1, ...chars);
-    setSegments(newSegs);
-  };
-
-  const handleMergeSegments = (index: number) => {
-    if (index >= segments.length - 1) return;
-    const newSegs = [...segments];
-    const merged = newSegs[index] + newSegs[index + 1];
-    newSegs.splice(index, 2, merged);
-    setSegments(newSegs);
-  };
-
-  // Copy LLM prompt with segments
+  // Copy LLM prompt (LLM handles tokenization)
   const handleCopyPrompt = async () => {
     setError('');
-    const existingMeanings = await getExistingMeaningsForSegments(segments);
-    const prompt = generateAnalysisPrompt(chinese.trim(), segments, existingMeanings);
+    const existingMeanings = await getExistingMeanings(chinese.trim());
+    const prompt = generateAnalysisPrompt(chinese.trim(), existingMeanings);
     await navigator.clipboard.writeText(prompt);
     setPromptCopied(true);
     setTimeout(() => setPromptCopied(false), 2000);
@@ -228,7 +193,6 @@ export function AddSentencePage() {
       } else {
         setChinese('');
         setEnglish('');
-        setSegments([]);
         setTokens([]);
         setTags([]);
         setStep('input');
@@ -314,62 +278,30 @@ export function AddSentencePage() {
             <TagInput tags={tags} onChange={setTags} />
           </div>
           <button
-            onClick={handleSegment}
-            disabled={dictLoading || !chinese.trim()}
+            onClick={handleNext}
+            disabled={!chinese.trim()}
             className={`w-full py-3 rounded-lg font-medium disabled:opacity-50 transition-colors ${
               isTutorial && tutorialStep === 1 ? 'ring-2 ring-offset-2' : ''
             }`}
             style={{ background: 'var(--accent)', color: 'var(--text-inverted)' }}
           >
-            {dictLoading ? 'Loading dictionary...' : 'Next: Segment Words'}
+            Next: Analyze with LLM
           </button>
         </div>
       )}
 
-      {/* Step 2: Adjust segmentation + copy LLM prompt */}
-      {step === 'segment' && (
+      {/* Step 2: Copy LLM prompt + paste response */}
+      {step === 'llm' && (
         <div className="space-y-4">
           {isTutorial && tutorialStep === 1 && (
             <TutorialBanner visibleAt={1}>
-              The app auto-segmented the sentence using the CC-CEDICT dictionary. You can
-              split or merge tokens if needed. Normally you'd copy a prompt to an LLM to get
-              pinyin and meanings &mdash; for this tutorial, click <strong>Use Tutorial Data</strong> to skip that step.
+              Normally you'd copy a prompt to an LLM to get tokenization, pinyin, and
+              meanings &mdash; for this tutorial, click <strong>Use Tutorial Data</strong> to skip that step.
             </TutorialBanner>
           )}
 
           <div className="p-3 rounded-lg inset">
             <div className="text-lg">{chinese}</div>
-          </div>
-
-          <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-            Adjust word boundaries: click a word to split into characters, or{' '}
-            <strong>+</strong> to merge adjacent tokens.
-          </p>
-
-          {/* Segment editing */}
-          <div className="flex flex-wrap gap-1 items-center p-3 rounded-lg surface">
-            {segments.map((seg, i) => (
-              <div key={i} className="flex items-center">
-                <button
-                  onClick={() => handleSplitSegment(i)}
-                  className="px-3 py-2 rounded-lg text-xl transition-colors"
-                  style={{ border: '2px solid var(--border)', background: 'var(--bg-surface)' }}
-                  title={seg.length > 1 ? 'Click to split' : 'Single character'}
-                >
-                  {seg}
-                </button>
-                {i < segments.length - 1 && (
-                  <button
-                    onClick={() => handleMergeSegments(i)}
-                    className="mx-0.5 px-1 text-lg font-bold"
-                    style={{ color: 'var(--text-tertiary)' }}
-                    title="Merge with next"
-                  >
-                    +
-                  </button>
-                )}
-              </div>
-            ))}
           </div>
 
           {/* Tutorial shortcut or normal LLM flow */}
@@ -384,7 +316,7 @@ export function AddSentencePage() {
           ) : (
             <div className="p-4 rounded-lg space-y-3 inset" style={{ border: '1px solid var(--border)' }}>
               <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                1. Copy the analysis prompt (includes your segmentation + existing meanings)
+                1. Copy the analysis prompt (the LLM will tokenize and analyze the sentence)
               </p>
               <button
                 onClick={handleCopyPrompt}
@@ -403,7 +335,7 @@ export function AddSentencePage() {
                 placeholder="Paste the JSON response here..."
                 rows={6}
                 className="w-full px-3 py-2 rounded-lg text-sm font-mono"
-              style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)', color: 'var(--text-primary)' }}
+                style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)', color: 'var(--text-primary)' }}
               />
               <button
                 onClick={handleParseLLMResponse}
@@ -568,7 +500,7 @@ export function AddSentencePage() {
 
           <div className="flex gap-2">
             <button
-              onClick={() => setStep('segment')}
+              onClick={() => setStep('llm')}
               className="flex-1 py-3 rounded-lg font-medium transition-colors"
               style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
             >

--- a/src/services/llmPrompt.ts
+++ b/src/services/llmPrompt.ts
@@ -48,10 +48,10 @@ export function generateAnalysisPrompt(
       .map((m) => `  ${m.headword} [${m.pinyin}] = "${m.english}"`)
       .join('\n');
     existingSection = `
-These meanings already exist in my app for characters in this sentence:
+Reference Meanings (use these EXACT strings for character-level English when they fit):
 ${lines}
 
-If a character/word has the same meaning as one listed above, pick it from the list (use the exact English string). Otherwise, assign a new meaning.
+If a character has multiple reference meanings listed, pick the one that fits this context. Use the exact English string from the list. Only assign a new meaning if none of the reference meanings apply.
 `;
   }
 
@@ -89,7 +89,7 @@ Rules:
 - Segment into linguistically correct words. Do NOT split compound words into individual characters (e.g. 作业 = one token, 正在 = one token). Do NOT merge separate words.
 - Exclude punctuation tokens (。，！？ etc.) — only include content words.
 - For pinyinNumeric: use tone numbers 1-5 (5 = neutral), separate syllables within a word by spaces (e.g. "cha4 bu4 duo1"). When a character has multiple accepted pronunciations, prefer the most common colloquial spoken form
-- For pinyinSandhi: apply all tone sandhi rules (3rd tone sandhi, 不 sandhi, 一 sandhi) and write with diacritics
+- For pinyinSandhi: apply all tone sandhi rules (3rd tone sandhi, 不 sandhi, 一 sandhi) and write with diacritics. Each token's pinyinSandhi must contain ONLY the syllables for that token's characters — never include syllables from neighboring tokens. For example, 作业 should be "zuòyè" (2 syllables for 2 characters), NOT "zuò zuòyè".
 - For english: give the CONTEXTUAL meaning only, not all possible meanings
 - For particles like 了 or 的, give their grammatical function as the english (e.g. "completion particle", "possessive particle")
 - For the "characters" array: include it for ALL tokens, even single-character ones
@@ -97,6 +97,7 @@ Rules:
   - For multi-character tokens: give each character's OWN independent meaning — the semantic building block it contributes to the compound, NOT the compound's meaning repeated or paraphrased onto the character
   - Test: the character meaning should make sense if the character appeared in a DIFFERENT compound word. If the meaning only makes sense within this specific word, you are giving the word's meaning, not the character's meaning.
   - Think of it as etymology: what does each character bring to the table? The compound's meaning emerges from combining the characters' individual meanings.
+- Validation: before returning, verify that each token's pinyinSandhi has exactly as many syllables as characters in its surfaceForm. If not, you have accidentally merged pinyin from a neighboring token — fix it.
 - Return ONLY the JSON, nothing else`;
 }
 

--- a/src/services/llmPrompt.ts
+++ b/src/services/llmPrompt.ts
@@ -1,8 +1,8 @@
 /**
  * LLM prompt generator for sentence analysis.
  *
- * Flow: CC-CEDICT tokenizer segments first → user adjusts → segments passed to LLM
- * The LLM fills in: English translation, pinyin, tone sandhi, character breakdowns, POS.
+ * Flow: user enters sentence → LLM tokenizes and analyzes → user reviews
+ * The LLM handles: segmentation, English translation, pinyin, tone sandhi, character breakdowns, POS.
  */
 import * as repo from '../db/repo';
 
@@ -12,15 +12,15 @@ export interface ExistingMeaning {
   english: string;
 }
 
-/** Look up existing meanings for the given segments (not individual characters within compounds) */
-export async function getExistingMeaningsForSegments(
-  segments: string[]
+/** Look up existing meanings for characters in the sentence */
+export async function getExistingMeanings(
+  chinese: string
 ): Promise<ExistingMeaning[]> {
-  const unique = [...new Set(segments)];
+  const chars = [...new Set(Array.from(chinese.replace(/\s/g, '')))];
   const results: ExistingMeaning[] = [];
 
-  for (const seg of unique) {
-    const meanings = await repo.getMeaningsByHeadword(seg);
+  for (const ch of chars) {
+    const meanings = await repo.getMeaningsByHeadword(ch);
 
     for (const m of meanings) {
       results.push({
@@ -35,12 +35,11 @@ export async function getExistingMeaningsForSegments(
 }
 
 /**
- * Generate LLM prompt with pre-segmented tokens.
- * The tokenizer has already split the sentence — the LLM just fills in definitions.
+ * Generate LLM prompt that tokenizes and analyzes a Chinese sentence.
+ * The LLM handles both segmentation into words and filling in definitions.
  */
 export function generateAnalysisPrompt(
   chinese: string,
-  segments: string[],
   existingMeanings?: ExistingMeaning[]
 ): string {
   let existingSection = '';
@@ -56,21 +55,20 @@ If a character/word has the same meaning as one listed above, pick it from the l
 `;
   }
 
-  const segmentList = segments.map((s) => `"${s}"`).join(', ');
-
-  return `Analyze this Chinese sentence and return ONLY a JSON object (no markdown, no explanation, no code fences).
+  return `Tokenize and analyze this Chinese sentence. Return ONLY a JSON object (no markdown, no explanation, no code fences).
 
 Sentence: ${chinese}
-Pre-segmented tokens (DO NOT change the segmentation): [${segmentList}]
 ${existingSection}
-Return this exact JSON structure:
+First, segment the sentence into words (tokens). Use linguistically correct word boundaries — for example, 作业 is one word meaning "homework", not two separate characters. Segment the way a native speaker would identify distinct words.
+
+Then return this exact JSON structure:
 {
   "chinese": "${chinese}",
   "english": "natural English translation",
   "pinyinSandhi": "full sentence pinyin with tone sandhi applied using diacritics",
   "tokens": [
     {
-      "surfaceForm": "the Chinese word/character EXACTLY as given in the pre-segmented tokens above",
+      "surfaceForm": "the Chinese word/character as segmented",
       "pinyinNumeric": "pinyin with tone numbers BEFORE sandhi e.g. hao3",
       "pinyinSandhi": "pinyin with diacritics AFTER tone sandhi applied",
       "english": "meaning IN THIS CONTEXT (not all meanings)",
@@ -88,7 +86,8 @@ Return this exact JSON structure:
 }
 
 Rules:
-- Use EXACTLY the pre-segmented tokens provided above. Do NOT re-segment or merge/split them. Output one token object per segment, in order.
+- Segment into linguistically correct words. Do NOT split compound words into individual characters (e.g. 作业 = one token, 正在 = one token). Do NOT merge separate words.
+- Exclude punctuation tokens (。，！？ etc.) — only include content words.
 - For pinyinNumeric: use tone numbers 1-5 (5 = neutral), separate syllables within a word by spaces (e.g. "cha4 bu4 duo1"). When a character has multiple accepted pronunciations, prefer the most common colloquial spoken form
 - For pinyinSandhi: apply all tone sandhi rules (3rd tone sandhi, 不 sandhi, 一 sandhi) and write with diacritics
 - For english: give the CONTEXTUAL meaning only, not all possible meanings


### PR DESCRIPTION
## Summary
- Moves sentence tokenization from CC-CEDICT dictionary (maximum-match algorithm) to the LLM prompt, fixing incorrect word boundaries like `做作+业` instead of `做+作业`
- Removes the segment editing UI (split/merge) from AddSentencePage since the LLM now handles segmentation
- Simplifies the add-sentence flow: input → copy LLM prompt → paste response → review → save

## Test plan
- [ ] Enter a sentence like `我正在做作业` and verify the LLM prompt asks for tokenization
- [ ] Paste an LLM response and confirm tokens are parsed correctly with proper word boundaries
- [ ] Verify tutorial flow still works (Use Tutorial Data button)
- [ ] Verify existing sentences/review cards are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)