### PR TITLE
Fix stale audio on Listen-mode card advance

### DIFF
--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -61,16 +61,17 @@ export function ReviewCard() {
 
   const isListenType = card?.reviewMode === 'listen-type';
   useEffect(() => {
-    if (!isListenType || !sentence) return;
-    if (autoPlayed.current !== card?.id) {
-      autoPlayed.current = card!.id;
+    if (!isListenType || !sentence || !card) return;
+    if (sentence.id !== card.sentenceId) return;
+    if (autoPlayed.current !== card.id) {
+      autoPlayed.current = card.id;
       speakChinese(sentence.chinese, speechRate).catch(() => {});
     }
     if (pinyinInputRef.current) {
       pinyinInputRef.current.focus();
     }
     return () => { stopSpeaking(); };
-  }, [isListenType, sentence, card?.id]);
+  }, [isListenType, sentence, card?.id, card?.sentenceId]);
 
   const handleUndo = async () => {
     if (!undoInfo || undoing || pendingRating !== null) return;


### PR DESCRIPTION
## Summary
- Listen-mode auto-play spoke the *previous* card's sentence after advancing because the effect fired on `card.id` change before the async sentence-load effect had updated `sentence`.
- Guard the effect so it only plays once `sentence.id === card.sentenceId`, ensuring the audio matches the card shown.

## Repro
1. Review in Listen & Type mode.
2. Hear card A (e.g. "méi yǒu"), type it, press Good.
3. Card advances to B, but audio is still A's "méi yǒu". Typing "mei you" is graded against B and marked wrong.

## Test plan
- [ ] Review multiple Listen-mode cards in a row; each new card plays its own audio.
- [ ] Replay button still works on the new card.
- [ ] Non-Listen modes unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)