### PR TITLE
Disable clickable words on front of review cards

### DIFF
--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -87,7 +87,7 @@ export function ReviewCard() {
         <div className="flex-1 flex flex-col items-center justify-center">
           {isEnToZh ? (
             <div className="text-xl text-center">
-              <ClickableEnglish text={sentence.english} />
+              {sentence.english}
             </div>
           ) : isPyToEnZh ? (
             <div className="text-center">


### PR DESCRIPTION
## Summary
- Replace `ClickableEnglish` with plain text on the en-to-zh card front so users cannot tap words to peek at Chinese meanings before answering

## Test plan
- [ ] In en-to-zh review mode, verify English words on the front are NOT clickable
- [ ] After flipping, verify English words on the back ARE still clickable via `ClickableEnglish`

🤖 Generated with [Claude Code](https://claude.com/claude-code)