### PR TITLE
Remove duplicate Settings button from dashboard

### DIFF
--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -129,7 +129,6 @@ export function DashboardPage() {
           },
           { label: 'Graph', path: '/graph', onClick: () => navigate('/graph') },
           { label: 'Stats', path: '/stats', onClick: () => navigate('/stats') },
-          { label: 'Settings', path: '/settings', onClick: () => navigate('/settings') },
         ].map((btn) => (
           <button
             key={btn.label}


### PR DESCRIPTION
## Summary
- Dashboard's quick-actions row had a Settings button next to Stats that duplicated the Settings link already present in the top nav
- Removed the dashboard entry; top-nav link is the single source

## Test plan
- [ ] Open dashboard: quick-actions row shows Add / Browse / Graph / Stats (no Settings)
- [ ] Top-right Settings link still navigates to /settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)