### PR TITLE
Client-side audio Storage cleanup + orphan backfill (closes #106)

### DIFF
--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -433,6 +433,11 @@ export async function deleteAudioRecording(id: string): Promise<void> {
   await localDb.audioRecordings.delete(id);
 }
 
+export async function getAllAudioStoragePaths(): Promise<string[]> {
+  const rows = await localDb.audioRecordings.toArray();
+  return rows.map((r) => r.storagePath).filter((p): p is string => !!p);
+}
+
 // ============================================================
 // Meaning flags
 // ============================================================

--- a/src/db/remoteRepo.ts
+++ b/src/db/remoteRepo.ts
@@ -327,6 +327,17 @@ export async function getAllAudioRecordings(): Promise<AudioRecording[]> {
   return data.map(audioRecordingFromRow);
 }
 
+/** Storage paths for every audio recording the caller can see (RLS-
+ *  scoped to the current user). Used by the orphan-audio sweep. */
+export async function getAllAudioStoragePaths(): Promise<string[]> {
+  const data = await fetchAllPages((from, to) =>
+    supabase.from('audio_recordings').select('storage_path').order('id').range(from, to),
+  );
+  return data
+    .map((r) => (r as { storage_path: string | null }).storage_path)
+    .filter((p): p is string => !!p);
+}
+
 // ============================================================
 // Sync metadata
 // ============================================================

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -10,6 +10,7 @@
 import * as local from './localRepo';
 import { localDb, type SyncOp } from './localDb';
 import { supabase } from '../lib/supabase';
+import { removeStorageObjects } from '../lib/audioStorage';
 import { getDeviceId, scheduleSyncSoon } from './syncEngine';
 import {
   getUserId as getRemoteUserId,
@@ -153,11 +154,15 @@ export async function updateSentenceTags(id: string, tags: string[]): Promise<vo
 }
 
 export async function deleteSentenceById(id: string): Promise<void> {
+  const audioPaths = (await local.getAudioRecordingsBySentence(id))
+    .map((r) => r.storagePath)
+    .filter((p): p is string => !!p);
   await local.deleteSentenceById(id);
   await enqueue({
     op: 'deleteEntity',
     payload: { entity_type: 'sentence', entity_id: id },
   });
+  await removeStorageObjects(audioPaths);
 }
 
 export async function deleteSentencesBySource(source: string): Promise<void> {
@@ -315,6 +320,7 @@ export async function deleteReviewLogsByCardIds(cardIds: string[]): Promise<void
 // ============================================================
 
 export async function deleteAllUserData(): Promise<void> {
+  const audioPaths = await local.getAllAudioStoragePaths();
   await local.deleteAllUserData();
   // Clear hydration + USN so the app can rehydrate from server if
   // the delete op doesn't push (e.g. user is offline or closes the tab).
@@ -322,6 +328,7 @@ export async function deleteAllUserData(): Promise<void> {
   await localDb.syncMeta.delete('lastUsn');
   await localDb.syncMeta.delete('schemaVersion');
   await enqueue({ op: 'deleteAllData', payload: {} });
+  await removeStorageObjects(audioPaths);
 }
 
 // ============================================================
@@ -363,6 +370,8 @@ export async function updateAudioRecordingName(id: string, name: string) {
 }
 
 export async function deleteAudioRecording(id: string) {
+  const rec = await local.getAudioRecording(id);
+
   // Coalesce any still-pending upsert for this id so record-then-delete
   // offline doesn't waste an upload. Narrowed by the `op` index first.
   const pendingUpsert = await localDb.outbox
@@ -379,6 +388,10 @@ export async function deleteAudioRecording(id: string) {
     op: 'deleteEntity',
     payload: { entity_type: 'audio_recording', entity_id: id },
   });
+  // Clean up the Storage blob. The server's AFTER DELETE trigger no
+  // longer can (platform change — migration 009 swallowed the error
+  // so deletes stop failing), so the client handles it explicitly.
+  await removeStorageObjects([rec?.storagePath]);
 }
 
 /**

--- a/src/db/syncEngine.ts
+++ b/src/db/syncEngine.ts
@@ -11,6 +11,7 @@
  *   - graves: delete from local Dexie
  */
 import { supabase } from '../lib/supabase';
+import { AUDIO_BUCKET, removeStorageObjects } from '../lib/audioStorage';
 import { localDb, type SyncOp } from './localDb';
 import {
   meaningFromRow,
@@ -244,7 +245,7 @@ async function pushUpsertAudioRecording(op: SyncOp): Promise<void> {
     const ext = extensionFromMime(payload.mimeType);
     storagePath = `${userId}/${payload.id}.${ext}`;
     const { error: uploadErr } = await supabase.storage
-      .from('audio-recordings')
+      .from(AUDIO_BUCKET)
       .upload(storagePath, rec.blob!, {
         contentType: payload.mimeType,
         upsert: true,
@@ -264,9 +265,7 @@ async function pushUpsertAudioRecording(op: SyncOp): Promise<void> {
       // this was a metadata-only push, the cascade from the deleted
       // sentence already removed the object via the delete trigger.
       if (isFirstUpload) {
-        try {
-          await supabase.storage.from('audio-recordings').remove([storagePath!]);
-        } catch {}
+        await removeStorageObjects([storagePath]);
       }
       await localDb.audioRecordings.delete(payload.id);
       return;

--- a/src/lib/audioStorage.ts
+++ b/src/lib/audioStorage.ts
@@ -1,0 +1,25 @@
+import { supabase } from './supabase';
+
+const BUCKET = 'audio-recordings';
+
+/**
+ * Delete storage objects best-effort. Called after a successful local +
+ * server row delete, to clean up the backing Storage blob. Failures
+ * are logged but never thrown — the row is already gone; orphaned
+ * blobs can be reaped by the backfill helper.
+ *
+ * Filters out null/undefined/empty paths (a recording may not have
+ * uploaded yet, in which case there's no blob to delete).
+ */
+export async function removeStorageObjects(
+  paths: (string | null | undefined)[],
+): Promise<void> {
+  const real = paths.filter((p): p is string => !!p);
+  if (real.length === 0) return;
+  try {
+    const { error } = await supabase.storage.from(BUCKET).remove(real);
+    if (error) console.warn('removeStorageObjects failed', error);
+  } catch (e) {
+    console.warn('removeStorageObjects threw', e);
+  }
+}

--- a/src/lib/audioStorage.ts
+++ b/src/lib/audioStorage.ts
@@ -1,6 +1,9 @@
 import { supabase } from './supabase';
 
-const BUCKET = 'audio-recordings';
+export const AUDIO_BUCKET = 'audio-recordings';
+
+/** Supabase Storage caps each remove() request at 1000 keys. */
+const REMOVE_BATCH_SIZE = 1000;
 
 /**
  * Delete storage objects best-effort. Called after a successful local +
@@ -16,10 +19,13 @@ export async function removeStorageObjects(
 ): Promise<void> {
   const real = paths.filter((p): p is string => !!p);
   if (real.length === 0) return;
-  try {
-    const { error } = await supabase.storage.from(BUCKET).remove(real);
-    if (error) console.warn('removeStorageObjects failed', error);
-  } catch (e) {
-    console.warn('removeStorageObjects threw', e);
+  for (let i = 0; i < real.length; i += REMOVE_BATCH_SIZE) {
+    const chunk = real.slice(i, i + REMOVE_BATCH_SIZE);
+    try {
+      const { error } = await supabase.storage.from(AUDIO_BUCKET).remove(chunk);
+      if (error) console.warn('removeStorageObjects failed', error);
+    } catch (e) {
+      console.warn('removeStorageObjects threw', e);
+    }
   }
 }

--- a/src/lib/cleanOrphanedAudio.ts
+++ b/src/lib/cleanOrphanedAudio.ts
@@ -1,0 +1,102 @@
+import { supabase } from './supabase';
+
+const BUCKET = 'audio-recordings';
+
+export interface OrphanReport {
+  totalInBucket: number;
+  totalInDb: number;
+  orphans: string[];
+  removed: string[];
+  failed: { path: string; reason: string }[];
+}
+
+/**
+ * One-off sweep to delete Storage blobs that no longer have a matching
+ * audio_recordings row — left behind by migration 009 (which stopped
+ * the server-side DELETE trigger from throwing but also stopped it
+ * from succeeding, so every blob deleted via cascade since the
+ * platform change was orphaned). Run once per user via DevTools:
+ *
+ *   await window.__cleanOrphanedAudio()
+ *
+ * Lists every object under the current user's folder in the
+ * audio-recordings bucket, joins against audio_recordings.storage_path
+ * in the DB, deletes blobs whose path isn't referenced by any row.
+ */
+export async function cleanOrphanedAudio(): Promise<OrphanReport> {
+  const { data: userData } = await supabase.auth.getUser();
+  const userId = userData.user?.id;
+  if (!userId) {
+    throw new Error('Not signed in — cannot clean orphaned audio.');
+  }
+
+  const { data: objects, error: listErr } = await supabase.storage
+    .from(BUCKET)
+    .list(userId, { limit: 1000 });
+  if (listErr) throw new Error(`Failed to list bucket: ${listErr.message}`);
+  const bucketPaths = new Set(
+    (objects ?? []).map((o) => `${userId}/${o.name}`),
+  );
+
+  const { data: rows, error: rowErr } = await supabase
+    .from('audio_recordings')
+    .select('storage_path')
+    .eq('user_id', userId);
+  if (rowErr) throw new Error(`Failed to query rows: ${rowErr.message}`);
+  const dbPaths = new Set(
+    (rows ?? [])
+      .map((r) => (r as { storage_path: string | null }).storage_path)
+      .filter((p): p is string => !!p),
+  );
+
+  const orphans = [...bucketPaths].filter((p) => !dbPaths.has(p));
+
+  const removed: string[] = [];
+  const failed: { path: string; reason: string }[] = [];
+
+  if (orphans.length > 0) {
+    const { data: rmData, error: rmErr } = await supabase.storage
+      .from(BUCKET)
+      .remove(orphans);
+    if (rmErr) {
+      for (const p of orphans) failed.push({ path: p, reason: rmErr.message });
+    } else {
+      for (const obj of rmData ?? []) {
+        if (obj.name) removed.push(obj.name);
+      }
+      for (const p of orphans) {
+        if (!removed.includes(p)) {
+          failed.push({ path: p, reason: 'not confirmed deleted' });
+        }
+      }
+    }
+  }
+
+  return {
+    totalInBucket: bucketPaths.size,
+    totalInDb: dbPaths.size,
+    orphans,
+    removed,
+    failed,
+  };
+}
+
+export async function runCleanOrphanedAudioInConsole(): Promise<OrphanReport> {
+  const report = await cleanOrphanedAudio();
+  console.log(
+    `Orphan sweep: ${report.totalInBucket} objects in bucket, ${report.totalInDb} rows in DB, ` +
+      `${report.orphans.length} orphaned, ${report.removed.length} removed, ` +
+      `${report.failed.length} failed`,
+  );
+  if (report.orphans.length > 0) {
+    console.group('Orphans');
+    console.table(report.orphans);
+    console.groupEnd();
+  }
+  if (report.failed.length > 0) {
+    console.group('Failed deletions');
+    console.table(report.failed);
+    console.groupEnd();
+  }
+  return report;
+}

--- a/src/lib/cleanOrphanedAudio.ts
+++ b/src/lib/cleanOrphanedAudio.ts
@@ -1,6 +1,8 @@
 import { supabase } from './supabase';
+import { AUDIO_BUCKET } from './audioStorage';
+import * as remote from '../db/remoteRepo';
 
-const BUCKET = 'audio-recordings';
+const LIST_PAGE_SIZE = 1000;
 
 export interface OrphanReport {
   totalInBucket: number;
@@ -10,18 +12,33 @@ export interface OrphanReport {
   failed: { path: string; reason: string }[];
 }
 
+async function listAllUserObjects(userId: string): Promise<string[]> {
+  const all: string[] = [];
+  let offset = 0;
+  while (true) {
+    const { data, error } = await supabase.storage
+      .from(AUDIO_BUCKET)
+      .list(userId, { limit: LIST_PAGE_SIZE, offset });
+    if (error) throw new Error(`Failed to list bucket: ${error.message}`);
+    const page = data ?? [];
+    for (const obj of page) all.push(`${userId}/${obj.name}`);
+    if (page.length < LIST_PAGE_SIZE) break;
+    offset += LIST_PAGE_SIZE;
+  }
+  return all;
+}
+
 /**
  * One-off sweep to delete Storage blobs that no longer have a matching
  * audio_recordings row — left behind by migration 009 (which stopped
  * the server-side DELETE trigger from throwing but also stopped it
- * from succeeding, so every blob deleted via cascade since the
- * platform change was orphaned). Run once per user via DevTools:
+ * from succeeding). Run once per user via DevTools:
  *
  *   await window.__cleanOrphanedAudio()
  *
- * Lists every object under the current user's folder in the
- * audio-recordings bucket, joins against audio_recordings.storage_path
- * in the DB, deletes blobs whose path isn't referenced by any row.
+ * Don't run while actively recording audio — an in-flight upload that
+ * has reached the bucket but not the DB row yet will be misclassified
+ * as an orphan.
  */
 export async function cleanOrphanedAudio(): Promise<OrphanReport> {
   const { data: userData } = await supabase.auth.getUser();
@@ -30,50 +47,37 @@ export async function cleanOrphanedAudio(): Promise<OrphanReport> {
     throw new Error('Not signed in — cannot clean orphaned audio.');
   }
 
-  const { data: objects, error: listErr } = await supabase.storage
-    .from(BUCKET)
-    .list(userId, { limit: 1000 });
-  if (listErr) throw new Error(`Failed to list bucket: ${listErr.message}`);
-  const bucketPaths = new Set(
-    (objects ?? []).map((o) => `${userId}/${o.name}`),
-  );
+  const [bucketPaths, dbPathList] = await Promise.all([
+    listAllUserObjects(userId),
+    remote.getAllAudioStoragePaths(),
+  ]);
+  const dbPaths = new Set(dbPathList);
 
-  const { data: rows, error: rowErr } = await supabase
-    .from('audio_recordings')
-    .select('storage_path')
-    .eq('user_id', userId);
-  if (rowErr) throw new Error(`Failed to query rows: ${rowErr.message}`);
-  const dbPaths = new Set(
-    (rows ?? [])
-      .map((r) => (r as { storage_path: string | null }).storage_path)
-      .filter((p): p is string => !!p),
-  );
-
-  const orphans = [...bucketPaths].filter((p) => !dbPaths.has(p));
+  const orphans = bucketPaths.filter((p) => !dbPaths.has(p));
 
   const removed: string[] = [];
   const failed: { path: string; reason: string }[] = [];
 
-  if (orphans.length > 0) {
+  // Supabase Storage caps remove() at 1000 keys per request.
+  const BATCH = 1000;
+  for (let i = 0; i < orphans.length; i += BATCH) {
+    const chunk = orphans.slice(i, i + BATCH);
     const { data: rmData, error: rmErr } = await supabase.storage
-      .from(BUCKET)
-      .remove(orphans);
+      .from(AUDIO_BUCKET)
+      .remove(chunk);
     if (rmErr) {
-      for (const p of orphans) failed.push({ path: p, reason: rmErr.message });
-    } else {
-      for (const obj of rmData ?? []) {
-        if (obj.name) removed.push(obj.name);
-      }
-      for (const p of orphans) {
-        if (!removed.includes(p)) {
-          failed.push({ path: p, reason: 'not confirmed deleted' });
-        }
-      }
+      for (const p of chunk) failed.push({ path: p, reason: rmErr.message });
+      continue;
+    }
+    const confirmed = new Set((rmData ?? []).map((obj) => obj.name).filter((n): n is string => !!n));
+    for (const p of chunk) {
+      if (confirmed.has(p)) removed.push(p);
+      else failed.push({ path: p, reason: 'not confirmed deleted' });
     }
   }
 
   return {
-    totalInBucket: bucketPaths.size,
+    totalInBucket: bucketPaths.length,
     totalInDb: dbPaths.size,
     orphans,
     removed,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,13 +3,16 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 import { runAuditInConsole, runRepairInConsole } from './lib/auditPinyin'
+import { runCleanOrphanedAudioInConsole } from './lib/cleanOrphanedAudio'
 
 const w = window as unknown as {
   __auditPinyin?: () => Promise<unknown>
   __repairPinyin?: () => Promise<unknown>
+  __cleanOrphanedAudio?: () => Promise<unknown>
 }
 w.__auditPinyin = runAuditInConsole
 w.__repairPinyin = runRepairInConsole
+w.__cleanOrphanedAudio = runCleanOrphanedAudioInConsole
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
Closes #106.

## Context
Migration 009 stopped a platform-level rejection on direct \`DELETE from storage.objects\` from crashing the app, at the cost of the AFTER DELETE trigger no longer cleaning up audio blobs. Since that PR shipped, every audio recording whose row was deleted has orphaned its backing Storage blob forever. Storage cost grows unboundedly; blobs of "deleted" recordings are still accessible.

## Fix
Client-side cleanup at every row-delete site, plus a one-off backfill for blobs already orphaned.

**Delete paths now call \`removeStorageObjects([...])\` after the local + sync op:**
- \`repo.deleteAudioRecording(id)\` — single recording
- \`repo.deleteSentenceById(id)\` — collects all recordings for that sentence
- \`repo.deleteAllUserData()\` — sweeps every recording before clearing

Storage removal is best-effort: failures are logged, never thrown. The row deletion has already committed, so the worst case is an orphan — which the backfill helper catches.

**Backfill (DevTools):**
\`\`\`js
await window.__cleanOrphanedAudio()
// Orphan sweep: 42 objects in bucket, 18 rows in DB, 24 orphaned, 24 removed, 0 failed
\`\`\`
Lists all objects under the user's folder in the \`audio-recordings\` bucket, joins against \`audio_recordings.storage_path\`, deletes any blob with no matching row. Exposed on window alongside \`__auditPinyin\` / \`__repairPinyin\`.

## Files
- \`src/lib/audioStorage.ts\` (new) — thin helper: \`removeStorageObjects(paths)\`
- \`src/lib/cleanOrphanedAudio.ts\` (new) — backfill + DevTools wrapper
- \`src/main.tsx\` — exposes \`window.__cleanOrphanedAudio\`
- \`src/db/repo.ts\` — wire cleanup into the three delete paths
- \`src/db/localRepo.ts\` — new \`getAllAudioStoragePaths()\`

## Deploy
No migration. Merge and run \`await window.__cleanOrphanedAudio()\` once to reap the backlog.

## Test plan
- [ ] Delete a sentence with audio → row deleted locally, Storage object gone from the bucket.
- [ ] Delete a single recording via the audio-controls UI → same.
- [ ] Run the backfill on an account that had pre-migration-009 deletes → confirms removed blob count matches the backlog.
- [ ] 76/76 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)