### PR TITLE
Parallelize Anki text import with retry and circuit breaker

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -617,6 +617,7 @@ function AnkiSection() {
   const [audioField, setAudioField] = useState<number | null>(null);
   const [audioName, setAudioName] = useState('anki');
   const [selectedNotes, setSelectedNotes] = useState<Set<number>>(new Set());
+  const [importConcurrency, setImportConcurrency] = useState(5);
   const lastClickedIdx = useRef<number | null>(null);
   const dragSelectMode = useRef<boolean | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -666,7 +667,13 @@ function AnkiSection() {
       }
       setApkgAnalyzing(false);
     } else {
-      await runImport(() => importFromAnki(file, (p) => setAnkiProgress({ ...p }), abortRef.current!.signal));
+      await runImport(() => importFromAnki(
+        file,
+        (p) => setAnkiProgress({ ...p }),
+        abortRef.current!.signal,
+        undefined,
+        { concurrency: importConcurrency },
+      ));
     }
   };
 
@@ -785,6 +792,26 @@ function AnkiSection() {
             <p className="mt-2 text-xs" style={{ color: 'var(--text-tertiary)' }}>
               Accepts .apkg, .txt, .csv, or .tsv files. In Anki, use File &gt; Export to create a file.
             </p>
+            <div className="mt-3 flex items-center gap-2">
+              <label className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                Parallel LLM calls
+              </label>
+              <input
+                type="number"
+                min={1}
+                max={10}
+                value={importConcurrency}
+                onChange={(e) => {
+                  const n = Math.max(1, Math.min(10, Number(e.target.value) || 1));
+                  setImportConcurrency(n);
+                }}
+                className="w-16 px-2 py-1 rounded text-sm text-center"
+                style={{ background: 'var(--bg-inset)', border: '1px solid var(--border)', color: 'var(--text-primary)' }}
+              />
+              <span className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
+                1 = sequential. Lower this if you hit rate limits.
+              </span>
+            </div>
           </div>
         )}
 
@@ -1031,6 +1058,14 @@ function AnkiSection() {
         {/* Summary after completion */}
         {!ankiImporting && ankiProgress && (
           <div className="space-y-3">
+            {ankiProgress.rateLimited && (
+              <div
+                className="p-3 rounded-lg text-sm"
+                style={{ background: 'color-mix(in srgb, var(--danger) 10%, var(--bg-surface))', color: 'var(--danger)', border: '1px solid color-mix(in srgb, var(--danger) 30%, transparent)' }}
+              >
+                Paused after repeated rate-limit errors from your AI provider. Re-run the import (duplicates are skipped) or lower Parallel LLM calls and try again.
+              </div>
+            )}
             <div className="p-3 rounded-lg" style={{ background: 'var(--bg-inset)' }}>
               <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
                 Import complete

--- a/src/services/ankiApkg.ts
+++ b/src/services/ankiApkg.ts
@@ -31,7 +31,7 @@ function getSql() {
   return sqlPromise;
 }
 
-function stripAnkiHtml(html: string): string {
+export function stripAnkiHtml(html: string): string {
   return html
     .replace(/\[sound:[^\]]+\]/g, '')
     .replace(/<img[^>]*>/g, '')

--- a/src/services/ankiImport.test.ts
+++ b/src/services/ankiImport.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest';
+import { classifyError } from './ankiImport';
+
+describe('classifyError', () => {
+  it('tags 429 as rate-limit', () => {
+    expect(classifyError({ status: 429, message: 'Too Many Requests' })).toBe('rate-limit');
+  });
+
+  it('tags "rate limit" in the message as rate-limit even without a status', () => {
+    expect(classifyError(new Error('OpenAI rate limit exceeded'))).toBe('rate-limit');
+    expect(classifyError(new Error('quota exceeded for gpt-4'))).toBe('rate-limit');
+  });
+
+  it('tags 5xx and network-ish errors as network', () => {
+    expect(classifyError({ status: 503, message: 'Service Unavailable' })).toBe('network');
+    expect(classifyError(new Error('fetch failed: ECONNRESET'))).toBe('network');
+    expect(classifyError(new Error('network timeout'))).toBe('network');
+  });
+
+  it('tags parse errors distinctly so retry does not fire on bad LLM JSON', () => {
+    expect(classifyError(new Error('Could not parse JSON response'))).toBe('llm-parse');
+    expect(classifyError(new Error('invalid json at position 4'))).toBe('llm-parse');
+  });
+
+  it('unclassified errors fall through to "other"', () => {
+    expect(classifyError(new Error('something weird'))).toBe('other');
+    expect(classifyError('raw string error')).toBe('other');
+  });
+
+  it('reads wrapped response.status', () => {
+    expect(classifyError({ response: { status: 429 } })).toBe('rate-limit');
+  });
+});

--- a/src/services/ankiImport.ts
+++ b/src/services/ankiImport.ts
@@ -24,6 +24,7 @@
 import { generateCompletion } from './aiProvider';
 import { generateAnalysisPrompt, parseLLMResponse, getExistingMeanings, type LLMResponse } from './llmPrompt';
 import { ingestSentence } from './ingestion';
+import { stripAnkiHtml } from './ankiApkg';
 import * as repo from '../db/repo';
 
 // ────────────────────────────────────────────────────────────
@@ -43,13 +44,14 @@ export type ErrorKind =
   | 'llm-parse'
   | 'duplicate'
   | 'no-fields'
+  | 'aborted'
   | 'other';
 
 export interface ImportIssue {
   sentence: string;
   reason: string;
   type: 'skipped' | 'failed';
-  errorKind: ErrorKind;
+  errorKind?: ErrorKind;
 }
 
 export interface ImportProgress {
@@ -164,11 +166,8 @@ Rules:
 // Row extraction
 // ────────────────────────────────────────────────────────────
 
-function stripHtml(s: string): string {
-  return s.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
-}
-
 interface ExtractedFields {
+  /** Always trimmed — downstream code should not re-normalize. */
   chinese: string;
   english: string;
   pinyin: string | null;
@@ -177,11 +176,14 @@ interface ExtractedFields {
 function extractFields(row: string, mapping: FieldMapping): ExtractedFields | null {
   const fields = row.split(mapping.separator);
 
-  const chinese = stripHtml(fields[mapping.chineseField] ?? '').trim();
+  const chinese = stripAnkiHtml(fields[mapping.chineseField] ?? '');
   if (!chinese) return null;
   if (!/[\u4e00-\u9fff\u3400-\u4dbf]/.test(chinese)) return null;
 
-  let english = '';
+  const pinyin = mapping.pinyinField !== null
+    ? stripAnkiHtml(fields[mapping.pinyinField] ?? '') || null
+    : null;
+
   if (mapping.englishField === mapping.chineseField) {
     const parts = chinese.split(/\s*[-=:：]\s*/);
     if (parts.length >= 2) {
@@ -190,16 +192,14 @@ function extractFields(row: string, mapping: FieldMapping): ExtractedFields | nu
       return {
         chinese: chinesePart?.trim() || chinese,
         english: englishPart?.trim() || '',
-        pinyin: mapping.pinyinField !== null ? stripHtml(fields[mapping.pinyinField] ?? '').trim() || null : null,
+        pinyin,
       };
     }
-  } else {
-    english = stripHtml(fields[mapping.englishField] ?? '').trim();
   }
 
-  const pinyin = mapping.pinyinField !== null
-    ? stripHtml(fields[mapping.pinyinField] ?? '').trim() || null
-    : null;
+  const english = mapping.englishField === mapping.chineseField
+    ? ''
+    : stripAnkiHtml(fields[mapping.englishField] ?? '');
 
   return { chinese, english, pinyin };
 }
@@ -256,32 +256,20 @@ async function withRetry<T>(
 // Bounded concurrency + circuit breaker
 // ────────────────────────────────────────────────────────────
 
-/**
- * Run `tasks` with at most `concurrency` in flight at once.
- *
- * `shouldAbort` is checked before dispatching each new task; in-flight tasks
- * continue to completion. This is how the circuit breaker drains cleanly
- * once rate limiting trips — we stop firing new calls but let pending ones
- * finish so their results are still reported.
- */
+/** Run `tasks` with at most `concurrency` in flight at once. */
 async function parallelMap<T, U>(
   tasks: T[],
   concurrency: number,
   run: (task: T, index: number) => Promise<U>,
-  shouldAbort?: () => boolean,
-): Promise<Array<U | { aborted: true }>> {
-  const results = new Array<U | { aborted: true }>(tasks.length);
-  const effectiveConcurrency = Math.max(1, Math.min(concurrency, tasks.length || 1));
+): Promise<U[]> {
+  const results = new Array<U>(tasks.length);
+  const width = Math.max(1, Math.min(concurrency, tasks.length || 1));
   let nextIndex = 0;
 
-  const workers = Array.from({ length: effectiveConcurrency }, async () => {
+  const workers = Array.from({ length: width }, async () => {
     while (true) {
       const i = nextIndex++;
       if (i >= tasks.length) return;
-      if (shouldAbort?.()) {
-        results[i] = { aborted: true };
-        continue;
-      }
       results[i] = await run(tasks[i], i);
     }
   });
@@ -325,9 +313,8 @@ type AnalysisResult = AnalysisSuccess | AnalysisFailure;
 
 async function analyzeOne(input: AnalysisInput, maxRetries: number): Promise<AnalysisResult> {
   try {
-    const chinese = input.fields.chinese.trim();
-    const existingMeanings = await getExistingMeanings(chinese);
-    const prompt = generateAnalysisPrompt(chinese, existingMeanings);
+    const existingMeanings = await getExistingMeanings(input.fields.chinese);
+    const prompt = generateAnalysisPrompt(input.fields.chinese, existingMeanings);
     const raw = await withRetry(() => generateCompletion(prompt), maxRetries);
     const parsed = parseLLMResponse(raw);
     return { kind: 'ok', index: input.index, fields: input.fields, parsed };
@@ -349,7 +336,7 @@ async function ingestOne(
   const { fields, parsed } = success;
   const finalEnglish = fields.english || parsed.english;
   await ingestSentence({
-    chinese: fields.chinese.trim(),
+    chinese: fields.chinese,
     english: finalEnglish,
     tokens: parsed.tokens.map((t) => ({
       surfaceForm: t.surfaceForm,
@@ -404,23 +391,27 @@ export async function importFromAnki(
     issues: [],
   };
 
+  const recordIssue = (issue: ImportIssue) => {
+    progress.issues.push(issue);
+    if (issue.type === 'skipped') progress.skipped++;
+    else progress.failed++;
+    progress.processed++;
+    onProgress({ ...progress });
+  };
+
   onProgress({ ...progress, currentSentence: 'Detecting field mapping…' });
 
   const mapping = await detectFieldMapping(rows);
 
-  // Stage A: extract fields from every row
   const plans: RowPlan[] = rows.map((rawRow, index) => ({
     index,
     rawRow,
     fields: extractFields(rawRow, mapping),
   }));
 
-  // Account for rows that had no extractable fields up front.
   for (const plan of plans) {
     if (!plan.fields) {
-      progress.skipped++;
-      progress.processed++;
-      progress.issues.push({
+      recordIssue({
         sentence: plan.rawRow.slice(0, 60),
         reason: 'Could not extract fields',
         type: 'skipped',
@@ -428,27 +419,23 @@ export async function importFromAnki(
       });
     }
   }
-  onProgress({ ...progress });
 
-  // Stage B: dedup against local Dexie. These reads are cheap and independent;
-  // running them in parallel lets us report the final skipped count before we
-  // even start spending LLM tokens.
+  // Dedup reads are cheap and independent; running them all in parallel lets
+  // us report the final skipped count before we start spending LLM tokens.
   onProgress({ ...progress, currentSentence: 'Checking for duplicates…' });
   const dedupChecks = await Promise.all(
     plans
       .filter((p): p is RowPlan & { fields: ExtractedFields } => !!p.fields)
-      .map(async (p) => {
-        const existing = await repo.getSentenceByChinese(p.fields.chinese.trim());
-        return { plan: p, isDuplicate: !!existing };
-      }),
+      .map(async (p) => ({
+        plan: p,
+        isDuplicate: !!(await repo.getSentenceByChinese(p.fields.chinese)),
+      })),
   );
 
   const toAnalyze: AnalysisInput[] = [];
   for (const { plan, isDuplicate } of dedupChecks) {
     if (isDuplicate) {
-      progress.skipped++;
-      progress.processed++;
-      progress.issues.push({
+      recordIssue({
         sentence: plan.fields.chinese,
         reason: 'Duplicate — already in app',
         type: 'skipped',
@@ -458,63 +445,44 @@ export async function importFromAnki(
       toAnalyze.push({ index: plan.index, fields: plan.fields });
     }
   }
-  onProgress({ ...progress });
 
-  // Stage C: parallel LLM analysis with per-call retry + circuit breaker.
   // `tripped` flips true once we hit RATE_LIMIT_TRIP_THRESHOLD consecutive
-  // rate-limit errors — after that, new tasks short-circuit to failures so
-  // the user doesn't wait for dozens more hopeless requests.
+  // rate-limit errors across completions — after that, new tasks short-circuit
+  // so the user doesn't wait for dozens more hopeless requests.
   let rateLimitStreak = 0;
   let tripped = false;
 
-  const analysisResults = await parallelMap(
-    toAnalyze,
-    concurrency,
-    async (task) => {
-      if (abortSignal?.aborted || tripped) {
-        const errorKind: ErrorKind = tripped ? 'rate-limit' : 'other';
-        return {
-          kind: 'err' as const,
-          index: task.index,
-          fields: task.fields,
-          errorKind,
-          message: tripped ? 'Skipped after sustained rate limiting' : 'Aborted',
-        };
-      }
-      const result = await analyzeOne(task, maxRetries);
-      // Running counter of consecutive rate-limit errors across completions —
-      // any success resets it. Simpler than a sliding window and good enough
-      // for the "provider is hard-refusing us" case.
-      if (result.kind === 'err' && result.errorKind === 'rate-limit') {
-        rateLimitStreak++;
-        if (rateLimitStreak >= RATE_LIMIT_TRIP_THRESHOLD) tripped = true;
-      } else {
-        rateLimitStreak = 0;
-      }
-      progress.currentSentence = task.fields.chinese;
-      onProgress({ ...progress });
-      return result;
-    },
-    () => abortSignal?.aborted === true,
-  );
+  const analysisResults = await parallelMap(toAnalyze, concurrency, async (task) => {
+    if (abortSignal?.aborted) {
+      return { kind: 'err' as const, index: task.index, fields: task.fields, errorKind: 'aborted' as ErrorKind, message: 'Aborted' };
+    }
+    if (tripped) {
+      return { kind: 'err' as const, index: task.index, fields: task.fields, errorKind: 'rate-limit' as ErrorKind, message: 'Skipped after sustained rate limiting' };
+    }
+    const result = await analyzeOne(task, maxRetries);
+    if (result.kind === 'err' && result.errorKind === 'rate-limit') {
+      rateLimitStreak++;
+      if (rateLimitStreak >= RATE_LIMIT_TRIP_THRESHOLD) tripped = true;
+    } else {
+      rateLimitStreak = 0;
+    }
+    progress.currentSentence = task.fields.chinese;
+    onProgress({ ...progress });
+    return result;
+  });
 
-  // Stage D: sequential ingest. `findOrCreateMeaning` dedups on
-  // (headword, pinyinNumeric, englishShort) via a read-then-write, which
-  // races if run in parallel, so we serialize this stage.
+  // Ingest runs serially: `findOrCreateMeaning` dedups via read-then-write,
+  // which races if run in parallel, so we keep this stage single-threaded.
   for (const result of analysisResults) {
     if (abortSignal?.aborted) break;
-    if ('aborted' in result) continue;
 
     if (result.kind === 'err') {
-      progress.failed++;
-      progress.processed++;
-      progress.issues.push({
+      recordIssue({
         sentence: result.fields.chinese,
         reason: result.message.slice(0, 150),
         type: 'failed',
         errorKind: result.errorKind,
       });
-      onProgress({ ...progress });
       continue;
     }
 
@@ -524,28 +492,18 @@ export async function importFromAnki(
     try {
       await ingestOne(result, ['anki-import']);
       progress.imported++;
+      progress.processed++;
+      onProgress({ ...progress });
     } catch (e: any) {
       const msg: string = e?.message || 'Unknown error';
-      if (msg === 'duplicate' || msg.includes('already exists')) {
-        progress.skipped++;
-        progress.issues.push({
-          sentence: result.fields.chinese,
-          reason: 'Duplicate — already in app',
-          type: 'skipped',
-          errorKind: 'duplicate',
-        });
-      } else {
-        progress.failed++;
-        progress.issues.push({
-          sentence: result.fields.chinese,
-          reason: msg.slice(0, 150),
-          type: 'failed',
-          errorKind: 'other',
-        });
-      }
+      const isDuplicate = msg === 'duplicate' || msg.includes('already exists');
+      recordIssue({
+        sentence: result.fields.chinese,
+        reason: isDuplicate ? 'Duplicate — already in app' : msg.slice(0, 150),
+        type: isDuplicate ? 'skipped' : 'failed',
+        errorKind: isDuplicate ? 'duplicate' : 'other',
+      });
     }
-    progress.processed++;
-    onProgress({ ...progress });
   }
 
   progress.currentSentence = '';

--- a/src/services/ankiImport.ts
+++ b/src/services/ankiImport.ts
@@ -1,11 +1,28 @@
 /**
  * Anki import service.
- * Parses tab-separated or comma-separated text files exported from Anki,
- * uses LLM to identify field mappings, then ingests sentences via the
- * existing ingestion pipeline.
+ *
+ * Parses tab/comma-separated text exported from Anki, uses an LLM to identify
+ * field mappings, then ingests each sentence through the main pipeline.
+ *
+ * The import runs as a 4-stage pipeline so the slow step (LLM analysis) can
+ * fan out in parallel while everything stateful stays serialized:
+ *
+ *   A. Extract fields from every row           (pure, instant)
+ *   B. Dedup against local Dexie               (parallel reads, cheap)
+ *   C. Analyze via LLM with bounded concurrency (slow, parallel)
+ *   D. Ingest results sequentially             (serialized so findOrCreateMeaning
+ *                                               dedup stays correct)
+ *
+ * On top of the pipeline:
+ *   - Error classifier distinguishes rate-limit / network / parse / other.
+ *   - Transient errors (rate-limit, network) get retried with exp backoff.
+ *   - A circuit breaker stops firing new LLM calls after sustained rate
+ *     limiting so we don't burn through a whole file of hopeless attempts.
+ *   - The sentence-level dedup means rerunning the same file is safe — it
+ *     skips everything already imported and retries only the failures.
  */
 import { generateCompletion } from './aiProvider';
-import { generateAnalysisPrompt, parseLLMResponse, getExistingMeanings } from './llmPrompt';
+import { generateAnalysisPrompt, parseLLMResponse, getExistingMeanings, type LLMResponse } from './llmPrompt';
 import { ingestSentence } from './ingestion';
 import * as repo from '../db/repo';
 
@@ -20,10 +37,19 @@ export interface FieldMapping {
   separator: string;
 }
 
+export type ErrorKind =
+  | 'rate-limit'
+  | 'network'
+  | 'llm-parse'
+  | 'duplicate'
+  | 'no-fields'
+  | 'other';
+
 export interface ImportIssue {
   sentence: string;
   reason: string;
   type: 'skipped' | 'failed';
+  errorKind: ErrorKind;
 }
 
 export interface ImportProgress {
@@ -34,26 +60,37 @@ export interface ImportProgress {
   failed: number;
   currentSentence: string;
   issues: ImportIssue[];
+  /** Set when the circuit breaker tripped; communicates "you can re-run to retry these". */
+  rateLimited?: boolean;
 }
 
 export type ProgressCallback = (progress: ImportProgress) => void;
+
+export interface ImportOptions {
+  /** How many LLM calls to fan out at once during analysis. 1 = strictly sequential. */
+  concurrency?: number;
+  /** Max attempts per row when the LLM call hits a transient error. */
+  maxRetries?: number;
+}
+
+const DEFAULT_CONCURRENCY = 5;
+const DEFAULT_MAX_RETRIES = 3;
+/** Trip the circuit breaker after this many in-flight rate-limit errors in a row. */
+const RATE_LIMIT_TRIP_THRESHOLD = 5;
 
 // ────────────────────────────────────────────────────────────
 // File parsing
 // ────────────────────────────────────────────────────────────
 
-/** Read a file as text, handling common encodings. */
 export async function readFileAsText(file: File): Promise<string> {
   return file.text();
 }
 
-/** Split file content into rows, filtering out blanks and Anki directives. */
 export function parseRows(content: string): string[] {
   return content
     .split(/\r?\n/)
     .filter((line) => {
       const trimmed = line.trim();
-      // Skip empty lines, Anki directives, and HTML-only lines
       return trimmed.length > 0 && !trimmed.startsWith('#');
     });
 }
@@ -62,10 +99,6 @@ export function parseRows(content: string): string[] {
 // LLM field mapping
 // ────────────────────────────────────────────────────────────
 
-/**
- * Send a sample of rows to the LLM to determine field mapping.
- * Returns which column indices contain Chinese, English, and optionally pinyin.
- */
 export async function detectFieldMapping(rows: string[]): Promise<FieldMapping> {
   const sample = rows.slice(0, Math.min(8, rows.length));
   const sampleText = sample.map((r, i) => `Row ${i + 1}: ${r}`).join('\n');
@@ -99,7 +132,6 @@ Rules:
 
   const raw = await generateCompletion(prompt);
 
-  // Parse the LLM response
   let cleaned = raw.trim();
   cleaned = cleaned.replace(/^```json\s*/i, '').replace(/^```\s*/i, '');
   cleaned = cleaned.replace(/\s*```$/i, '');
@@ -108,7 +140,6 @@ Rules:
   try {
     const mapping = JSON.parse(cleaned) as FieldMapping;
 
-    // Validate
     if (typeof mapping.chineseField !== 'number' || mapping.chineseField < 0) {
       throw new Error('Invalid chineseField');
     }
@@ -119,7 +150,6 @@ Rules:
       mapping.pinyinField = null;
     }
 
-    // Normalize separator
     if (mapping.separator === '\\t' || mapping.separator === 'tab') {
       mapping.separator = '\t';
     }
@@ -134,30 +164,27 @@ Rules:
 // Row extraction
 // ────────────────────────────────────────────────────────────
 
-/** Strip HTML tags from a string. */
 function stripHtml(s: string): string {
   return s.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim();
 }
 
-/** Extract fields from a row using the detected mapping. */
-function extractFields(
-  row: string,
-  mapping: FieldMapping
-): { chinese: string; english: string; pinyin: string | null } | null {
+interface ExtractedFields {
+  chinese: string;
+  english: string;
+  pinyin: string | null;
+}
+
+function extractFields(row: string, mapping: FieldMapping): ExtractedFields | null {
   const fields = row.split(mapping.separator);
 
   const chinese = stripHtml(fields[mapping.chineseField] ?? '').trim();
   if (!chinese) return null;
-
-  // Check if there's actually Chinese text
   if (!/[\u4e00-\u9fff\u3400-\u4dbf]/.test(chinese)) return null;
 
   let english = '';
   if (mapping.englishField === mapping.chineseField) {
-    // Mixed field — try to split on common patterns like " - ", " = ", "："
     const parts = chinese.split(/\s*[-=:：]\s*/);
     if (parts.length >= 2) {
-      // Return the part that has Chinese as chinese, other as english
       const chinesePart = parts.find((p) => /[\u4e00-\u9fff]/.test(p));
       const englishPart = parts.find((p) => /[a-zA-Z]/.test(p) && !/[\u4e00-\u9fff]/.test(p));
       return {
@@ -178,42 +205,158 @@ function extractFields(
 }
 
 // ────────────────────────────────────────────────────────────
-// Sentence analysis via LLM (batch-friendly)
+// Error classification + retry
 // ────────────────────────────────────────────────────────────
 
 /**
- * Analyze a Chinese sentence using the LLM to get tokenization data,
- * then ingest it through the standard pipeline.
+ * Map a thrown error to a coarse category the UI can report on and the retry
+ * logic can branch on. We stay defensive about the error shape because
+ * different AI providers surface rate-limits differently (OpenAI sets
+ * `status: 429`, Anthropic sometimes wraps the status in a generic Error).
  */
-async function analyzeAndIngest(
-  chinese: string,
-  english: string,
-  _pinyin: string | null,
+export function classifyError(e: unknown): ErrorKind {
+  const err = e as { status?: number; message?: string; response?: { status?: number } };
+  const msg = (err?.message || String(e)).toLowerCase();
+  const status = err?.status ?? err?.response?.status;
+
+  if (status === 429 || /rate.?limit|quota|too many requests/.test(msg)) return 'rate-limit';
+  if (status !== undefined && status >= 500) return 'network';
+  if (/network|fetch|timeout|econnreset|socket/.test(msg)) return 'network';
+  if (/parse|json|invalid json|could not parse/.test(msg)) return 'llm-parse';
+  return 'other';
+}
+
+function isTransient(kind: ErrorKind): boolean {
+  return kind === 'rate-limit' || kind === 'network';
+}
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** Retry only transient errors; return the final error's kind on exhaustion. */
+async function withRetry<T>(
+  fn: () => Promise<T>,
+  maxAttempts: number,
+): Promise<T> {
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    try {
+      return await fn();
+    } catch (e) {
+      lastErr = e;
+      const kind = classifyError(e);
+      if (!isTransient(kind) || attempt === maxAttempts - 1) throw e;
+      // 1s, 3s, 9s — wide enough to survive typical 429 cooldowns
+      await sleep(Math.pow(3, attempt) * 1000);
+    }
+  }
+  throw lastErr;
+}
+
+// ────────────────────────────────────────────────────────────
+// Bounded concurrency + circuit breaker
+// ────────────────────────────────────────────────────────────
+
+/**
+ * Run `tasks` with at most `concurrency` in flight at once.
+ *
+ * `shouldAbort` is checked before dispatching each new task; in-flight tasks
+ * continue to completion. This is how the circuit breaker drains cleanly
+ * once rate limiting trips — we stop firing new calls but let pending ones
+ * finish so their results are still reported.
+ */
+async function parallelMap<T, U>(
+  tasks: T[],
+  concurrency: number,
+  run: (task: T, index: number) => Promise<U>,
+  shouldAbort?: () => boolean,
+): Promise<Array<U | { aborted: true }>> {
+  const results = new Array<U | { aborted: true }>(tasks.length);
+  const effectiveConcurrency = Math.max(1, Math.min(concurrency, tasks.length || 1));
+  let nextIndex = 0;
+
+  const workers = Array.from({ length: effectiveConcurrency }, async () => {
+    while (true) {
+      const i = nextIndex++;
+      if (i >= tasks.length) return;
+      if (shouldAbort?.()) {
+        results[i] = { aborted: true };
+        continue;
+      }
+      results[i] = await run(tasks[i], i);
+    }
+  });
+
+  await Promise.all(workers);
+  return results;
+}
+
+// ────────────────────────────────────────────────────────────
+// Pipeline stages — split out so each can be tested in isolation.
+// ────────────────────────────────────────────────────────────
+
+interface RowPlan {
+  /** 0-based row index for deterministic ordering in the final report. */
+  index: number;
+  rawRow: string;
+  fields: ExtractedFields | null;
+}
+
+interface AnalysisInput {
+  index: number;
+  fields: ExtractedFields;
+}
+
+interface AnalysisSuccess {
+  kind: 'ok';
+  index: number;
+  fields: ExtractedFields;
+  parsed: LLMResponse;
+}
+
+interface AnalysisFailure {
+  kind: 'err';
+  index: number;
+  fields: ExtractedFields;
+  errorKind: ErrorKind;
+  message: string;
+}
+
+type AnalysisResult = AnalysisSuccess | AnalysisFailure;
+
+async function analyzeOne(input: AnalysisInput, maxRetries: number): Promise<AnalysisResult> {
+  try {
+    const chinese = input.fields.chinese.trim();
+    const existingMeanings = await getExistingMeanings(chinese);
+    const prompt = generateAnalysisPrompt(chinese, existingMeanings);
+    const raw = await withRetry(() => generateCompletion(prompt), maxRetries);
+    const parsed = parseLLMResponse(raw);
+    return { kind: 'ok', index: input.index, fields: input.fields, parsed };
+  } catch (e: any) {
+    return {
+      kind: 'err',
+      index: input.index,
+      fields: input.fields,
+      errorKind: classifyError(e),
+      message: e?.message || 'Unknown error',
+    };
+  }
+}
+
+async function ingestOne(
+  success: AnalysisSuccess,
   tags: string[],
 ): Promise<void> {
-  // Check for duplicates
-  const existing = await repo.getSentenceByChinese(chinese.trim());
-  if (existing) {
-    throw new Error('duplicate');
-  }
-
-  // Get existing meanings for better LLM context
-  const existingMeanings = await getExistingMeanings(chinese.trim());
-  const prompt = generateAnalysisPrompt(chinese.trim(), existingMeanings);
-  const raw = await generateCompletion(prompt);
-  const parsed = parseLLMResponse(raw);
-
-  // Use LLM's English if we don't have one from the file
-  const finalEnglish = english || parsed.english;
-
+  const { fields, parsed } = success;
+  const finalEnglish = fields.english || parsed.english;
   await ingestSentence({
-    chinese: chinese.trim(),
+    chinese: fields.chinese.trim(),
     english: finalEnglish,
     tokens: parsed.tokens.map((t) => ({
       surfaceForm: t.surfaceForm,
       pinyinNumeric: t.pinyinNumeric,
       english: t.english,
       partOfSpeech: t.partOfSpeech || 'other',
+      isTransliteration: t.isTransliteration,
       characters: t.characters?.map((c) => ({
         char: c.char,
         pinyinNumeric: c.pinyinNumeric,
@@ -230,22 +373,16 @@ async function analyzeAndIngest(
 // Main import function
 // ────────────────────────────────────────────────────────────
 
-/**
- * Import sentences from an Anki export file.
- *
- * Flow:
- * 1. Parse file into rows
- * 2. Send sample to LLM to detect field mapping
- * 3. Extract Chinese/English/Pinyin from each row
- * 4. For each sentence, run LLM analysis + ingestion pipeline
- * 5. Report progress via callback
- */
 export async function importFromAnki(
   file: File,
   onProgress: ProgressCallback,
   abortSignal?: AbortSignal,
   maxItems?: number,
+  options: ImportOptions = {},
 ): Promise<ImportProgress> {
+  const concurrency = options.concurrency ?? DEFAULT_CONCURRENCY;
+  const maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES;
+
   const content = await readFileAsText(file);
   let rows = parseRows(content);
 
@@ -267,51 +404,152 @@ export async function importFromAnki(
     issues: [],
   };
 
-  onProgress({ ...progress, currentSentence: 'Detecting field mapping...' });
+  onProgress({ ...progress, currentSentence: 'Detecting field mapping…' });
 
-  // Step 1: Detect field mapping via LLM
   const mapping = await detectFieldMapping(rows);
 
-  // Step 2: Process each row
-  for (let i = 0; i < rows.length; i++) {
-    if (abortSignal?.aborted) break;
+  // Stage A: extract fields from every row
+  const plans: RowPlan[] = rows.map((rawRow, index) => ({
+    index,
+    rawRow,
+    fields: extractFields(rawRow, mapping),
+  }));
 
-    const fields = extractFields(rows[i], mapping);
-
-    if (!fields) {
+  // Account for rows that had no extractable fields up front.
+  for (const plan of plans) {
+    if (!plan.fields) {
       progress.skipped++;
-      progress.issues.push({ sentence: rows[i].slice(0, 60), reason: 'Could not extract fields', type: 'skipped' });
       progress.processed++;
+      progress.issues.push({
+        sentence: plan.rawRow.slice(0, 60),
+        reason: 'Could not extract fields',
+        type: 'skipped',
+        errorKind: 'no-fields',
+      });
+    }
+  }
+  onProgress({ ...progress });
+
+  // Stage B: dedup against local Dexie. These reads are cheap and independent;
+  // running them in parallel lets us report the final skipped count before we
+  // even start spending LLM tokens.
+  onProgress({ ...progress, currentSentence: 'Checking for duplicates…' });
+  const dedupChecks = await Promise.all(
+    plans
+      .filter((p): p is RowPlan & { fields: ExtractedFields } => !!p.fields)
+      .map(async (p) => {
+        const existing = await repo.getSentenceByChinese(p.fields.chinese.trim());
+        return { plan: p, isDuplicate: !!existing };
+      }),
+  );
+
+  const toAnalyze: AnalysisInput[] = [];
+  for (const { plan, isDuplicate } of dedupChecks) {
+    if (isDuplicate) {
+      progress.skipped++;
+      progress.processed++;
+      progress.issues.push({
+        sentence: plan.fields.chinese,
+        reason: 'Duplicate — already in app',
+        type: 'skipped',
+        errorKind: 'duplicate',
+      });
+    } else {
+      toAnalyze.push({ index: plan.index, fields: plan.fields });
+    }
+  }
+  onProgress({ ...progress });
+
+  // Stage C: parallel LLM analysis with per-call retry + circuit breaker.
+  // `tripped` flips true once we hit RATE_LIMIT_TRIP_THRESHOLD consecutive
+  // rate-limit errors — after that, new tasks short-circuit to failures so
+  // the user doesn't wait for dozens more hopeless requests.
+  let rateLimitStreak = 0;
+  let tripped = false;
+
+  const analysisResults = await parallelMap(
+    toAnalyze,
+    concurrency,
+    async (task) => {
+      if (abortSignal?.aborted || tripped) {
+        const errorKind: ErrorKind = tripped ? 'rate-limit' : 'other';
+        return {
+          kind: 'err' as const,
+          index: task.index,
+          fields: task.fields,
+          errorKind,
+          message: tripped ? 'Skipped after sustained rate limiting' : 'Aborted',
+        };
+      }
+      const result = await analyzeOne(task, maxRetries);
+      // Running counter of consecutive rate-limit errors across completions —
+      // any success resets it. Simpler than a sliding window and good enough
+      // for the "provider is hard-refusing us" case.
+      if (result.kind === 'err' && result.errorKind === 'rate-limit') {
+        rateLimitStreak++;
+        if (rateLimitStreak >= RATE_LIMIT_TRIP_THRESHOLD) tripped = true;
+      } else {
+        rateLimitStreak = 0;
+      }
+      progress.currentSentence = task.fields.chinese;
+      onProgress({ ...progress });
+      return result;
+    },
+    () => abortSignal?.aborted === true,
+  );
+
+  // Stage D: sequential ingest. `findOrCreateMeaning` dedups on
+  // (headword, pinyinNumeric, englishShort) via a read-then-write, which
+  // races if run in parallel, so we serialize this stage.
+  for (const result of analysisResults) {
+    if (abortSignal?.aborted) break;
+    if ('aborted' in result) continue;
+
+    if (result.kind === 'err') {
+      progress.failed++;
+      progress.processed++;
+      progress.issues.push({
+        sentence: result.fields.chinese,
+        reason: result.message.slice(0, 150),
+        type: 'failed',
+        errorKind: result.errorKind,
+      });
       onProgress({ ...progress });
       continue;
     }
 
-    progress.currentSentence = fields.chinese;
+    progress.currentSentence = result.fields.chinese;
     onProgress({ ...progress });
 
     try {
-      await analyzeAndIngest(
-        fields.chinese,
-        fields.english,
-        fields.pinyin,
-        ['anki-import'],
-      );
+      await ingestOne(result, ['anki-import']);
       progress.imported++;
     } catch (e: any) {
-      if (e.message === 'duplicate' || e.message?.includes('already exists')) {
+      const msg: string = e?.message || 'Unknown error';
+      if (msg === 'duplicate' || msg.includes('already exists')) {
         progress.skipped++;
-        progress.issues.push({ sentence: fields.chinese, reason: 'Duplicate — already in app', type: 'skipped' });
+        progress.issues.push({
+          sentence: result.fields.chinese,
+          reason: 'Duplicate — already in app',
+          type: 'skipped',
+          errorKind: 'duplicate',
+        });
       } else {
         progress.failed++;
-        progress.issues.push({ sentence: fields.chinese, reason: e.message?.slice(0, 150) || 'Unknown error', type: 'failed' });
+        progress.issues.push({
+          sentence: result.fields.chinese,
+          reason: msg.slice(0, 150),
+          type: 'failed',
+          errorKind: 'other',
+        });
       }
     }
-
     progress.processed++;
     onProgress({ ...progress });
   }
 
   progress.currentSentence = '';
+  if (tripped) progress.rateLimited = true;
   onProgress({ ...progress });
   return progress;
 }

--- a/src/services/llmPrompt.ts
+++ b/src/services/llmPrompt.ts
@@ -17,21 +17,12 @@ export async function getExistingMeanings(
   chinese: string
 ): Promise<ExistingMeaning[]> {
   const chars = [...new Set(Array.from(chinese.replace(/\s/g, '')))];
-  const results: ExistingMeaning[] = [];
-
-  for (const ch of chars) {
-    const meanings = await repo.getMeaningsByHeadword(ch);
-
-    for (const m of meanings) {
-      results.push({
-        headword: m.headword,
-        pinyin: m.pinyin,
-        english: m.englishShort,
-      });
-    }
-  }
-
-  return results;
+  const perChar = await Promise.all(chars.map((ch) => repo.getMeaningsByHeadword(ch)));
+  return perChar.flat().map((m) => ({
+    headword: m.headword,
+    pinyin: m.pinyin,
+    english: m.englishShort,
+  }));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Text Anki import now runs as a 4-stage pipeline: extract → dedup → **parallel LLM** → sequential ingest. The slow step (LLM analysis) fans out with bounded concurrency; `findOrCreateMeaning`'s read-then-write dedup stays correct because ingest is still serialized.
- Error classifier tags rate-limit / network / parse / other. Transient errors retry with exponential backoff (1s → 3s → 9s), so a transient 429 no longer drops the row.
- Circuit breaker trips after 5 consecutive rate-limit errors and stops firing new calls; in-flight calls drain, remaining rows are flagged so the user sees "paused — re-run or lower concurrency".
- Sentence-level dedup already made re-running safe; the new `duplicate` and `no-fields` `errorKind` tags let the UI show why each row was skipped.
- New Parallel LLM calls input (1–10, default 5) in the Anki import UI. `1` is strictly sequential for users with tight rate limits.

## Scope note
.apkg import stays sequential in this PR — it has audio-blob handling per-row that makes the parallelization non-trivial. Worth its own PR once this pattern proves out.

## Test plan
- [ ] Export a ~200-row Anki text file; import with concurrency=5. Confirm it completes in roughly 1/5 the time vs. concurrency=1 on the same file.
- [ ] Import a file containing sentences already in the app. Confirm dedup runs up front before any LLM calls and the skipped count rises immediately.
- [ ] With an AI key that hits its per-minute limit, confirm retries happen silently and most rows still succeed.
- [ ] With a revoked/expired key, confirm the circuit breaker trips after ~5 failures and the summary shows the rate-limited banner.
- [ ] Re-run the same file after a partial failure; only the failed rows get re-analyzed.
- [ ] `npm test` passes (new `ankiImport.test.ts` covers the error classifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)