### PR TITLE
Hide Auto-Analyze button on manual LLM path in Add Sentence

### DIFF
--- a/src/pages/AddSentencePage.tsx
+++ b/src/pages/AddSentencePage.tsx
@@ -708,46 +708,58 @@ export function AddSentencePage() {
               )}
 
               {/* Manual copy-paste flow */}
-              <details open={!aiEnabled || manualMode}>
-                <summary
-                  className="cursor-pointer text-sm font-medium py-1"
-                  style={{ color: 'var(--text-secondary)' }}
-                >
-                  {aiEnabled && !manualMode ? 'Or paste LLM response manually' : 'Copy prompt & paste LLM response'}
-                </summary>
-                <div className="mt-2 p-4 rounded-lg space-y-3 inset" style={{ border: '1px solid var(--border)' }}>
-                  <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                    1. Copy the analysis prompt (the LLM will tokenize and analyze the sentence)
-                  </p>
-                  <button
-                    onClick={handleCopyPrompt}
-                    className="w-full py-2 rounded font-medium text-sm transition-colors"
-                    style={{ background: 'var(--accent)', color: 'var(--text-inverted)' }}
-                  >
-                    {promptCopied ? 'Copied!' : 'Copy Prompt to Clipboard'}
-                  </button>
+              {(() => {
+                const body = (
+                  <div className="mt-2 p-4 rounded-lg space-y-3 inset" style={{ border: '1px solid var(--border)' }}>
+                    <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                      1. Copy the analysis prompt (the LLM will tokenize and analyze the sentence)
+                    </p>
+                    <button
+                      onClick={handleCopyPrompt}
+                      className="w-full py-2 rounded font-medium text-sm transition-colors"
+                      style={{ background: 'var(--accent)', color: 'var(--text-inverted)' }}
+                    >
+                      {promptCopied ? 'Copied!' : 'Copy Prompt to Clipboard'}
+                    </button>
 
-                  <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
-                    2. Paste it into ChatGPT / Claude / any LLM, then paste the response below
-                  </p>
-                  <textarea
-                    value={llmPasteValue}
-                    onChange={(e) => setLlmPasteValue(e.target.value)}
-                    placeholder="Paste the JSON response here..."
-                    rows={6}
-                    className="w-full px-3 py-2 rounded-lg text-sm font-mono"
-                    style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)', color: 'var(--text-primary)' }}
-                  />
-                  <button
-                    onClick={handleParseLLMResponse}
-                    disabled={!llmPasteValue.trim()}
-                    className="w-full py-2 rounded font-medium text-sm transition-colors disabled:opacity-50"
-                    style={{ background: 'var(--success)', color: 'var(--text-inverted)' }}
-                  >
-                    Parse &amp; Fill
-                  </button>
-                </div>
-              </details>
+                    <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
+                      2. Paste it into ChatGPT / Claude / any LLM, then paste the response below
+                    </p>
+                    <textarea
+                      value={llmPasteValue}
+                      onChange={(e) => setLlmPasteValue(e.target.value)}
+                      placeholder="Paste the JSON response here..."
+                      rows={6}
+                      className="w-full px-3 py-2 rounded-lg text-sm font-mono"
+                      style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)', color: 'var(--text-primary)' }}
+                    />
+                    <button
+                      onClick={handleParseLLMResponse}
+                      disabled={!llmPasteValue.trim()}
+                      className="w-full py-2 rounded font-medium text-sm transition-colors disabled:opacity-50"
+                      style={{ background: 'var(--success)', color: 'var(--text-inverted)' }}
+                    >
+                      Parse &amp; Fill
+                    </button>
+                  </div>
+                );
+                // When AI is configured and the user hasn't explicitly chosen the manual
+                // path, keep the old collapsible affordance below the Auto-Analyze button.
+                // Otherwise render the content flat — the user has already committed to manual.
+                return aiEnabled && !manualMode ? (
+                  <details>
+                    <summary
+                      className="cursor-pointer text-sm font-medium py-1"
+                      style={{ color: 'var(--text-secondary)' }}
+                    >
+                      Or paste LLM response manually
+                    </summary>
+                    {body}
+                  </details>
+                ) : (
+                  body
+                );
+              })()}
             </div>
           )}
 

--- a/src/pages/AddSentencePage.tsx
+++ b/src/pages/AddSentencePage.tsx
@@ -57,6 +57,8 @@ export function AddSentencePage() {
   const [saving, setSaving] = useState(false);
   const [llmPasteValue, setLlmPasteValue] = useState('');
   const [promptCopied, setPromptCopied] = useState(false);
+  /** True when the user explicitly chose the copy-prompt-manually path from the input step. */
+  const [manualMode, setManualMode] = useState(false);
   const [usePinyinIME, setUsePinyinIME] = useState(false);
   const [tags, setTags] = useState<string[]>([]);
   const [analyzing, setAnalyzing] = useState(false);
@@ -644,6 +646,7 @@ export function AddSentencePage() {
               onClick={() => {
                 if (!chinese.trim()) return;
                 setError('');
+                setManualMode(true);
                 setStep('llm');
               }}
               disabled={!chinese.trim() || analyzing}
@@ -692,8 +695,8 @@ export function AddSentencePage() {
                 </div>
               )}
 
-              {/* Auto-analyze (when AI is configured) */}
-              {aiEnabled && (
+              {/* Auto-analyze (when AI is configured and user didn't explicitly choose manual) */}
+              {aiEnabled && !manualMode && (
                 <button
                   onClick={handleAutoAnalyze}
                   disabled={analyzing}
@@ -705,12 +708,12 @@ export function AddSentencePage() {
               )}
 
               {/* Manual copy-paste flow */}
-              <details open={!aiEnabled}>
+              <details open={!aiEnabled || manualMode}>
                 <summary
                   className="cursor-pointer text-sm font-medium py-1"
                   style={{ color: 'var(--text-secondary)' }}
                 >
-                  {aiEnabled ? 'Or paste LLM response manually' : 'Copy prompt & paste LLM response'}
+                  {aiEnabled && !manualMode ? 'Or paste LLM response manually' : 'Copy prompt & paste LLM response'}
                 </summary>
                 <div className="mt-2 p-4 rounded-lg space-y-3 inset" style={{ border: '1px solid var(--border)' }}>
                   <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
@@ -749,7 +752,10 @@ export function AddSentencePage() {
           )}
 
           <button
-            onClick={() => setStep('input')}
+            onClick={() => {
+              setManualMode(false);
+              setStep('input');
+            }}
             className="w-full py-2 rounded-lg font-medium text-sm transition-colors"
             style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
           >


### PR DESCRIPTION
## Summary
- When AI is configured and the user clicks **Or copy prompt manually** on the Add Sentence input step, the next screen still rendered the **Auto-Analyze with AI** button and kept the paste section collapsed inside `<details>`.
- Track a `manualMode` flag that is set when the user takes that explicit manual path, hides the auto-analyze button, and forces the copy-prompt / paste-response section open.
- Back button resets `manualMode` so the user can still switch back to the AI flow.

## Test plan
- [ ] With an AI provider configured, open **Add Sentence**, type a sentence, click **Or copy prompt manually** → next screen shows only the copy-prompt / paste-response UI (no "Auto-Analyze with AI" button).
- [ ] From that screen, click **Back** then **Analyze with AI** → normal AI flow still runs.
- [ ] Without an AI provider configured, the LLM step still shows the existing manual-only UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)