### PR TITLE
Classify + surface permanent sync failures (closes #109)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { ResetPasswordPage } from './pages/ResetPasswordPage';
 import { IntroModal } from './components/IntroModal';
 import { ThemeToggle } from './components/ThemeToggle';
 import { SyncIndicator } from './components/SyncIndicator';
+import { SyncErrorBanner } from './components/SyncErrorBanner';
 import { useTutorialStore } from './stores/tutorialStore';
 import { useAuthStore } from './stores/authStore';
 import './stores/themeStore';
@@ -144,6 +145,7 @@ function App() {
           <ThemeToggle />
         </div>
         <div className="h-10" />
+        <SyncErrorBanner />
         {step === 0 && <IntroModal onDone={advance} />}
         <Routes>
           <Route

--- a/src/components/SyncErrorBanner.tsx
+++ b/src/components/SyncErrorBanner.tsx
@@ -1,24 +1,24 @@
 import { useState } from 'react';
 import { useSyncStore } from '../stores/syncStore';
 import { runSync } from '../db/syncEngine';
+import type { SyncOpType } from '../db/localDb';
+
+const OP_LABELS: Record<SyncOpType, string> = {
+  reviewCard: 'card review',
+  ingestBundle: 'new sentence',
+  deleteEntity: 'delete',
+  deleteAllData: 'clear all data',
+  updateTags: 'tag update',
+  upsertAudioRecording: 'audio upload',
+};
 
 export function SyncErrorBanner() {
   const failedCount = useSyncStore((s) => s.failedCount);
   const failedOps = useSyncStore((s) => s.failedOps);
   const status = useSyncStore((s) => s.status);
   const [expanded, setExpanded] = useState(false);
-  const [retrying, setRetrying] = useState(false);
 
   if (failedCount === 0) return null;
-
-  const handleRetry = async () => {
-    setRetrying(true);
-    try {
-      await runSync();
-    } finally {
-      setRetrying(false);
-    }
-  };
 
   return (
     <div
@@ -37,8 +37,8 @@ export function SyncErrorBanner() {
         </span>
         <button
           type="button"
-          onClick={handleRetry}
-          disabled={retrying || status === 'syncing'}
+          onClick={() => runSync()}
+          disabled={status === 'syncing'}
           className="px-2 py-0.5 rounded transition-colors disabled:opacity-50"
           style={{
             background: 'var(--bg-surface)',
@@ -46,7 +46,7 @@ export function SyncErrorBanner() {
             border: '1px solid var(--border)',
           }}
         >
-          {retrying || status === 'syncing' ? 'Retrying…' : 'Retry'}
+          {status === 'syncing' ? 'Retrying…' : 'Retry'}
         </button>
         <button
           type="button"
@@ -60,9 +60,10 @@ export function SyncErrorBanner() {
       {expanded && failedOps.length > 0 && (
         <ul className="mt-2 space-y-1">
           {failedOps.map((op, i) => (
-            <li key={i} className="font-mono" style={{ color: 'var(--text-secondary)' }}>
-              <strong>{op.opType}</strong>
-              {op.code && <> ({op.code})</>}: {op.error}
+            <li key={i} style={{ color: 'var(--text-secondary)' }}>
+              <strong>{OP_LABELS[op.op]}</strong>
+              {op.lastErrorCode && <> <span className="font-mono">({op.lastErrorCode})</span></>}
+              : <span className="font-mono">{op.lastError ?? 'Unknown error'}</span>
             </li>
           ))}
         </ul>

--- a/src/components/SyncErrorBanner.tsx
+++ b/src/components/SyncErrorBanner.tsx
@@ -1,0 +1,72 @@
+import { useState } from 'react';
+import { useSyncStore } from '../stores/syncStore';
+import { runSync } from '../db/syncEngine';
+
+export function SyncErrorBanner() {
+  const failedCount = useSyncStore((s) => s.failedCount);
+  const failedOps = useSyncStore((s) => s.failedOps);
+  const status = useSyncStore((s) => s.status);
+  const [expanded, setExpanded] = useState(false);
+  const [retrying, setRetrying] = useState(false);
+
+  if (failedCount === 0) return null;
+
+  const handleRetry = async () => {
+    setRetrying(true);
+    try {
+      await runSync();
+    } finally {
+      setRetrying(false);
+    }
+  };
+
+  return (
+    <div
+      className="sticky top-0 z-50 px-4 py-2 text-xs"
+      style={{
+        background: 'color-mix(in srgb, var(--danger) 12%, var(--bg-surface))',
+        borderBottom: '1px solid var(--danger)',
+        color: 'var(--text-primary)',
+      }}
+      role="alert"
+    >
+      <div className="flex flex-wrap items-center gap-2">
+        <span>
+          <strong>{failedCount}</strong> change{failedCount === 1 ? '' : 's'} couldn't sync to the
+          server. They're saved locally but won't reach other devices until resolved.
+        </span>
+        <button
+          type="button"
+          onClick={handleRetry}
+          disabled={retrying || status === 'syncing'}
+          className="px-2 py-0.5 rounded transition-colors disabled:opacity-50"
+          style={{
+            background: 'var(--bg-surface)',
+            color: 'var(--text-primary)',
+            border: '1px solid var(--border)',
+          }}
+        >
+          {retrying || status === 'syncing' ? 'Retrying…' : 'Retry'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setExpanded((v) => !v)}
+          className="px-2 py-0.5 rounded transition-colors"
+          style={{ background: 'transparent', color: 'var(--text-secondary)' }}
+        >
+          {expanded ? 'Hide details' : 'Show details'}
+        </button>
+      </div>
+      {expanded && failedOps.length > 0 && (
+        <ul className="mt-2 space-y-1">
+          {failedOps.map((op, i) => (
+            <li key={i} className="font-mono" style={{ color: 'var(--text-secondary)' }}>
+              <strong>{op.opType}</strong>
+              {op.code && <> ({op.code})</>}: {op.error}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/src/db/localDb.ts
+++ b/src/db/localDb.ts
@@ -33,6 +33,14 @@ export interface SyncOp {
   createdAt: number;
   deviceId: string;
   opId: string;
+  /** Server-reported error message from the most recent attempt.
+   *  Populated when status transitions to 'failed' — either after
+   *  MAX_ATTEMPTS or immediately on a permanent Postgres error. */
+  lastError?: string;
+  /** Postgres error code from the last attempt (if any). Permanent
+   *  families 23xxx/42xxx/58xxx mark the op 'failed' on the first hit
+   *  instead of burning retries. */
+  lastErrorCode?: string;
 }
 
 class MandaoDb extends Dexie {

--- a/src/db/syncEngine.ts
+++ b/src/db/syncEngine.ts
@@ -13,12 +13,12 @@
 import { supabase } from '../lib/supabase';
 import { AUDIO_BUCKET, removeStorageObjects } from '../lib/audioStorage';
 import { localDb, type SyncOp } from './localDb';
-import type { FailedOpSummary } from '../stores/syncStore';
+import type { FailedOp } from '../stores/syncStore';
 
 /** Sync error that preserves the Postgres code so the outbox can tell
  *  permanent (CHECK violation, missing column) apart from transient
  *  (network, rate limit). */
-class SyncError extends Error {
+export class SyncError extends Error {
   code?: string;
   constructor(message: string, code?: string) {
     super(message);
@@ -26,7 +26,10 @@ class SyncError extends Error {
   }
 }
 
-function syncErrorFrom(e: { message?: string; code?: string } | null | undefined, fallback = 'Unknown sync error'): SyncError {
+export function syncErrorFrom(
+  e: { message?: string; code?: string } | null | undefined,
+  fallback = 'Unknown sync error',
+): SyncError {
   return new SyncError(e?.message ?? fallback, e?.code);
 }
 
@@ -37,7 +40,7 @@ function syncErrorFrom(e: { message?: string; code?: string } | null | undefined
  *            function signature mismatch, insufficient_privilege)
  *    58xxx — system_error (server-side internal errors)
  */
-function isPermanentSyncError(e: unknown): boolean {
+export function isPermanentSyncError(e: unknown): boolean {
   if (!(e instanceof SyncError) || !e.code) return false;
   return /^(23|42|58)/.test(e.code);
 }
@@ -130,42 +133,45 @@ async function pushOutbox(): Promise<void> {
       }
     }
   } finally {
-    if (succeeded.length > 0) {
-      await localDb.outbox.bulkDelete(succeeded);
-    }
-    for (const { id, error } of failed) {
-      const permanent = isPermanentSyncError(error);
-      const message = (error as Error)?.message ?? String(error);
-      const code = error instanceof SyncError ? error.code : undefined;
-      await localDb.outbox
-        .where('id')
-        .equals(id)
-        .modify((op: SyncOp) => {
-          op.lastError = message;
-          op.lastErrorCode = code;
-          if (permanent) {
-            // Retrying can't fix a CHECK violation / missing column.
-            // Mark failed now; user sees it in the banner + can resync
-            // manually after the schema catches up.
-            op.status = 'failed';
-            op.attempts = MAX_ATTEMPTS;
-          } else {
-            op.attempts += 1;
-            op.status = op.attempts >= MAX_ATTEMPTS ? 'failed' : 'pending';
-          }
-        });
-    }
-    const handled = new Set([
-      ...succeeded,
-      ...failed.map((f) => f.id),
-    ]);
-    const unaccounted = ids.filter((id) => !handled.has(id));
-    if (unaccounted.length > 0) {
-      await localDb.outbox
-        .where('id')
-        .anyOf(unaccounted)
-        .modify({ status: 'pending' });
-    }
+    // Atomic: succeeded deletes + failed updates + unaccounted resets
+    // all commit together, so a tab crash mid-finally leaves a
+    // consistent outbox.
+    await localDb.transaction('rw', localDb.outbox, async () => {
+      if (succeeded.length > 0) {
+        await localDb.outbox.bulkDelete(succeeded);
+      }
+      for (const { id, error } of failed) {
+        const permanent = isPermanentSyncError(error);
+        const message = (error as Error)?.message ?? String(error);
+        const code = error instanceof SyncError ? error.code : undefined;
+        await localDb.outbox
+          .where('id')
+          .equals(id)
+          .modify((op: SyncOp) => {
+            op.lastError = message;
+            op.lastErrorCode = code;
+            if (permanent) {
+              // Retrying can't fix a CHECK violation / missing column.
+              op.status = 'failed';
+              op.attempts = MAX_ATTEMPTS;
+            } else {
+              op.attempts += 1;
+              op.status = op.attempts >= MAX_ATTEMPTS ? 'failed' : 'pending';
+            }
+          });
+      }
+      const handled = new Set([
+        ...succeeded,
+        ...failed.map((f) => f.id),
+      ]);
+      const unaccounted = ids.filter((id) => !handled.has(id));
+      if (unaccounted.length > 0) {
+        await localDb.outbox
+          .where('id')
+          .anyOf(unaccounted)
+          .modify({ status: 'pending' });
+      }
+    });
   }
 }
 
@@ -362,7 +368,7 @@ async function pullOnePage(): Promise<boolean> {
     last_usn: lastUsn,
     max_rows: PULL_PAGE_SIZE,
   });
-  if (error) throw new Error(error.message);
+  if (error) throw syncErrorFrom(error);
   if (!data) return false;
 
   const changes = data as {
@@ -556,21 +562,20 @@ export async function runSync(): Promise<void> {
     const stuck = stuckRows.length;
     store.setPendingCount(remaining + stuck);
 
-    const samples: FailedOpSummary[] = stuckRows
-      .slice(-5)
-      .map((op) => ({
-        opType: op.op,
-        error: op.lastError ?? 'Unknown error',
-        code: op.lastErrorCode,
-      }));
+    // Cap samples — banner only needs enough for the details toggle.
+    const samples: FailedOp[] = stuckRows.slice(-5).map((op) => ({
+      op: op.op,
+      lastError: op.lastError,
+      lastErrorCode: op.lastErrorCode,
+    }));
     store.setFailed(stuck, samples);
 
     store.setLastSyncedAt(Date.now());
-    if (stuck > 0) {
-      store.setError(`${stuck} operation(s) failed permanently`);
-    } else {
+    if (stuck === 0) {
       store.setStatus('synced');
     }
+    // When stuck > 0, setFailed already set status='error' + errorMessage,
+    // so a separate setError(...) call would duplicate the signal.
   } catch (e: any) {
     console.error('Sync failed:', e);
     store.setError(e.message || 'Sync failed');

--- a/src/db/syncEngine.ts
+++ b/src/db/syncEngine.ts
@@ -13,6 +13,34 @@
 import { supabase } from '../lib/supabase';
 import { AUDIO_BUCKET, removeStorageObjects } from '../lib/audioStorage';
 import { localDb, type SyncOp } from './localDb';
+import type { FailedOpSummary } from '../stores/syncStore';
+
+/** Sync error that preserves the Postgres code so the outbox can tell
+ *  permanent (CHECK violation, missing column) apart from transient
+ *  (network, rate limit). */
+class SyncError extends Error {
+  code?: string;
+  constructor(message: string, code?: string) {
+    super(message);
+    this.code = code;
+  }
+}
+
+function syncErrorFrom(e: { message?: string; code?: string } | null | undefined, fallback = 'Unknown sync error'): SyncError {
+  return new SyncError(e?.message ?? fallback, e?.code);
+}
+
+/** Postgres error families that are permanent — retrying can't fix them
+ *  without a code / schema change:
+ *    23xxx — integrity_constraint_violation (CHECK, NOT NULL, FK, unique)
+ *    42xxx — syntax_error_or_access_rule_violation (missing column,
+ *            function signature mismatch, insufficient_privilege)
+ *    58xxx — system_error (server-side internal errors)
+ */
+function isPermanentSyncError(e: unknown): boolean {
+  if (!(e instanceof SyncError) || !e.code) return false;
+  return /^(23|42|58)/.test(e.code);
+}
 import {
   meaningFromRow,
   meaningLinkFromRow,
@@ -80,7 +108,7 @@ async function pushOutbox(): Promise<void> {
   const runs = groupConsecutiveRuns(pending);
 
   const succeeded: number[] = [];
-  const failed: number[] = [];
+  const failed: { id: number; error: unknown }[] = [];
 
   try {
     for (let i = 0; i < runs.length; i++) {
@@ -94,7 +122,7 @@ async function pushOutbox(): Promise<void> {
           failed.push(...e.failed);
         } else {
           console.error(`Sync push failed for ${ops[0].op}:`, e);
-          failed.push(...ops.map((o) => o.id!));
+          for (const op of ops) failed.push({ id: op.id!, error: e });
         }
         // Stop processing further runs to preserve causal ordering.
         // Remaining un-attempted ops stay inflight → reset in finally.
@@ -105,16 +133,32 @@ async function pushOutbox(): Promise<void> {
     if (succeeded.length > 0) {
       await localDb.outbox.bulkDelete(succeeded);
     }
-    if (failed.length > 0) {
+    for (const { id, error } of failed) {
+      const permanent = isPermanentSyncError(error);
+      const message = (error as Error)?.message ?? String(error);
+      const code = error instanceof SyncError ? error.code : undefined;
       await localDb.outbox
         .where('id')
-        .anyOf(failed)
+        .equals(id)
         .modify((op: SyncOp) => {
-          op.status = op.attempts + 1 >= MAX_ATTEMPTS ? 'failed' : 'pending';
-          op.attempts += 1;
+          op.lastError = message;
+          op.lastErrorCode = code;
+          if (permanent) {
+            // Retrying can't fix a CHECK violation / missing column.
+            // Mark failed now; user sees it in the banner + can resync
+            // manually after the schema catches up.
+            op.status = 'failed';
+            op.attempts = MAX_ATTEMPTS;
+          } else {
+            op.attempts += 1;
+            op.status = op.attempts >= MAX_ATTEMPTS ? 'failed' : 'pending';
+          }
         });
     }
-    const handled = new Set([...succeeded, ...failed]);
+    const handled = new Set([
+      ...succeeded,
+      ...failed.map((f) => f.id),
+    ]);
     const unaccounted = ids.filter((id) => !handled.has(id));
     if (unaccounted.length > 0) {
       await localDb.outbox
@@ -161,8 +205,8 @@ async function pushOpBatch(ops: SyncOp[]): Promise<void> {
  */
 class PartialBatchError extends Error {
   succeeded: number[];
-  failed: number[];
-  constructor(succeeded: number[], failed: number[]) {
+  failed: { id: number; error: unknown }[];
+  constructor(succeeded: number[], failed: { id: number; error: unknown }[]) {
     super('Partial batch failure');
     this.succeeded = succeeded;
     this.failed = failed;
@@ -174,13 +218,13 @@ async function pushSequential(
   fn: (op: SyncOp) => Promise<void>,
 ): Promise<void> {
   const ok: number[] = [];
-  const bad: number[] = [];
+  const bad: { id: number; error: unknown }[] = [];
   for (const op of ops) {
     try {
       await fn(op);
       ok.push(op.id!);
-    } catch {
-      bad.push(op.id!);
+    } catch (e) {
+      bad.push({ id: op.id!, error: e });
     }
   }
   if (bad.length > 0) throw new PartialBatchError(ok, bad);
@@ -189,24 +233,24 @@ async function pushSequential(
 async function pushReviewOps(ops: SyncOp[]): Promise<void> {
   const payload = ops.map((o) => o.payload);
   const { error } = await supabase.rpc('apply_review_ops', { ops: payload });
-  if (error) throw new Error(error.message);
+  if (error) throw syncErrorFrom(error);
 }
 
 
 async function pushIngestBundle(op: SyncOp): Promise<void> {
   const { error } = await supabase.rpc('apply_ingest_bundle', { bundle: op.payload });
-  if (error) throw new Error(error.message);
+  if (error) throw syncErrorFrom(error);
 }
 
 async function pushDeleteOps(ops: SyncOp[]): Promise<void> {
   const payload = ops.map((o) => o.payload);
   const { error } = await supabase.rpc('apply_delete_ops', { ops: payload });
-  if (error) throw new Error(error.message);
+  if (error) throw syncErrorFrom(error);
 }
 
 async function pushDeleteAllData(): Promise<void> {
   const { error } = await supabase.rpc('delete_all_user_data');
-  if (error) throw new Error(error.message);
+  if (error) throw syncErrorFrom(error);
 }
 
 /**
@@ -250,7 +294,7 @@ async function pushUpsertAudioRecording(op: SyncOp): Promise<void> {
         contentType: payload.mimeType,
         upsert: true,
       });
-    if (uploadErr) throw new Error(uploadErr.message);
+    if (uploadErr) throw syncErrorFrom(uploadErr);
   }
 
   const { error: rowErr } = await supabase
@@ -270,7 +314,7 @@ async function pushUpsertAudioRecording(op: SyncOp): Promise<void> {
       await localDb.audioRecordings.delete(payload.id);
       return;
     }
-    throw new Error(rowErr.message);
+    throw syncErrorFrom(rowErr);
   }
 
   if (isFirstUpload) {
@@ -284,13 +328,13 @@ async function pushUpdateTags(op: SyncOp): Promise<void> {
   // auto-sets usn + updated_at on the server side.
   // Explicit user_id filter for defense-in-depth alongside RLS.
   const userId = (await supabase.auth.getSession()).data.session?.user?.id;
-  if (!userId) throw new Error('Not authenticated');
+  if (!userId) throw new SyncError('Not authenticated');
   const { error } = await supabase
     .from('sentences')
     .update({ tags })
     .eq('id', id)
     .eq('user_id', userId);
-  if (error) throw new Error(error.message);
+  if (error) throw syncErrorFrom(error);
 }
 
 // ============================================================
@@ -508,8 +552,19 @@ export async function runSync(): Promise<void> {
     await pullChanges();
 
     const remaining = await localDb.outbox.where('status').equals('pending').count();
-    const stuck = await localDb.outbox.where('status').equals('failed').count();
+    const stuckRows = await localDb.outbox.where('status').equals('failed').toArray();
+    const stuck = stuckRows.length;
     store.setPendingCount(remaining + stuck);
+
+    const samples: FailedOpSummary[] = stuckRows
+      .slice(-5)
+      .map((op) => ({
+        opType: op.op,
+        error: op.lastError ?? 'Unknown error',
+        code: op.lastErrorCode,
+      }));
+    store.setFailed(stuck, samples);
+
     store.setLastSyncedAt(Date.now());
     if (stuck > 0) {
       store.setError(`${stuck} operation(s) failed permanently`);

--- a/src/db/syncErrors.test.ts
+++ b/src/db/syncErrors.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import { SyncError, isPermanentSyncError, syncErrorFrom } from './syncEngine';
+
+describe('isPermanentSyncError', () => {
+  it('flags 23xxx (integrity constraint violations) as permanent', () => {
+    expect(isPermanentSyncError(new SyncError('CHECK violation', '23514'))).toBe(true);
+    expect(isPermanentSyncError(new SyncError('FK violation', '23503'))).toBe(true);
+    expect(isPermanentSyncError(new SyncError('unique violation', '23505'))).toBe(true);
+    expect(isPermanentSyncError(new SyncError('not null', '23502'))).toBe(true);
+  });
+
+  it('flags 42xxx (syntax / definition) as permanent', () => {
+    expect(isPermanentSyncError(new SyncError('missing column', '42703'))).toBe(true);
+    expect(isPermanentSyncError(new SyncError('bad function sig', '42883'))).toBe(true);
+  });
+
+  it('flags 58xxx (system errors) as permanent', () => {
+    expect(isPermanentSyncError(new SyncError('system', '58000'))).toBe(true);
+  });
+
+  it('does not flag 22xxx (data exceptions) or 40xxx (txn rollback)', () => {
+    expect(isPermanentSyncError(new SyncError('divide by zero', '22012'))).toBe(false);
+    expect(isPermanentSyncError(new SyncError('serialization', '40001'))).toBe(false);
+  });
+
+  it('does not flag errors without a code', () => {
+    expect(isPermanentSyncError(new SyncError('unknown'))).toBe(false);
+  });
+
+  it('does not flag plain Error or other thrown values', () => {
+    expect(isPermanentSyncError(new Error('network timeout'))).toBe(false);
+    expect(isPermanentSyncError('string error')).toBe(false);
+    expect(isPermanentSyncError(null)).toBe(false);
+    expect(isPermanentSyncError(undefined)).toBe(false);
+  });
+});
+
+describe('syncErrorFrom', () => {
+  it('preserves message and code from a Supabase error-shaped object', () => {
+    const wrapped = syncErrorFrom({ message: 'CHECK violation', code: '23514' });
+    expect(wrapped).toBeInstanceOf(SyncError);
+    expect(wrapped.message).toBe('CHECK violation');
+    expect(wrapped.code).toBe('23514');
+  });
+
+  it('uses a fallback message when none provided', () => {
+    const wrapped = syncErrorFrom(null, 'fallback');
+    expect(wrapped.message).toBe('fallback');
+    expect(wrapped.code).toBeUndefined();
+  });
+});

--- a/src/stores/syncStore.ts
+++ b/src/stores/syncStore.ts
@@ -1,16 +1,28 @@
 import { create } from 'zustand';
+import type { SyncOpType } from '../db/localDb';
 
 export type SyncStatus = 'synced' | 'syncing' | 'offline' | 'error';
+
+export interface FailedOpSummary {
+  opType: SyncOpType;
+  error: string;
+  code?: string;
+}
 
 interface SyncState {
   status: SyncStatus;
   lastSyncedAt: number | null;
   pendingCount: number;
+  /** Count of ops stuck in 'failed' status — won't retry automatically. */
+  failedCount: number;
+  /** Up to N most-recent failed ops for the error banner's detail view. */
+  failedOps: FailedOpSummary[];
   errorMessage: string | null;
   online: boolean;
   setStatus: (status: SyncStatus) => void;
   setLastSyncedAt: (ts: number) => void;
   setPendingCount: (count: number) => void;
+  setFailed: (count: number, samples: FailedOpSummary[]) => void;
   setError: (msg: string | null) => void;
   setOnline: (online: boolean) => void;
 }
@@ -19,11 +31,14 @@ export const useSyncStore = create<SyncState>((set) => ({
   status: navigator.onLine ? 'synced' : 'offline',
   lastSyncedAt: null,
   pendingCount: 0,
+  failedCount: 0,
+  failedOps: [],
   errorMessage: null,
   online: navigator.onLine,
   setStatus: (status) => set(status === 'error' ? { status } : { status, errorMessage: null }),
   setLastSyncedAt: (ts) => set({ lastSyncedAt: ts }),
   setPendingCount: (count) => set({ pendingCount: count }),
+  setFailed: (count, samples) => set({ failedCount: count, failedOps: samples }),
   setError: (msg) => set({ errorMessage: msg, status: msg ? 'error' : 'synced' }),
   // When going online, don't claim 'synced' — let runSync update status.
   // When going offline, set status immediately.

--- a/src/stores/syncStore.ts
+++ b/src/stores/syncStore.ts
@@ -1,28 +1,25 @@
 import { create } from 'zustand';
-import type { SyncOpType } from '../db/localDb';
+import type { SyncOp } from '../db/localDb';
 
 export type SyncStatus = 'synced' | 'syncing' | 'offline' | 'error';
 
-export interface FailedOpSummary {
-  opType: SyncOpType;
-  error: string;
-  code?: string;
-}
+/** Subset of a SyncOp that the error banner needs — identity + error. */
+export type FailedOp = Pick<SyncOp, 'op' | 'lastError' | 'lastErrorCode'>;
 
 interface SyncState {
   status: SyncStatus;
   lastSyncedAt: number | null;
   pendingCount: number;
-  /** Count of ops stuck in 'failed' status — won't retry automatically. */
+  /** Total count of ops in 'failed' status (may exceed failedOps.length — failedOps is capped for display). */
   failedCount: number;
   /** Up to N most-recent failed ops for the error banner's detail view. */
-  failedOps: FailedOpSummary[];
+  failedOps: FailedOp[];
   errorMessage: string | null;
   online: boolean;
   setStatus: (status: SyncStatus) => void;
   setLastSyncedAt: (ts: number) => void;
   setPendingCount: (count: number) => void;
-  setFailed: (count: number, samples: FailedOpSummary[]) => void;
+  setFailed: (count: number, samples: FailedOp[]) => void;
   setError: (msg: string | null) => void;
   setOnline: (online: boolean) => void;
 }
@@ -38,7 +35,16 @@ export const useSyncStore = create<SyncState>((set) => ({
   setStatus: (status) => set(status === 'error' ? { status } : { status, errorMessage: null }),
   setLastSyncedAt: (ts) => set({ lastSyncedAt: ts }),
   setPendingCount: (count) => set({ pendingCount: count }),
-  setFailed: (count, samples) => set({ failedCount: count, failedOps: samples }),
+  setFailed: (count, samples) =>
+    set((state) => ({
+      failedCount: count,
+      failedOps: samples,
+      // Failed ops are terminal — keep status 'error' so the SyncIndicator
+      // dot stays red, without relying on a duplicate setError() call.
+      status: count > 0 ? 'error' : state.status,
+      errorMessage:
+        count > 0 ? `${count} change${count === 1 ? '' : 's'} couldn't sync` : state.errorMessage,
+    })),
   setError: (msg) => set({ errorMessage: msg, status: msg ? 'error' : 'synced' }),
   // When going online, don't claim 'synced' — let runSync update status.
   // When going offline, set status immediately.


### PR DESCRIPTION
Closes #109.

## Problem
Silent sync failures bit us three times this session:
- Missing migration 007 → \`srs_cards_review_mode_check\` violation
- Missing migration 011 → \`meaning_flags_flag_kind_check\` violation
- Supabase platform change → storage.objects delete rejected

Each time the local Dexie write succeeded, the sync op retried forever in the background, and nothing surfaced the problem until someone checked DevTools. PR #110 patched the logout-confirm case; this PR handles the general class.

## What changed

**1. Postgres error classification (\`src/db/syncEngine.ts\`).**
- New \`SyncError\` wrapper preserves the Postgres \`code\` alongside the message (we were losing it via \`throw new Error(e.message)\`).
- \`isPermanentSyncError()\` recognizes families that can't be fixed by retrying without a code/schema change:
  - \`23xxx\` — integrity_constraint_violation (CHECK, NOT NULL, FK, unique)
  - \`42xxx\` — syntax/definition errors (missing column, function signature mismatch, insufficient_privilege)
  - \`58xxx\` — system_error (server internals)
- Replaced \`throw new Error(err.message)\` at every RPC call site with \`throw syncErrorFrom(err)\`.

**2. Fail fast on permanent errors (\`pushOutbox\`).**
- Previously an op only became \`status='failed'\` after \`MAX_ATTEMPTS\` burned through.
- Now a permanent PG error flips \`status='failed'\` immediately and records \`op.lastError\` + \`op.lastErrorCode\` for the UI.
- Transient errors (network, timeout) still retry up to \`MAX_ATTEMPTS\` — unchanged.
- \`PartialBatchError\` now carries per-id error info so the classifier can run per op.

**3. \`SyncOp\` schema gains \`lastError?: string\` and \`lastErrorCode?: string\`.**
- Dexie stores are versioned by field shape, not schema, so this is additive without a migration bump.

**4. \`syncStore\` exposes \`failedCount\` + \`failedOps: FailedOpSummary[]\`.**
- Populated from the outbox at the end of each \`runSync()\` cycle.
- Up to 5 most-recent failure samples for the banner's detail view.

**5. Global \`<SyncErrorBanner />\`.**
- Rendered at the top of \`App.tsx\`, visible on every page.
- Shows count of failed ops, \`[Retry]\` button (calls \`runSync\`), and \`[Show details]\` toggle that expands to the ops + error codes.
- Only appears when \`failedCount > 0\`.

## Test plan
- [ ] Simulate a permanent failure by adding a sentence before applying a required migration. Banner appears immediately; retries don't burn cycles.
- [ ] Fix the migration → hit \`[Retry]\` in the banner → ops clear, banner disappears.
- [ ] Simulate a transient failure (toggle airplane mode, then do a write) → op retries normally, no banner.
- [ ] Existing 76 tests still pass.

## Out of scope
- Startup \`schema_version()\` RPC — proactive schema drift check. The banner catches the same class on first failed write, so preemptive detection has diminishing returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)