### PR TITLE
Hotfix: swallow storage-delete errors in audio cleanup trigger

### DIFF
--- a/supabase/migrations/009_audio_cleanup_swallow_errors.sql
+++ b/supabase/migrations/009_audio_cleanup_swallow_errors.sql
@@ -1,0 +1,40 @@
+-- ============================================================
+-- Migration: don't let storage.objects protection block row deletes
+--
+-- Migration 004 added an AFTER DELETE trigger on audio_recordings that
+-- ran `delete from storage.objects ...` to clean up the audio blob.
+-- A Supabase platform update now rejects ANY direct DELETE on
+-- storage.objects with:
+--   "Direct deletion from storage tables is not allowed. Use the
+--    Storage API instead."
+-- regardless of RLS or SECURITY DEFINER.
+--
+-- Result: any cascade that touches audio_recordings (deleting a
+-- sentence, clearing data) fails in the sync RPC, and the whole
+-- transaction rolls back.
+--
+-- Hotfix: wrap the storage delete in a savepoint so the exception is
+-- swallowed. The audio_recording row still gets removed; only the
+-- backing Storage object is orphaned. Proper cleanup (via the Storage
+-- HTTP API from a client or edge function) is tracked separately.
+-- ============================================================
+
+create or replace function delete_audio_recording_object()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, storage
+as $func$
+begin
+  begin
+    delete from storage.objects
+    where bucket_id = 'audio-recordings'
+      and name = OLD.storage_path;
+  exception when others then
+    -- Platform protection or any other failure — log and continue so
+    -- the outer DELETE on audio_recordings still commits.
+    raise warning 'audio cleanup failed for %: %', OLD.storage_path, SQLERRM;
+  end;
+  return OLD;
+end;
+$func$;


### PR DESCRIPTION
## Bug
A Supabase platform update now rejects direct \`DELETE\` on \`storage.objects\` with:

> Direct deletion from storage tables is not allowed. Use the Storage API instead.

...regardless of RLS or \`SECURITY DEFINER\`. The \`AFTER DELETE\` trigger on \`audio_recordings\` (added in migration 004) runs exactly that query to cascade-clean the audio blob. Result: any cascade that touches audio_recordings (deleting a sentence, clear-all-data, etc.) bubbles the error up through the sync RPC and rolls the whole transaction back. Observed as 403 on \`apply_delete_ops\`.

## Hotfix
Migration 009 rewrites the trigger function to catch the exception and continue. The audio_recording row deletes cleanly; the backing Storage object is orphaned.

## Known cost
Storage blobs no longer auto-cleanup on row delete. Orphaned files accumulate in the \`audio-recordings\` bucket. Proper fix needs either:
- Client-side: delete the Storage object via \`supabase.storage.from(...).remove([...])\` before deleting the DB row.
- Server-side: use \`pg_net\` to call the Storage HTTP API from the trigger, or move cleanup into an edge function driven by a DB webhook.

Will track separately.

## Apply + merge plan
1. Merge this PR.
2. Apply migration 009 to Supabase (SQL editor or \`supabase db push\`).
3. Deletions stop failing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)