### PR TITLE
Flag phonetic loanwords so character glosses aren't misleading

### DIFF
--- a/src/components/MeaningCard.tsx
+++ b/src/components/MeaningCard.tsx
@@ -97,6 +97,15 @@ function MeaningContent() {
 
         <AudioButton text={meaning.headword} className="mt-2" />
         <div className="mt-2 text-sm" style={{ color: 'var(--text-secondary)' }}>{meaning.partOfSpeech}</div>
+        {meaning.isTransliteration && (
+          <div
+            className="mt-2 inline-block px-2 py-0.5 rounded text-xs"
+            style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+            title="Phonetic loanword: characters approximate a foreign word's sound rather than compose its meaning."
+          >
+            Phonetic loanword
+          </div>
+        )}
         <div className="mt-1 text-xl">
           <ClickableEnglish text={meaning.englishShort} />
         </div>
@@ -155,6 +164,11 @@ function MeaningContent() {
           <h3 className="text-sm font-medium uppercase tracking-wider mb-2" style={{ color: 'var(--text-tertiary)' }}>
             Character Breakdown
           </h3>
+          {meaning.isTransliteration && (
+            <p className="text-xs mb-2" style={{ color: 'var(--text-secondary)' }}>
+              Phonetic — each character approximates a foreign sound; the glosses below are not the word's meaning.
+            </p>
+          )}
           <div className="flex gap-4 justify-center">
             {charBreakdown.map((item) => (
               <button

--- a/src/db/mappers.test.ts
+++ b/src/db/mappers.test.ts
@@ -34,6 +34,18 @@ describe('meaningFromRow', () => {
     };
     expect(meaningFromRow(row).updatedAt).toBe(1000);
   });
+
+  it('picks up is_transliteration and defaults missing column to false', () => {
+    const base = {
+      id: 'm1', headword: '汉堡', pinyin: 'hàn bǎo', pinyin_numeric: 'han4 bao3',
+      part_of_speech: 'noun', english_short: 'hamburger', english_full: 'hamburger',
+      type: 'word', level: 0, created_at: 1000, updated_at: 1000, usn: 1,
+    };
+    expect(meaningFromRow({ ...base, is_transliteration: true }).isTransliteration).toBe(true);
+    // Old rows from before the migration had no column; mapper must default to false
+    // so the UI never shows a false-positive "Phonetic loanword" badge.
+    expect(meaningFromRow(base).isTransliteration).toBe(false);
+  });
 });
 
 describe('meaningLinkFromRow', () => {

--- a/src/db/mappers.ts
+++ b/src/db/mappers.ts
@@ -20,6 +20,7 @@ export function meaningFromRow(r: any): Meaning {
     pinyinNumeric: r.pinyin_numeric, partOfSpeech: r.part_of_speech,
     englishShort: r.english_short, englishFull: r.english_full,
     type: r.type, level: r.level,
+    isTransliteration: r.is_transliteration ?? false,
     createdAt: r.created_at, updatedAt: r.updated_at ?? r.created_at,
     usn: r.usn,
   };

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -19,6 +19,12 @@ export interface Meaning {
   type: 'word' | 'character' | 'component';
   /** HSK level or custom difficulty 1-6, 0 = unassigned */
   level: number;
+  /**
+   * True when the headword is a phonetic loanword (e.g. 汉堡 = hamburger).
+   * The characters approximate a foreign word's sound; their literal meanings
+   * do not compose into the headword's meaning. Only meaningful on type='word'.
+   */
+  isTransliteration?: boolean;
   createdAt: number;
   updatedAt: number;
   usn?: number;

--- a/src/pages/AddSentencePage.tsx
+++ b/src/pages/AddSentencePage.tsx
@@ -38,6 +38,7 @@ interface TokenFormData {
   pinyinSandhi: string;
   english: string;
   partOfSpeech: string;
+  isTransliteration?: boolean;
   characters?: CharacterInput[];
 }
 
@@ -214,6 +215,7 @@ export function AddSentencePage() {
         pinyinSandhi: t.pinyinSandhi || '',
         english: t.english,
         partOfSpeech: t.partOfSpeech || '',
+        isTransliteration: !!t.isTransliteration,
         characters: t.characters?.map((c) => ({
           char: c.char,
           pinyinNumeric: c.pinyinNumeric,
@@ -244,6 +246,7 @@ export function AddSentencePage() {
         pinyinSandhi: t.pinyinSandhi || '',
         english: t.english,
         partOfSpeech: t.partOfSpeech || '',
+        isTransliteration: !!t.isTransliteration,
         characters: t.characters?.map((c) => ({
           char: c.char,
           pinyinNumeric: c.pinyinNumeric,
@@ -323,6 +326,7 @@ export function AddSentencePage() {
         pinyinSandhi: t.pinyinSandhi || '',
         english: t.english,
         partOfSpeech: t.partOfSpeech || '',
+        isTransliteration: !!t.isTransliteration,
         characters: t.characters?.map((c) => ({
           char: c.char,
           pinyinNumeric: c.pinyinNumeric,
@@ -400,6 +404,7 @@ export function AddSentencePage() {
         pinyinNumeric: t.pinyinNumeric,
         english: t.english,
         partOfSpeech: t.partOfSpeech || 'other',
+        isTransliteration: t.isTransliteration,
         characters: t.characters,
       }));
 
@@ -904,8 +909,22 @@ export function AddSentencePage() {
                 {/* Character breakdowns — always visible + editable for multi-char words */}
                 {t.characters && t.characters.length > 1 && (
                   <div className="mt-2 pt-2 border-t">
+                    <label className="flex items-center gap-2 mb-2 text-xs cursor-pointer" style={{ color: 'var(--text-secondary)' }}>
+                      <input
+                        type="checkbox"
+                        checked={!!t.isTransliteration}
+                        onChange={(e) => {
+                          const newTokens = [...tokens];
+                          newTokens[i] = { ...newTokens[i], isTransliteration: e.target.checked };
+                          setTokens(newTokens);
+                        }}
+                      />
+                      Phonetic loanword (characters approximate a foreign sound, not meaning — e.g. 汉堡 = hamburger)
+                    </label>
                     <div className="text-xs font-medium mb-2" style={{ color: 'var(--text-secondary)' }}>
-                      Character breakdown (verify these are standalone meanings, not the whole word's meaning):
+                      {t.isTransliteration
+                        ? "Character breakdown (phonetic gloss — each character contributes sound, not literal meaning):"
+                        : "Character breakdown (verify these are standalone meanings, not the whole word's meaning):"}
                     </div>
                     <div className="space-y-2">
                       {t.characters.map((c, ci) => (

--- a/src/services/ingestion.ts
+++ b/src/services/ingestion.ts
@@ -48,6 +48,12 @@ export interface TokenInput {
   pinyinNumeric: string;
   english: string;
   partOfSpeech: string;
+  /**
+   * True for phonetic loanwords (e.g. 汉堡 "hamburger"). When set, the parent
+   * Meaning is flagged so the UI can label it and readers know the character
+   * breakdown is phonetic, not semantic.
+   */
+  isTransliteration?: boolean;
   /** Per-character breakdowns from the LLM */
   characters?: CharacterInput[];
 }
@@ -193,6 +199,7 @@ function buildIngestPayload(
       pinyin_numeric: m.pinyinNumeric, part_of_speech: m.partOfSpeech,
       english_short: m.englishShort, english_full: m.englishFull,
       type: m.type, level: m.level,
+      is_transliteration: !!m.isTransliteration,
       created_at: m.createdAt, updated_at: m.updatedAt,
     })),
     meaning_links: acc.meaningLinks.map((l) => ({
@@ -255,6 +262,7 @@ async function findOrCreateMeaning(token: TokenInput, acc: IngestAccumulator): P
     englishFull: token.english,
     type: isCharacter ? 'character' : 'word',
     level: 0,
+    isTransliteration: !isCharacter && !!token.isTransliteration,
     createdAt: Date.now(),
     updatedAt: Date.now(),
   };

--- a/src/services/llmPrompt.ts
+++ b/src/services/llmPrompt.ts
@@ -78,6 +78,7 @@ Then return this exact JSON structure:
       "pinyinSandhi": "pinyin with diacritics AFTER tone sandhi applied",
       "english": "meaning IN THIS CONTEXT (not all meanings)",
       "partOfSpeech": "one of: noun, verb, adj, adv, prep, conj, particle, measure, pronoun, number, other",
+      "isTransliteration": false,
       "characters": [
         {
           "char": "individual character",
@@ -102,6 +103,9 @@ Rules:
   - For multi-character tokens: give each character's OWN independent meaning — the semantic building block it contributes to the compound, NOT the compound's meaning repeated or paraphrased onto the character
   - Test: the character meaning should make sense if the character appeared in a DIFFERENT compound word. If the meaning only makes sense within this specific word, you are giving the word's meaning, not the character's meaning.
   - Think of it as etymology: what does each character bring to the table? The compound's meaning emerges from combining the characters' individual meanings.
+- isTransliteration: set true ONLY when the token is a phonetic loanword — the characters were chosen to approximate a foreign word's SOUND, and their normal literal meanings do not compose into the token's meaning. Examples: 汉堡 (hamburger), 咖啡 (coffee), 沙发 (sofa), 巧克力 (chocolate), 披萨 (pizza), 沙拉 (salad), 三明治 (sandwich), 可乐 (cola), 吉他 (guitar), 摩托 (motor), 麦克风 (microphone). Set false for native compounds (好吃, 作业, 电脑 "electric brain", etc.) and for semantic loans that translate meaning rather than sound.
+  - When isTransliteration is true, each character's "english" MUST be the phonetic gloss: "phonetic (sounds like '<syllable>')" — do NOT invent a literal meaning for that character in this word. The character's normal meanings still exist in isolation, but in this compound the character is contributing sound, not sense.
+  - Omit the field or set it to false when uncertain — false is the safe default.
 - Validation: before returning, verify that each token's pinyinSandhi has exactly as many syllables as characters in its surfaceForm. If not, you have accidentally merged pinyin from a neighboring token — fix it.
 - Return ONLY the JSON, nothing else`;
 }
@@ -119,6 +123,8 @@ export interface LLMTokenResponse {
   pinyinSandhi?: string;
   english: string;
   partOfSpeech: string;
+  /** True for phonetic loanwords (e.g. 汉堡 = hamburger) — characters contribute sound, not meaning. */
+  isTransliteration?: boolean;
   characters?: LLMCharacterResponse[];
 }
 

--- a/supabase/migrations/005_meaning_is_transliteration.sql
+++ b/supabase/migrations/005_meaning_is_transliteration.sql
@@ -1,0 +1,184 @@
+-- ============================================================
+-- Meanings: flag phonetic loanwords so the UI can label them and
+-- skip misleading character-by-character glosses.
+--
+-- Example: 汉堡 (hànbǎo) = hamburger. The characters 汉 and 堡
+-- approximate the English sound; they do NOT compose semantically
+-- into "hamburger". We still store character MeaningLinks (the
+-- characters exist in the word), but their english is a phonetic
+-- gloss rather than a fabricated literal meaning.
+-- ============================================================
+
+alter table meanings
+  add column if not exists is_transliteration boolean not null default false;
+
+-- Extend apply_ingest_bundle to persist the flag on insert.
+-- Other columns and semantics are unchanged.
+create or replace function apply_ingest_bundle(bundle jsonb)
+returns void
+language plpgsql security invoker set search_path = public
+as $$
+declare
+  uid uuid := auth.uid();
+  m jsonb;
+  ml jsonb;
+  t jsonb;
+  c jsonb;
+  v_level int;
+  v_created_at bigint;
+  v_updated_at bigint;
+  v_position int;
+  v_due bigint;
+  v_stability float;
+  v_difficulty float;
+  v_elapsed_days float;
+  v_scheduled_days float;
+  v_reps int;
+  v_lapses int;
+  v_state int;
+  v_last_review bigint;
+begin
+  set local statement_timeout = '10s';
+
+  if uid is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  -- Insert meanings (skip if already exists)
+  for m in select * from jsonb_array_elements(bundle->'meanings')
+  loop
+    begin
+      v_level := (m->>'level')::int;
+      v_created_at := (m->>'created_at')::bigint;
+      v_updated_at := (m->>'updated_at')::bigint;
+    exception when others then
+      raise exception 'Invalid field value in meaning';
+    end;
+
+    insert into meanings (
+      id, user_id, headword, pinyin, pinyin_numeric,
+      part_of_speech, english_short, english_full,
+      type, level, is_transliteration, created_at, updated_at
+    ) values (
+      m->>'id', uid, m->>'headword', m->>'pinyin', m->>'pinyin_numeric',
+      m->>'part_of_speech', m->>'english_short', m->>'english_full',
+      m->>'type', v_level,
+      coalesce((m->>'is_transliteration')::boolean, false),
+      v_created_at, v_updated_at
+    )
+    on conflict (id) do nothing;
+  end loop;
+
+  -- Insert meaning links (verify referenced meanings belong to this user)
+  for ml in select * from jsonb_array_elements(bundle->'meaning_links')
+  loop
+    if not exists (select 1 from meanings where id = ml->>'parent_meaning_id' and user_id = uid) then
+      raise exception 'Unauthorized operation';
+    end if;
+    if not exists (select 1 from meanings where id = ml->>'child_meaning_id' and user_id = uid) then
+      raise exception 'Unauthorized operation';
+    end if;
+
+    begin
+      v_position := (ml->>'position')::int;
+    exception when others then
+      raise exception 'Invalid field value in meaning_link';
+    end;
+
+    insert into meaning_links (
+      id, user_id, parent_meaning_id, child_meaning_id, position, role
+    ) values (
+      ml->>'id', uid, ml->>'parent_meaning_id', ml->>'child_meaning_id',
+      v_position, ml->>'role'
+    )
+    on conflict (id) do nothing;
+  end loop;
+
+  -- Insert sentence (skip if already exists)
+  begin
+    v_created_at := (bundle->'sentence'->>'created_at')::bigint;
+  exception when others then
+    raise exception 'Invalid field value in sentence';
+  end;
+
+  insert into sentences (
+    id, user_id, chinese, english, pinyin, pinyin_sandhi,
+    audio_url, source, tags, created_at
+  ) values (
+    bundle->'sentence'->>'id', uid,
+    bundle->'sentence'->>'chinese', bundle->'sentence'->>'english',
+    bundle->'sentence'->>'pinyin', bundle->'sentence'->>'pinyin_sandhi',
+    bundle->'sentence'->>'audio_url', bundle->'sentence'->>'source',
+    coalesce(
+      (select array_agg(t.value::text) from jsonb_array_elements_text(bundle->'sentence'->'tags') t),
+      '{}'::text[]
+    ),
+    v_created_at
+  )
+  on conflict (id) do nothing;
+
+  -- Insert tokens (verify referenced sentence and meaning belong to this user)
+  for t in select * from jsonb_array_elements(bundle->'tokens')
+  loop
+    if not exists (select 1 from sentences where id = t->>'sentence_id' and user_id = uid) then
+      raise exception 'Unauthorized operation';
+    end if;
+    if not exists (select 1 from meanings where id = t->>'meaning_id' and user_id = uid) then
+      raise exception 'Unauthorized operation';
+    end if;
+
+    begin
+      v_position := (t->>'position')::int;
+    exception when others then
+      raise exception 'Invalid field value in token';
+    end;
+
+    insert into sentence_tokens (
+      id, user_id, sentence_id, meaning_id, position, surface_form, pinyin_sandhi
+    ) values (
+      t->>'id', uid, t->>'sentence_id', t->>'meaning_id',
+      v_position, t->>'surface_form', t->>'pinyin_sandhi'
+    )
+    on conflict (id) do nothing;
+  end loop;
+
+  -- Insert SRS cards (verify referenced sentence and deck belong to this user)
+  for c in select * from jsonb_array_elements(bundle->'cards')
+  loop
+    if not exists (select 1 from sentences where id = c->>'sentence_id' and user_id = uid) then
+      raise exception 'Unauthorized operation';
+    end if;
+    if not exists (select 1 from decks where id = c->>'deck_id' and user_id = uid) then
+      raise exception 'Unauthorized operation';
+    end if;
+
+    begin
+      v_due := (c->>'due')::bigint;
+      v_stability := (c->>'stability')::float;
+      v_difficulty := (c->>'difficulty')::float;
+      v_elapsed_days := (c->>'elapsed_days')::float;
+      v_scheduled_days := (c->>'scheduled_days')::float;
+      v_reps := (c->>'reps')::int;
+      v_lapses := (c->>'lapses')::int;
+      v_state := (c->>'state')::int;
+      v_last_review := case when c->>'last_review' = 'null' then null else (c->>'last_review')::bigint end;
+      v_created_at := (c->>'created_at')::bigint;
+    exception when others then
+      raise exception 'Invalid field value in srs_card';
+    end;
+
+    insert into srs_cards (
+      id, user_id, sentence_id, deck_id, review_mode,
+      due, stability, difficulty, elapsed_days, scheduled_days,
+      reps, lapses, state, last_review, created_at
+    ) values (
+      c->>'id', uid, c->>'sentence_id', c->>'deck_id', c->>'review_mode',
+      v_due, v_stability, v_difficulty,
+      v_elapsed_days, v_scheduled_days,
+      v_reps, v_lapses, v_state,
+      v_last_review, v_created_at
+    )
+    on conflict (id) do nothing;
+  end loop;
+end;
+$$;


### PR DESCRIPTION
## Summary
- LLM returns `isTransliteration` per token (e.g. 汉堡, 咖啡, 沙发). For those tokens each character's gloss becomes `"phonetic (sounds like '<syllable>')"` instead of a fabricated literal meaning.
- Flag persists on the parent `Meaning` row via new column `meanings.is_transliteration` (migration `005`) and is plumbed through ingestion + mapper.
- Add Sentence review step exposes a checkbox so the user can override the LLM's call; MeaningCard shows a "Phonetic loanword" badge and a note above the character breakdown.

## Test plan
- [ ] Add `我喜欢吃汉堡`: LLM flags 汉堡, review step checkbox is pre-checked, character glosses read as phonetic, saved MeaningCard shows the badge.
- [ ] Add `我喜欢喝咖啡`: same flow for 咖啡.
- [ ] Add `好吃的作业`: no token is flagged; no badge appears.
- [ ] In review step, manually toggle the checkbox on and off — helper text switches between "standalone meanings" vs. "phonetic gloss".
- [ ] Existing meanings from before the migration show `isTransliteration = false` (mapper default) — no false-positive badge on old rows.
- [ ] `npm test` passes (new mapper test covers the default and explicit cases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)