### PR TITLE
Fix main build: narrow CheckPinyinFlag.kind for IngestFlag discrimination

### DIFF
--- a/src/lib/checkPinyin.ts
+++ b/src/lib/checkPinyin.ts
@@ -1,8 +1,9 @@
 import { lookup } from './cedict';
-import type { MeaningFlagKind } from '../db/schema';
 
 export interface CheckPinyinFlag {
-  kind: MeaningFlagKind;
+  /** Narrowed to the kinds checkPinyin actually produces. Lets the
+   *  IngestFlag union discriminate against SegmentationFlag cleanly. */
+  kind: 'cedict-disagreement' | 'cedict-unknown';
   headword: string;
   /** What the pipeline saw when producing this flag. Not necessarily the
    *  value that ends up persisted — user may edit on the review screen. */


### PR DESCRIPTION
Hotfix: main's Vercel build is failing post-#112 merge.

## Error
\`\`\`
src/pages/AddSentencePage.tsx: Property 'tokenIndices' does not exist on type 'IngestFlag'.
  Property 'tokenIndices' does not exist on type 'CheckPinyinFlag'.
\`\`\`

## Cause
\`CheckPinyinFlag.kind\` was typed as the full \`MeaningFlagKind\` union, which includes \`'segmentation-disagreement'\`. That meant TypeScript couldn't discriminate \`IngestFlag = CheckPinyinFlag | SegmentationFlag\` via a \`kind\` check — after \`if (flag.kind === 'segmentation-disagreement')\`, flag could still be a \`CheckPinyinFlag\` per the type, so \`tokenIndices\`/\`cedictEnglish\` didn't resolve.

Local \`npx tsc --noEmit\` missed it; Vercel's stricter production build caught it.

## Fix
Narrow \`CheckPinyinFlag.kind\` to just the two values \`checkPinyin\` actually produces: \`'cedict-disagreement' | 'cedict-unknown'\`. Now the kind check cleanly narrows to \`SegmentationFlag\`.

One-line change. \`npm run build\` succeeds locally; 76/76 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)