### PR TITLE
Fix srs_cards review_mode CHECK rejecting listen-type

### DIFF
--- a/supabase/migrations/006_srs_review_mode_listen_type.sql
+++ b/supabase/migrations/006_srs_review_mode_listen_type.sql
@@ -1,0 +1,20 @@
+-- ============================================================
+-- Align the srs_cards.review_mode CHECK constraint with the 4
+-- review modes the client has been emitting since #76:
+--   en-to-zh, zh-to-en, py-to-en-zh, listen-type
+--
+-- `schema.sql` was updated when listen-type was added, but no
+-- migration was written, so already-provisioned databases still
+-- reject listen-type (and, depending on provisioning vintage,
+-- possibly py-to-en-zh). apply_ingest_bundle runs as one txn, so
+-- the failing card insert rolls back the entire sentence + all
+-- its meanings, producing the "save looks fine locally but the
+-- data disappears after sign out" symptom.
+-- ============================================================
+
+alter table srs_cards
+  drop constraint if exists srs_cards_review_mode_check;
+
+alter table srs_cards
+  add constraint srs_cards_review_mode_check
+  check (review_mode in ('en-to-zh', 'zh-to-en', 'py-to-en-zh', 'listen-type'));


### PR DESCRIPTION
## Summary
- Existing prod Supabase DBs still carry the pre-listen-type CHECK constraint on `srs_cards.review_mode`, rejecting every `listen-type` card the client creates.
- Because `apply_ingest_bundle` is one atomic txn, the failing insert rolls back the entire sentence, its meanings, AND the other 3 successfully-scheduled cards — so every Add Sentence save silently fails to sync even though the local Dexie write succeeds. After sign-out/sign-in, hydration pulls from the empty server and the user's local data appears to vanish.
- Commit 7926462 updated `schema.sql` when listen-type was added but never wrote a migration. This adds the missing migration.

## Test plan
- [ ] Apply migration `006_srs_review_mode_listen_type.sql` to Supabase.
- [ ] In the app, add a new sentence — confirm no 400 on `apply_ingest_bundle` in the network tab.
- [ ] Sign out, sign back in — the sentence is still there.
- [ ] `select pg_get_constraintdef(oid) from pg_constraint where conname = 'srs_cards_review_mode_check';` shows all 4 modes in the constraint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)