### PR TITLE
Replace sun/moon emoji with SVG icons in theme toggle

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,13 +1,53 @@
 import { useThemeStore } from '../stores/themeStore';
 
+function SunIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <circle cx="12" cy="12" r="5" />
+      <line x1="12" y1="1" x2="12" y2="3" />
+      <line x1="12" y1="21" x2="12" y2="23" />
+      <line x1="4.22" y1="4.22" x2="5.64" y2="5.64" />
+      <line x1="18.36" y1="18.36" x2="19.78" y2="19.78" />
+      <line x1="1" y1="12" x2="3" y2="12" />
+      <line x1="21" y1="12" x2="23" y2="12" />
+      <line x1="4.22" y1="19.78" x2="5.64" y2="18.36" />
+      <line x1="18.36" y1="5.64" x2="19.78" y2="4.22" />
+    </svg>
+  );
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
 export function ThemeToggle() {
   const { theme, setTheme } = useThemeStore();
 
   const toggle = () => {
     setTheme(theme === 'light' ? 'dark' : 'light');
   };
-
-  const icon = theme === 'dark' ? '\u263E' : '\u2600';
 
   return (
     <button
@@ -16,7 +56,7 @@ export function ThemeToggle() {
       style={{ color: 'var(--text-tertiary)' }}
       title={theme === 'dark' ? 'Switch to light' : 'Switch to dark'}
     >
-      {icon}
+      {theme === 'dark' ? <MoonIcon /> : <SunIcon />}
     </button>
   );
 }


### PR DESCRIPTION
## Summary
- Replaced raw Unicode sun (☀) and moon (☾) characters in the mobile theme toggle with proper inline SVG icon components (`SunIcon` and `MoonIcon`)
- Icons use `stroke="currentColor"` to inherit the button's text color, matching the existing UI style
- SVGs follow Lucide/Feather icon style for visual consistency with the rest of the app

Closes #61

## Test plan
- [ ] Verify the sun icon displays correctly in light mode on mobile
- [ ] Verify the moon icon displays correctly in dark mode on mobile
- [ ] Confirm icons inherit the correct color (`var(--text-tertiary)`)
- [ ] Check that toggling between light/dark mode still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)