### PR TITLE
Disable autocorrect on LLM paste textarea (fixes #90)

### DIFF
--- a/src/pages/AddSentencePage.tsx
+++ b/src/pages/AddSentencePage.tsx
@@ -702,6 +702,10 @@ export function AddSentencePage() {
                     onChange={(e) => setLlmPasteValue(e.target.value)}
                     placeholder="Paste the JSON response here..."
                     rows={6}
+                    autoCorrect="off"
+                    autoCapitalize="off"
+                    autoComplete="off"
+                    spellCheck={false}
                     className="w-full px-3 py-2 rounded-lg text-sm font-mono"
                     style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)', color: 'var(--text-primary)' }}
                   />


### PR DESCRIPTION
## Summary
- The "Paste LLM response" textarea on the Add Sentence page was allowing mobile autocorrect, autocapitalize, and smart-quote substitution to mangle the user's edits — making it hard to add, remove, or correct characters in the pasted JSON.
- Adds `autoCorrect="off"`, `autoCapitalize="off"`, `autoComplete="off"`, `spellCheck={false}` so the field behaves like a code input.

Fixes #90

## Test plan
- [ ] On mobile, paste an LLM JSON response and edit characters — confirm autocorrect / auto-capitalization / smart quotes don't fire
- [ ] Confirm the "Parse & Fill" flow still works end-to-end
- [ ] Desktop editing remains unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)