### PR TITLE
Graph page redesign + fog + orphan-meaning cascade

### DIFF
--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -94,42 +94,48 @@ export async function deleteMeaningLinksByIds(ids: string[]): Promise<void> {
 }
 
 /**
- * Given a set of candidate meaning IDs whose parent sentence was just
- * deleted, compute the transitive closure of meanings that are now
- * orphaned — no surviving sentence_token and no surviving parent
- * meaning_link points to them.
+ * Pure orphan-closure computation — split out of findOrphanClosure so
+ * it's exercisable without Dexie. Given the candidate set and the
+ * current meaning_links + sentence_tokens, returns the meaning IDs
+ * that should be deleted and the meaning_link IDs that should go with
+ * them (any link incident to an orphan, on either end).
  *
- * Character meanings only reachable via meaning_links from a compound
- * word also get cleaned up once the compound word is orphaned.
- * Returns both the orphan meaning IDs and the meaning_link IDs
- * referencing any of them (as parent or child), so callers can delete
- * them + enqueue sync ops in one pass.
+ * An orphan is a meaning with:
+ *   - no surviving sentence_token pointing at it, AND
+ *   - no surviving meaning_link from a *non-orphan* parent.
+ *
+ * The fixed-point loop handles the transitive case: a character
+ * reachable only from a compound word becomes an orphan once the
+ * compound word is itself determined to be orphan.
  */
-export async function findOrphanClosure(
+export function computeOrphanClosure(
   candidateMeaningIds: string[],
-): Promise<{ meanings: string[]; links: string[] }> {
+  allLinks: MeaningLink[],
+  allTokens: SentenceToken[],
+): { meanings: string[]; links: string[] } {
   if (candidateMeaningIds.length === 0) return { meanings: [], links: [] };
 
-  // Precompute three maps so the fixed-point loop is O(1) per lookup:
-  //   referenced: any remaining sentence_token still points at this meaning
-  //   parentsOf:  meaning_links indexed by childMeaningId
-  //   childrenOf: meaning_links indexed by parentMeaningId
-  // Trades one full scan of each table for O(N·M) nested scans in the
-  // previous implementation.
-  const [allLinks, allTokens] = await Promise.all([
-    localDb.meaningLinks.toArray(),
-    localDb.sentenceTokens.toArray(),
-  ]);
+  // Precompute three indexes so the fixed-point loop is O(1) per
+  // lookup, and so the final "which links touch the orphan set" step
+  // doesn't need another full scan:
+  //   referenced:      any remaining sentence_token still points at m
+  //   parentsOf:       m → parent meaning IDs
+  //   childrenOf:      m → child meaning IDs
+  //   linksTouching:   m → meaning_link IDs incident to m
   const referenced = new Set(allTokens.map((t) => t.meaningId));
   const parentsOf = new Map<string, string[]>();
   const childrenOf = new Map<string, string[]>();
+  const linksTouching = new Map<string, string[]>();
+  const pushTo = (m: Map<string, string[]>, k: string, v: string) => {
+    const arr = m.get(k);
+    if (arr) arr.push(v);
+    else m.set(k, [v]);
+  };
   for (const l of allLinks) {
-    const ps = parentsOf.get(l.childMeaningId);
-    if (ps) ps.push(l.parentMeaningId);
-    else parentsOf.set(l.childMeaningId, [l.parentMeaningId]);
-    const cs = childrenOf.get(l.parentMeaningId);
-    if (cs) cs.push(l.childMeaningId);
-    else childrenOf.set(l.parentMeaningId, [l.childMeaningId]);
+    pushTo(parentsOf, l.childMeaningId, l.parentMeaningId);
+    pushTo(childrenOf, l.parentMeaningId, l.childMeaningId);
+    pushTo(linksTouching, l.parentMeaningId, l.id);
+    pushTo(linksTouching, l.childMeaningId, l.id);
   }
 
   const orphans = new Set<string>();
@@ -154,10 +160,27 @@ export async function findOrphanClosure(
     candidates = nextCandidates;
   }
 
-  const links = allLinks
-    .filter((l) => orphans.has(l.parentMeaningId) || orphans.has(l.childMeaningId))
-    .map((l) => l.id);
-  return { meanings: [...orphans], links };
+  const linkIds = new Set<string>();
+  for (const m of orphans) {
+    for (const lid of linksTouching.get(m) ?? []) linkIds.add(lid);
+  }
+  return { meanings: [...orphans], links: [...linkIds] };
+}
+
+/**
+ * Thin Dexie wrapper around computeOrphanClosure — reads the current
+ * meaning_links + sentence_tokens tables and defers to the pure
+ * computation. See computeOrphanClosure for semantics.
+ */
+export async function findOrphanClosure(
+  candidateMeaningIds: string[],
+): Promise<{ meanings: string[]; links: string[] }> {
+  if (candidateMeaningIds.length === 0) return { meanings: [], links: [] };
+  const [allLinks, allTokens] = await Promise.all([
+    localDb.meaningLinks.toArray(),
+    localDb.sentenceTokens.toArray(),
+  ]);
+  return computeOrphanClosure(candidateMeaningIds, allLinks, allTokens);
 }
 
 // ============================================================

--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -110,7 +110,28 @@ export async function findOrphanClosure(
 ): Promise<{ meanings: string[]; links: string[] }> {
   if (candidateMeaningIds.length === 0) return { meanings: [], links: [] };
 
-  const allLinks = await localDb.meaningLinks.toArray();
+  // Precompute three maps so the fixed-point loop is O(1) per lookup:
+  //   referenced: any remaining sentence_token still points at this meaning
+  //   parentsOf:  meaning_links indexed by childMeaningId
+  //   childrenOf: meaning_links indexed by parentMeaningId
+  // Trades one full scan of each table for O(N·M) nested scans in the
+  // previous implementation.
+  const [allLinks, allTokens] = await Promise.all([
+    localDb.meaningLinks.toArray(),
+    localDb.sentenceTokens.toArray(),
+  ]);
+  const referenced = new Set(allTokens.map((t) => t.meaningId));
+  const parentsOf = new Map<string, string[]>();
+  const childrenOf = new Map<string, string[]>();
+  for (const l of allLinks) {
+    const ps = parentsOf.get(l.childMeaningId);
+    if (ps) ps.push(l.parentMeaningId);
+    else parentsOf.set(l.childMeaningId, [l.parentMeaningId]);
+    const cs = childrenOf.get(l.parentMeaningId);
+    if (cs) cs.push(l.childMeaningId);
+    else childrenOf.set(l.parentMeaningId, [l.childMeaningId]);
+  }
+
   const orphans = new Set<string>();
   let candidates = [...candidateMeaningIds];
   let changed = true;
@@ -120,22 +141,14 @@ export async function findOrphanClosure(
     const nextCandidates: string[] = [];
     for (const mId of candidates) {
       if (orphans.has(mId)) continue;
-      const tokenCount = await localDb.sentenceTokens
-        .where('meaningId')
-        .equals(mId)
-        .count();
-      if (tokenCount > 0) continue;
-      const hasLivingParent = allLinks.some(
-        (l) => l.childMeaningId === mId && !orphans.has(l.parentMeaningId),
-      );
+      if (referenced.has(mId)) continue;
+      const parents = parentsOf.get(mId) ?? [];
+      const hasLivingParent = parents.some((p) => !orphans.has(p));
       if (hasLivingParent) continue;
       orphans.add(mId);
       changed = true;
-      // Children might be newly orphaned now that this parent is gone.
-      for (const l of allLinks) {
-        if (l.parentMeaningId === mId && !orphans.has(l.childMeaningId)) {
-          nextCandidates.push(l.childMeaningId);
-        }
+      for (const cId of childrenOf.get(mId) ?? []) {
+        if (!orphans.has(cId)) nextCandidates.push(cId);
       }
     }
     candidates = nextCandidates;

--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -93,6 +93,60 @@ export async function deleteMeaningLinksByIds(ids: string[]): Promise<void> {
   await localDb.meaningLinks.bulkDelete(ids);
 }
 
+/**
+ * Given a set of candidate meaning IDs whose parent sentence was just
+ * deleted, compute the transitive closure of meanings that are now
+ * orphaned — no surviving sentence_token and no surviving parent
+ * meaning_link points to them.
+ *
+ * Character meanings only reachable via meaning_links from a compound
+ * word also get cleaned up once the compound word is orphaned.
+ * Returns both the orphan meaning IDs and the meaning_link IDs
+ * referencing any of them (as parent or child), so callers can delete
+ * them + enqueue sync ops in one pass.
+ */
+export async function findOrphanClosure(
+  candidateMeaningIds: string[],
+): Promise<{ meanings: string[]; links: string[] }> {
+  if (candidateMeaningIds.length === 0) return { meanings: [], links: [] };
+
+  const allLinks = await localDb.meaningLinks.toArray();
+  const orphans = new Set<string>();
+  let candidates = [...candidateMeaningIds];
+  let changed = true;
+
+  while (changed) {
+    changed = false;
+    const nextCandidates: string[] = [];
+    for (const mId of candidates) {
+      if (orphans.has(mId)) continue;
+      const tokenCount = await localDb.sentenceTokens
+        .where('meaningId')
+        .equals(mId)
+        .count();
+      if (tokenCount > 0) continue;
+      const hasLivingParent = allLinks.some(
+        (l) => l.childMeaningId === mId && !orphans.has(l.parentMeaningId),
+      );
+      if (hasLivingParent) continue;
+      orphans.add(mId);
+      changed = true;
+      // Children might be newly orphaned now that this parent is gone.
+      for (const l of allLinks) {
+        if (l.parentMeaningId === mId && !orphans.has(l.childMeaningId)) {
+          nextCandidates.push(l.childMeaningId);
+        }
+      }
+    }
+    candidates = nextCandidates;
+  }
+
+  const links = allLinks
+    .filter((l) => orphans.has(l.parentMeaningId) || orphans.has(l.childMeaningId))
+    .map((l) => l.id);
+  return { meanings: [...orphans], links };
+}
+
 // ============================================================
 // Sentences
 // ============================================================

--- a/src/db/orphanClosure.test.ts
+++ b/src/db/orphanClosure.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import { computeOrphanClosure } from './localRepo';
+import type { MeaningLink, SentenceToken } from './schema';
+
+// Minimal factories — every field the function reads, nothing else.
+// The schema carries extra fields (role, position, surfaceForm, usn)
+// that the algorithm ignores, so we omit them via casts to keep the
+// fixtures readable.
+const link = (id: string, parent: string, child: string): MeaningLink =>
+  ({ id, parentMeaningId: parent, childMeaningId: child }) as MeaningLink;
+
+const token = (meaningId: string, sentenceId = 's1'): SentenceToken =>
+  ({ id: `t-${sentenceId}-${meaningId}`, sentenceId, meaningId }) as SentenceToken;
+
+describe('computeOrphanClosure', () => {
+  it('returns empty when no candidates', () => {
+    const r = computeOrphanClosure([], [], []);
+    expect(r.meanings).toEqual([]);
+    expect(r.links).toEqual([]);
+  });
+
+  it('removes a candidate with no parent link and no sentence_token', () => {
+    const r = computeOrphanClosure(['m1'], [], []);
+    expect(r.meanings).toEqual(['m1']);
+    expect(r.links).toEqual([]);
+  });
+
+  it('preserves a candidate still referenced by a sentence_token', () => {
+    const tokens = [token('m1', 's-other')];
+    const r = computeOrphanClosure(['m1'], [], tokens);
+    expect(r.meanings).toEqual([]);
+    expect(r.links).toEqual([]);
+  });
+
+  it('preserves a candidate whose parent meaning is not in the candidate set', () => {
+    // parent m-word still lives (not a candidate), child m1 stays with it
+    const links = [link('l1', 'm-word', 'm1')];
+    const r = computeOrphanClosure(['m1'], links, []);
+    expect(r.meanings).toEqual([]);
+    expect(r.links).toEqual([]);
+  });
+
+  it('transitively orphans a child once its only parent is an orphan', () => {
+    // Compound word m-word has one child character m-char.
+    // No sentence_tokens survive. Candidates are just the compound;
+    // the character should get dragged along via transitive closure.
+    const links = [link('l1', 'm-word', 'm-char')];
+    const r = computeOrphanClosure(['m-word'], links, []);
+    expect(new Set(r.meanings)).toEqual(new Set(['m-word', 'm-char']));
+    expect(r.links).toEqual(['l1']);
+  });
+
+  it('handles a diamond: A orphans drag B, C, and the bridge link', () => {
+    // A → B, A → C, B → C. Deleting A should orphan B and C, and
+    // return all three links.
+    const links = [
+      link('l1', 'A', 'B'),
+      link('l2', 'A', 'C'),
+      link('l3', 'B', 'C'),
+    ];
+    const r = computeOrphanClosure(['A'], links, []);
+    expect(new Set(r.meanings)).toEqual(new Set(['A', 'B', 'C']));
+    expect(new Set(r.links)).toEqual(new Set(['l1', 'l2', 'l3']));
+  });
+
+  it('protects a child that has at least one living parent', () => {
+    // Two parents for m-char: m-word-1 (candidate, will orphan) and
+    // m-word-2 (not a candidate, lives). m-char should survive.
+    const links = [
+      link('l1', 'm-word-1', 'm-char'),
+      link('l2', 'm-word-2', 'm-char'),
+    ];
+    const r = computeOrphanClosure(['m-word-1'], links, []);
+    expect(r.meanings).toEqual(['m-word-1']);
+    // l1 is incident to the orphan m-word-1 and is returned so the
+    // caller removes the dead edge. l2 is untouched.
+    expect(r.links).toEqual(['l1']);
+  });
+
+  it('token on the child keeps the child and its descendants alive', () => {
+    // m-word is orphan; m-char is reachable from m-word but has its
+    // own surviving sentence_token, so it must stay.
+    const links = [link('l1', 'm-word', 'm-char')];
+    const tokens = [token('m-char', 's-still-here')];
+    const r = computeOrphanClosure(['m-word'], links, tokens);
+    expect(r.meanings).toEqual(['m-word']);
+    expect(r.links).toEqual(['l1']);
+  });
+
+  it('is order-insensitive when candidates are processed out of order', () => {
+    // Same diamond as above, but seed candidates with the leaf first.
+    // The fixed-point loop must still converge to the same result.
+    const links = [
+      link('l1', 'A', 'B'),
+      link('l2', 'A', 'C'),
+      link('l3', 'B', 'C'),
+    ];
+    const r = computeOrphanClosure(['C', 'B', 'A'], links, []);
+    expect(new Set(r.meanings)).toEqual(new Set(['A', 'B', 'C']));
+    expect(new Set(r.links)).toEqual(new Set(['l1', 'l2', 'l3']));
+  });
+});

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -153,18 +153,37 @@ export async function updateSentenceTags(id: string, tags: string[]): Promise<vo
   await enqueue({ op: 'updateTags', payload: { id, tags } });
 }
 
-/** Enqueue deleteEntity ops for an orphan closure. Concurrent because
- *  each enqueue is its own Dexie transaction — avoids the per-call
- *  await stall when the closure is large. */
+/** Enqueue deleteEntity ops for an orphan closure in a single Dexie
+ *  bulkAdd transaction. Using a per-op `enqueue` fan-out here would
+ *  spin up one transaction per op, which the backfill sweep can push
+ *  into the thousands on an old account. */
 export async function enqueueOrphanDeletes(meaningIds: string[], linkIds: string[]): Promise<void> {
-  await Promise.all([
-    ...linkIds.map((lid) =>
-      enqueue({ op: 'deleteEntity', payload: { entity_type: 'meaning_link', entity_id: lid } }),
-    ),
-    ...meaningIds.map((mid) =>
-      enqueue({ op: 'deleteEntity', payload: { entity_type: 'meaning', entity_id: mid } }),
-    ),
-  ]);
+  if (meaningIds.length === 0 && linkIds.length === 0) return;
+  const now = Date.now();
+  const deviceId = getDeviceId();
+  const rows: SyncOp[] = [
+    ...linkIds.map((lid) => ({
+      op: 'deleteEntity' as const,
+      payload: { entity_type: 'meaning_link', entity_id: lid },
+      status: 'pending' as const,
+      attempts: 0,
+      createdAt: now,
+      deviceId,
+      opId: uuid(),
+    })),
+    ...meaningIds.map((mid) => ({
+      op: 'deleteEntity' as const,
+      payload: { entity_type: 'meaning', entity_id: mid },
+      status: 'pending' as const,
+      attempts: 0,
+      createdAt: now,
+      deviceId,
+      opId: uuid(),
+    })),
+  ];
+  await localDb.outbox.bulkAdd(rows);
+  if (navigator.onLine) useSyncStore.getState().setStatus('syncing');
+  scheduleSyncSoon();
 }
 
 export async function deleteSentenceById(id: string): Promise<void> {

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -154,14 +154,55 @@ export async function updateSentenceTags(id: string, tags: string[]): Promise<vo
 }
 
 export async function deleteSentenceById(id: string): Promise<void> {
-  const audioPaths = (await local.getAudioRecordingsBySentence(id))
+  // Collect audio paths + meanings this sentence was the only reason
+  // for, BEFORE the delete cascades away the sentence_tokens we need
+  // to inspect.
+  const [audioRecs, tokens] = await Promise.all([
+    local.getAudioRecordingsBySentence(id),
+    local.getSentenceTokensBySentence(id),
+  ]);
+  const audioPaths = audioRecs
     .map((r) => r.storagePath)
     .filter((p): p is string => !!p);
+  const candidateMeaningIds = [...new Set(tokens.map((t) => t.meaningId))];
+
+  // Delete the sentence — localRepo cascades tokens, cards, review_logs,
+  // and audio_recordings rows.
   await local.deleteSentenceById(id);
+
+  // Find meanings (and their meaning_links) that are now orphaned.
+  // Includes transitive closure: compound-word children freed by the
+  // word's deletion get cleaned up too.
+  const { meanings: orphanedMeanings, links: orphanedLinks } =
+    await local.findOrphanClosure(candidateMeaningIds);
+
+  if (orphanedLinks.length > 0) {
+    await local.deleteMeaningLinksByIds(orphanedLinks);
+  }
+  if (orphanedMeanings.length > 0) {
+    await local.deleteMeaningsByIds(orphanedMeanings);
+  }
+
+  // Server-side enqueue. Meaning delete cascades meaning_links via FK,
+  // but we enqueue link deletes too so graves are emitted for other
+  // devices to pick up.
   await enqueue({
     op: 'deleteEntity',
     payload: { entity_type: 'sentence', entity_id: id },
   });
+  for (const linkId of orphanedLinks) {
+    await enqueue({
+      op: 'deleteEntity',
+      payload: { entity_type: 'meaning_link', entity_id: linkId },
+    });
+  }
+  for (const mId of orphanedMeanings) {
+    await enqueue({
+      op: 'deleteEntity',
+      payload: { entity_type: 'meaning', entity_id: mId },
+    });
+  }
+
   await removeStorageObjects(audioPaths);
 }
 

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -153,13 +153,27 @@ export async function updateSentenceTags(id: string, tags: string[]): Promise<vo
   await enqueue({ op: 'updateTags', payload: { id, tags } });
 }
 
+/** Enqueue deleteEntity ops for an orphan closure. Concurrent because
+ *  each enqueue is its own Dexie transaction — avoids the per-call
+ *  await stall when the closure is large. */
+export async function enqueueOrphanDeletes(meaningIds: string[], linkIds: string[]): Promise<void> {
+  await Promise.all([
+    ...linkIds.map((lid) =>
+      enqueue({ op: 'deleteEntity', payload: { entity_type: 'meaning_link', entity_id: lid } }),
+    ),
+    ...meaningIds.map((mid) =>
+      enqueue({ op: 'deleteEntity', payload: { entity_type: 'meaning', entity_id: mid } }),
+    ),
+  ]);
+}
+
 export async function deleteSentenceById(id: string): Promise<void> {
   // Collect audio paths + meanings this sentence was the only reason
   // for, BEFORE the delete cascades away the sentence_tokens we need
   // to inspect.
   const [audioRecs, tokens] = await Promise.all([
     local.getAudioRecordingsBySentence(id),
-    local.getSentenceTokensBySentence(id),
+    local.getTokensBySentence(id),
   ]);
   const audioPaths = audioRecs
     .map((r) => r.storagePath)
@@ -183,26 +197,14 @@ export async function deleteSentenceById(id: string): Promise<void> {
     await local.deleteMeaningsByIds(orphanedMeanings);
   }
 
-  // Server-side enqueue. Meaning delete cascades meaning_links via FK,
-  // but we enqueue link deletes too so graves are emitted for other
-  // devices to pick up.
+  // Sentence delete cascades meaning_links server-side via FK, but we
+  // still enqueue link/meaning deletes so graves are emitted for other
+  // devices to sync.
   await enqueue({
     op: 'deleteEntity',
     payload: { entity_type: 'sentence', entity_id: id },
   });
-  for (const linkId of orphanedLinks) {
-    await enqueue({
-      op: 'deleteEntity',
-      payload: { entity_type: 'meaning_link', entity_id: linkId },
-    });
-  }
-  for (const mId of orphanedMeanings) {
-    await enqueue({
-      op: 'deleteEntity',
-      payload: { entity_type: 'meaning', entity_id: mId },
-    });
-  }
-
+  await enqueueOrphanDeletes(orphanedMeanings, orphanedLinks);
   await removeStorageObjects(audioPaths);
 }
 

--- a/src/lib/cleanOrphanedMeanings.ts
+++ b/src/lib/cleanOrphanedMeanings.ts
@@ -1,6 +1,4 @@
 import * as repo from '../db/repo';
-import { localDb } from '../db/localDb';
-import { enqueueSync } from '../db/repo';
 import * as local from '../db/localRepo';
 
 export interface OrphanMeaningReport {
@@ -34,18 +32,7 @@ export async function cleanOrphanedMeanings(): Promise<OrphanMeaningReport> {
     await local.deleteMeaningsByIds(orphanedMeanings);
   }
 
-  for (const linkId of orphanedLinks) {
-    await enqueueSync({
-      op: 'deleteEntity',
-      payload: { entity_type: 'meaning_link', entity_id: linkId },
-    });
-  }
-  for (const mId of orphanedMeanings) {
-    await enqueueSync({
-      op: 'deleteEntity',
-      payload: { entity_type: 'meaning', entity_id: mId },
-    });
-  }
+  await repo.enqueueOrphanDeletes(orphanedMeanings, orphanedLinks);
 
   return {
     scanned: meanings.length,
@@ -60,8 +47,5 @@ export async function runCleanOrphanedMeaningsInConsole(): Promise<OrphanMeaning
     `Orphan meanings sweep: scanned ${report.scanned}, removed ` +
       `${report.orphanedMeanings} meanings + ${report.orphanedLinks} links.`,
   );
-  // Mark-as-used so unused-var lint won't gripe at localDb being pulled
-  // in via tree-shaking hygiene from repo.ts.
-  void localDb;
   return report;
 }

--- a/src/lib/cleanOrphanedMeanings.ts
+++ b/src/lib/cleanOrphanedMeanings.ts
@@ -1,0 +1,67 @@
+import * as repo from '../db/repo';
+import { localDb } from '../db/localDb';
+import { enqueueSync } from '../db/repo';
+import * as local from '../db/localRepo';
+
+export interface OrphanMeaningReport {
+  scanned: number;
+  orphanedMeanings: number;
+  orphanedLinks: number;
+}
+
+/**
+ * One-off sweep for Meaning rows left behind by pre-fix sentence
+ * deletes. Earlier versions deleted the sentence + tokens but kept the
+ * Meaning rows forever, so old accounts accumulate disconnected rows.
+ *
+ * Builds the orphan closure from every Meaning currently in Dexie and
+ * deletes the ones that have no sentence_token reference and no
+ * surviving parent meaning_link. Enqueues the same deleteEntity ops
+ * the normal sentence-delete path emits so the server catches up.
+ *
+ * Run from DevTools after loading the app:
+ *   await window.__cleanOrphanedMeanings()
+ */
+export async function cleanOrphanedMeanings(): Promise<OrphanMeaningReport> {
+  const meanings = await repo.getAllMeanings();
+  const { meanings: orphanedMeanings, links: orphanedLinks } =
+    await local.findOrphanClosure(meanings.map((m) => m.id));
+
+  if (orphanedLinks.length > 0) {
+    await local.deleteMeaningLinksByIds(orphanedLinks);
+  }
+  if (orphanedMeanings.length > 0) {
+    await local.deleteMeaningsByIds(orphanedMeanings);
+  }
+
+  for (const linkId of orphanedLinks) {
+    await enqueueSync({
+      op: 'deleteEntity',
+      payload: { entity_type: 'meaning_link', entity_id: linkId },
+    });
+  }
+  for (const mId of orphanedMeanings) {
+    await enqueueSync({
+      op: 'deleteEntity',
+      payload: { entity_type: 'meaning', entity_id: mId },
+    });
+  }
+
+  return {
+    scanned: meanings.length,
+    orphanedMeanings: orphanedMeanings.length,
+    orphanedLinks: orphanedLinks.length,
+  };
+}
+
+export async function runCleanOrphanedMeaningsInConsole(): Promise<OrphanMeaningReport> {
+  const report = await cleanOrphanedMeanings();
+  console.log(
+    `Orphan meanings sweep: scanned ${report.scanned}, removed ` +
+      `${report.orphanedMeanings} meanings + ${report.orphanedLinks} links.`,
+  );
+  // Mark-as-used so unused-var lint won't gripe at localDb being pulled
+  // in via tree-shaking hygiene from repo.ts.
+  void localDb;
+  return report;
+}

--- a/src/lib/cleanOrphanedMeanings.ts
+++ b/src/lib/cleanOrphanedMeanings.ts
@@ -17,6 +17,11 @@ export interface OrphanMeaningReport {
  * surviving parent meaning_link. Enqueues the same deleteEntity ops
  * the normal sentence-delete path emits so the server catches up.
  *
+ * This seeds findOrphanClosure with the full Meaning table, so the
+ * closure computation touches every link + token row — O(whole
+ * corpus). Intended for manual DevTools invocation only, not any hot
+ * path.
+ *
  * Run from DevTools after loading the app:
  *   await window.__cleanOrphanedMeanings()
  */

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,15 +4,18 @@ import './index.css'
 import App from './App.tsx'
 import { runAuditInConsole, runRepairInConsole } from './lib/auditPinyin'
 import { runCleanOrphanedAudioInConsole } from './lib/cleanOrphanedAudio'
+import { runCleanOrphanedMeaningsInConsole } from './lib/cleanOrphanedMeanings'
 
 const w = window as unknown as {
   __auditPinyin?: () => Promise<unknown>
   __repairPinyin?: () => Promise<unknown>
   __cleanOrphanedAudio?: () => Promise<unknown>
+  __cleanOrphanedMeanings?: () => Promise<unknown>
 }
 w.__auditPinyin = runAuditInConsole
 w.__repairPinyin = runRepairInConsole
 w.__cleanOrphanedAudio = runCleanOrphanedAudioInConsole
+w.__cleanOrphanedMeanings = runCleanOrphanedMeaningsInConsole
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -466,13 +466,14 @@ export function GraphPage() {
       const inSeenSubgraph =
         fogEnabled && source.seen && target.seen && !touchesHovered;
       // Opacity packed as a two-char hex suffix on the stroke color.
-      //   fogged:        05  (barely visible — ambient background)
-      //   hover-dimmed:  0d  (dim, but more visible than fog)
+      //   fogged:        22  (still traceable — shows the graph's
+      //                       shape even in the unstudied portion)
+      //   hover-dimmed:  0d
       //   seen subgraph: 80  (studied content, pops without hover)
       //   touches hover: cc  (highlighted)
       //   default:       33  (baseline, fog off)
       const opacity = fogged
-        ? '05'
+        ? '22'
         : dimmedByHover
           ? '0d'
           : touchesHovered

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -78,6 +78,11 @@ function getNodeColor(type: GraphNode['type'], colors: ReturnType<typeof getThem
 // Build graph data from DB
 // ============================================================
 
+// `seen` is snapshotted here at build time. A card reviewed in the
+// same session (via the MeaningCard overlay or another tab) won't
+// un-fog its subtree until the page remounts or buildGraphData() runs
+// again. Acceptable for now — fog is a coarse orientation tool, not a
+// live indicator — but revisit if review-from-graph becomes common.
 async function buildGraphData(): Promise<GraphData> {
   const [meanings, links, sentenceTokens, sentences, cards] = await Promise.all([
     repo.getAllMeanings(),
@@ -400,8 +405,10 @@ export function GraphPage() {
       ctx.stroke();
       ctx.globalAlpha = 1;
 
-      // Label
-      if (globalScale > 0.5 || isHovered) {
+      // Fogged nodes stay as pure color blobs so only the studied
+      // subgraph carries text. `fogged` is false when `isHovered`
+      // (see its definition above), so hover still reveals the label.
+      if (!fogged && (globalScale > 0.5 || isHovered)) {
         const label = n.label;
         const isSingleChar = label.length === 1;
         // A single character can live inside the node; multi-character
@@ -413,25 +420,29 @@ export function GraphPage() {
         ctx.textBaseline = 'middle';
 
         if (labelInside) {
-          // Size the glyph to fit inside the circle. Chinese characters
-          // render at roughly their point size wide/tall, so aiming for
-          // ~1.35× the radius keeps the glyph comfortably inside the ring.
-          // Still clamp to a readable floor so tiny nodes don't become
-          // unreadable pixel blobs when zoomed out.
-          const charSize = Math.min(size * 1.35, 16 / globalScale);
-          ctx.font = `bold ${charSize}px "SF Pro", system-ui, sans-serif`;
-          ctx.fillStyle = '#ffffff';
-          ctx.globalAlpha = dimmed ? 0.4 : 1;
-          ctx.fillText(label, x, y + 1);
-          ctx.globalAlpha = 1;
-
-          if (globalScale > 1.2 || isHovered) {
-            ctx.font = `${fontSize * 0.85}px "SF Pro", system-ui, sans-serif`;
-            ctx.fillStyle = colors.textTertiary;
-            ctx.globalAlpha = dimmed ? 0.3 : 1;
-            const eng = n.english.length > 15 ? n.english.slice(0, 14) + '…' : n.english;
-            ctx.fillText(eng, x, y + size + fontSize);
+          // Inside-glyph is unreadable soup at low zoom — stay as a
+          // blob until we're close enough to actually read the char.
+          if (globalScale > 1.0 || isHovered) {
+            // Size the glyph to fit inside the circle. Chinese characters
+            // render at roughly their point size wide/tall, so aiming for
+            // ~1.35× the radius keeps the glyph comfortably inside the ring.
+            // Still clamp to a readable floor so tiny nodes don't become
+            // unreadable pixel blobs when zoomed out.
+            const charSize = Math.min(size * 1.35, 16 / globalScale);
+            ctx.font = `bold ${charSize}px "SF Pro", system-ui, sans-serif`;
+            ctx.fillStyle = '#ffffff';
+            ctx.globalAlpha = dimmed ? 0.4 : 1;
+            ctx.fillText(label, x, y + 1);
             ctx.globalAlpha = 1;
+
+            if (globalScale > 1.4 || isHovered) {
+              ctx.font = `${fontSize * 0.85}px "SF Pro", system-ui, sans-serif`;
+              ctx.fillStyle = colors.textTertiary;
+              ctx.globalAlpha = dimmed ? 0.3 : 1;
+              const eng = n.english.length > 15 ? n.english.slice(0, 14) + '…' : n.english;
+              ctx.fillText(eng, x, y + size + fontSize);
+              ctx.globalAlpha = 1;
+            }
           }
         } else {
           // Below-node label (sentences, pinyin clusters, multi-char words).
@@ -484,17 +495,19 @@ export function GraphPage() {
       const widthMul = touchesHovered ? 1.5 : inSeenSubgraph ? 1.3 : 1;
 
       // Uniform base width across link types — differentiation is
-      // carried by color (and dash pattern for pinyin).
+      // carried by color alone. Non-fogged edges render thicker so the
+      // visible graph has more presence; fogged edges stay thin to
+      // read as ambient.
+      const baseWidth = fogged ? 1.0 : 1.8;
       ctx.beginPath();
       ctx.moveTo(source.x, source.y);
       ctx.lineTo(target.x, target.y);
-      ctx.lineWidth = (1.2 * widthMul) / globalScale;
+      ctx.lineWidth = (baseWidth * widthMul) / globalScale;
 
       if (l.type === 'character-of') {
         ctx.strokeStyle = colors.character + opacity;
       } else if (l.type === 'same-pinyin') {
         ctx.strokeStyle = colors.pinyin + opacity;
-        ctx.setLineDash([4 / globalScale, 4 / globalScale]);
       } else {
         // in-sentence: use textSecondary (medium gray) instead of
         // textTertiary (light gray) so these edges aren't washed out.
@@ -502,7 +515,6 @@ export function GraphPage() {
       }
 
       ctx.stroke();
-      ctx.setLineDash([]);
     },
     [colors, hoveredNode, fogEnabled]
   );

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -21,6 +21,10 @@ interface GraphNode {
   weight: number;
   /** Color group */
   group: number;
+  /** True if the user has reviewed this node's sentence at least once,
+   *  or if it's a word/character that composes one they have. Pinyin
+   *  cluster nodes are 'seen' if any member character is seen. */
+  seen: boolean;
   x?: number;
   y?: number;
 }
@@ -75,12 +79,46 @@ function getNodeColor(type: GraphNode['type'], colors: ReturnType<typeof getThem
 // ============================================================
 
 async function buildGraphData(): Promise<GraphData> {
-  const [meanings, links, sentenceTokens, sentences] = await Promise.all([
+  const [meanings, links, sentenceTokens, sentences, cards] = await Promise.all([
     repo.getAllMeanings(),
     repo.getAllMeaningLinks(),
     repo.getAllSentenceTokens(),
     repo.getAllSentences(),
+    repo.getAllSrsCards(),
   ]);
+
+  // A sentence is "seen" once any of its SRS cards has actually been
+  // reviewed (reps > 0). Fresh sentences the user just added but never
+  // studied don't count — the whole point of fog is to surface what
+  // the user has actively engaged with vs the raw deck.
+  const seenSentenceIds = new Set<string>();
+  for (const c of cards) {
+    if (c.reps > 0) seenSentenceIds.add(c.sentenceId);
+  }
+
+  // Meanings referenced by seen sentences, then fan out via
+  // meaning_links — a seen compound word's character children count as
+  // seen too (you encountered them while studying the word).
+  const seenMeaningIds = new Set<string>();
+  for (const t of sentenceTokens) {
+    if (seenSentenceIds.has(t.sentenceId)) seenMeaningIds.add(t.meaningId);
+  }
+  const childrenOf = new Map<string, string[]>();
+  for (const l of links) {
+    const cs = childrenOf.get(l.parentMeaningId);
+    if (cs) cs.push(l.childMeaningId);
+    else childrenOf.set(l.parentMeaningId, [l.childMeaningId]);
+  }
+  const frontier = [...seenMeaningIds];
+  while (frontier.length > 0) {
+    const mId = frontier.pop()!;
+    for (const childId of childrenOf.get(mId) ?? []) {
+      if (!seenMeaningIds.has(childId)) {
+        seenMeaningIds.add(childId);
+        frontier.push(childId);
+      }
+    }
+  }
 
   const nodes: GraphNode[] = [];
   const graphLinks: GraphLink[] = [];
@@ -124,6 +162,7 @@ async function buildGraphData(): Promise<GraphData> {
       type: m.type,
       weight: Math.max(1, count),
       group: m.type === 'word' ? 0 : m.type === 'character' ? 1 : 2,
+      seen: seenMeaningIds.has(m.id),
     });
   }
 
@@ -137,6 +176,7 @@ async function buildGraphData(): Promise<GraphData> {
       type: 'sentence',
       weight: 2,
       group: 3,
+      seen: seenSentenceIds.has(s.id),
     });
   }
 
@@ -167,6 +207,10 @@ async function buildGraphData(): Promise<GraphData> {
       type: 'pinyin',
       weight: meaningIds.length,
       group: 4,
+      // Cluster node is seen if any member character is seen — so the
+      // cluster joins the visible subgraph as soon as one of its
+      // characters has been studied.
+      seen: meaningIds.some((id) => seenMeaningIds.has(id)),
     });
     for (const mId of meaningIds) {
       graphLinks.push({ source: nodeId, target: mId, type: 'same-pinyin' });
@@ -206,6 +250,16 @@ export function GraphPage() {
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
   const [colors, setColors] = useState(getThemeColors);
   const [loading, setLoading] = useState(true);
+  const [fogEnabled, setFogEnabled] = useState(() => {
+    // Persist the toggle so it survives reloads. Default on — the whole
+    // point is that a 5000-sentence deck shouldn't look uniform before
+    // you've studied most of it.
+    const stored = localStorage.getItem('mandao_graph_fog');
+    return stored === null ? true : stored === 'true';
+  });
+  useEffect(() => {
+    localStorage.setItem('mandao_graph_fog', String(fogEnabled));
+  }, [fogEnabled]);
   const containerRef = useRef<HTMLDivElement>(null);
   const fgRef = useRef<ForceGraphMethods | undefined>(undefined);
 
@@ -304,7 +358,9 @@ export function GraphPage() {
         hoveredNode !== null &&
         hoveredNode.id !== n.id &&
         neighborsById.current.get(hoveredNode.id)?.has(n.id);
-      const dimmed = hoveredNode !== null && !isHovered && !isNeighbor;
+      const dimmedByHover = hoveredNode !== null && !isHovered && !isNeighbor;
+      const fogged = fogEnabled && !n.seen && !isHovered;
+      const dimmed = dimmedByHover || fogged;
       const baseSize = n.type === 'sentence' ? 4 : n.type === 'pinyin' ? 5 : 6;
       const size = baseSize + Math.sqrt(n.weight) * 2;
       const fontSize = Math.max(10 / globalScale, 2);
@@ -320,10 +376,14 @@ export function GraphPage() {
         ctx.shadowBlur = 6;
       }
 
+      // Fogged nodes go deeper into the background than hover-dimmed
+      // ones — they should read as ambient, not paused for you to
+      // return to like a hover-dimmed neighbor would.
+      const fillAlpha = fogged ? 0.1 : dimmedByHover ? 0.18 : 1;
       ctx.beginPath();
       ctx.arc(x, y, size, 0, 2 * Math.PI);
       ctx.fillStyle = nodeColor;
-      ctx.globalAlpha = dimmed ? 0.18 : 1;
+      ctx.globalAlpha = fillAlpha;
       ctx.fill();
       ctx.globalAlpha = 1;
       ctx.shadowBlur = 0;
@@ -393,8 +453,14 @@ export function GraphPage() {
       const l = link as GraphLink;
       const touchesHovered =
         hoveredNode !== null && (source.id === hoveredNode.id || target.id === hoveredNode.id);
-      const dimmed = hoveredNode !== null && !touchesHovered;
-      const opacity = dimmed ? '0d' : touchesHovered ? 'cc' : '33';
+      const dimmedByHover = hoveredNode !== null && !touchesHovered;
+      const fogged = fogEnabled && !source.seen && !target.seen && !touchesHovered;
+      // Opacity packed as a two-char hex suffix on the stroke color.
+      //   fogged:        05  (barely visible — ambient background)
+      //   hover-dimmed:  0d  (dim, but more visible than fog)
+      //   touches hover: cc  (highlighted)
+      //   default:       33  (baseline)
+      const opacity = fogged ? '05' : dimmedByHover ? '0d' : touchesHovered ? 'cc' : '33';
 
       ctx.beginPath();
       ctx.moveTo(source.x, source.y);
@@ -437,6 +503,26 @@ export function GraphPage() {
         }}
       >
         ← Back
+      </button>
+
+      {/* Fog toggle — bottom-left corner.
+          Dims unstudied nodes so a big deck doesn't look uniform. */}
+      <button
+        type="button"
+        onClick={() => setFogEnabled((v) => !v)}
+        className="absolute bottom-3 left-3 z-40 px-3 py-1.5 rounded-full text-xs font-medium transition-colors backdrop-blur-sm"
+        style={{
+          background: 'color-mix(in srgb, var(--bg-surface) 85%, transparent)',
+          color: fogEnabled ? 'var(--accent)' : 'var(--text-tertiary)',
+          border: `1px solid ${fogEnabled ? 'color-mix(in srgb, var(--accent) 40%, transparent)' : 'var(--border)'}`,
+        }}
+        title={
+          fogEnabled
+            ? 'Fog is on — unreviewed nodes are dim'
+            : 'Fog is off — all nodes at full opacity'
+        }
+      >
+        {fogEnabled ? '◐ Fog: on' : '○ Fog: off'}
       </button>
 
       {/* Floating legend — bottom-right pill */}

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -495,7 +495,9 @@ export function GraphPage() {
         ctx.strokeStyle = colors.pinyin + opacity;
         ctx.setLineDash([4 / globalScale, 4 / globalScale]);
       } else {
-        ctx.strokeStyle = colors.textTertiary + opacity;
+        // in-sentence: use textSecondary (medium gray) instead of
+        // textTertiary (light gray) so these edges aren't washed out.
+        ctx.strokeStyle = colors.textSecondary + opacity;
       }
 
       ctx.stroke();

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -58,6 +58,25 @@ function getThemeColors() {
   };
 }
 
+/** Mix two hex colors in RGB space; t=0 → a, t=1 → b. Used for node
+ *  highlights (lighter color toward the top-left for a gradient sheen). */
+function mixColor(a: string, b: string, t: number): string {
+  const parse = (c: string) => {
+    const h = c.replace('#', '');
+    const n = h.length === 3 ? h.split('').map((ch) => ch + ch).join('') : h;
+    return [
+      parseInt(n.slice(0, 2), 16) || 0,
+      parseInt(n.slice(2, 4), 16) || 0,
+      parseInt(n.slice(4, 6), 16) || 0,
+    ];
+  };
+  const [ar, ag, ab] = parse(a);
+  const [br, bg, bb] = parse(b);
+  const mix = (x: number, y: number) => Math.round(x + (y - x) * t);
+  const hex = (n: number) => n.toString(16).padStart(2, '0');
+  return `#${hex(mix(ar, br))}${hex(mix(ag, bg))}${hex(mix(ab, bb))}`;
+}
+
 function getNodeColor(type: GraphNode['type'], colors: ReturnType<typeof getThemeColors>): string {
   switch (type) {
     case 'word': return colors.word;
@@ -201,12 +220,32 @@ export function GraphPage() {
   const [hoveredNode, setHoveredNode] = useState<GraphNode | null>(null);
   const [dimensions, setDimensions] = useState({ width: 800, height: 600 });
   const [colors, setColors] = useState(getThemeColors);
+  const [loading, setLoading] = useState(true);
   const containerRef = useRef<HTMLDivElement>(null);
   const fgRef = useRef<ForceGraphMethods | undefined>(undefined);
 
   useEffect(() => {
-    buildGraphData().then(setGraphData);
+    buildGraphData().then((data) => {
+      setGraphData(data);
+      setLoading(false);
+    });
   }, []);
+
+  /** Precomputed neighbor map for connection-highlight on hover.
+   *  Recomputed on data change (rare), O(links) memory — fine. */
+  const neighborsById = useRef(new Map<string, Set<string>>());
+  useEffect(() => {
+    const map = new Map<string, Set<string>>();
+    for (const link of graphData.links) {
+      const s = typeof link.source === 'string' ? link.source : (link.source as any).id;
+      const t = typeof link.target === 'string' ? link.target : (link.target as any).id;
+      if (!map.has(s)) map.set(s, new Set());
+      if (!map.has(t)) map.set(t, new Set());
+      map.get(s)!.add(t);
+      map.get(t)!.add(s);
+    }
+    neighborsById.current = map;
+  }, [graphData]);
 
   // Re-read colors when theme changes
   useEffect(() => {
@@ -229,13 +268,17 @@ export function GraphPage() {
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
-  // Zoom to fit on load
+  // Zoom to fit once the force simulation has had time to lay nodes out.
+  // A single zoom after ~1s gets the camera close; a second at ~2.5s
+  // re-centers after the sim cools so the final view isn't off-screen.
   useEffect(() => {
-    if (graphData.nodes.length > 0 && fgRef.current) {
-      setTimeout(() => {
-        fgRef.current?.zoomToFit(400, 60);
-      }, 500);
-    }
+    if (graphData.nodes.length === 0 || !fgRef.current) return;
+    const first = setTimeout(() => fgRef.current?.zoomToFit(400, 80), 1000);
+    const settle = setTimeout(() => fgRef.current?.zoomToFit(600, 80), 2500);
+    return () => {
+      clearTimeout(first);
+      clearTimeout(settle);
+    };
   }, [graphData]);
 
   const handleNodeClick = useCallback(
@@ -260,32 +303,47 @@ export function GraphPage() {
       const x = n.x || 0;
       const y = n.y || 0;
       const isHovered = hoveredNode?.id === n.id;
+      const isNeighbor =
+        hoveredNode !== null &&
+        hoveredNode.id !== n.id &&
+        neighborsById.current.get(hoveredNode.id)?.has(n.id);
+      const dimmed = hoveredNode !== null && !isHovered && !isNeighbor;
       const baseSize = n.type === 'sentence' ? 4 : n.type === 'pinyin' ? 5 : 6;
       const size = baseSize + Math.sqrt(n.weight) * 2;
       const fontSize = Math.max(10 / globalScale, 2);
       const nodeColor = getNodeColor(n.type, colors);
 
-      // Glow effect on hover
-      if (isHovered) {
-        ctx.shadowColor = nodeColor;
-        ctx.shadowBlur = 20;
-      }
+      // Soft ambient glow on every node so the canvas feels alive even
+      // without hover. Stronger glow + highlight on hovered/neighbor.
+      ctx.shadowColor = nodeColor;
+      ctx.shadowBlur = isHovered ? 24 : isNeighbor ? 12 : 6;
 
-      // Node circle
+      // Radial gradient fill for a bit of dimensionality.
+      const grad = ctx.createRadialGradient(
+        x - size * 0.3,
+        y - size * 0.3,
+        size * 0.2,
+        x,
+        y,
+        size,
+      );
+      grad.addColorStop(0, mixColor(nodeColor, '#ffffff', 0.35));
+      grad.addColorStop(1, nodeColor);
+
       ctx.beginPath();
       ctx.arc(x, y, size, 0, 2 * Math.PI);
-      ctx.fillStyle = nodeColor;
-      ctx.globalAlpha = isHovered ? 1 : 0.85;
+      ctx.fillStyle = grad;
+      ctx.globalAlpha = dimmed ? 0.18 : isHovered ? 1 : 0.92;
       ctx.fill();
       ctx.globalAlpha = 1;
       ctx.shadowBlur = 0;
 
-      // Ring
-      if (n.type !== 'sentence') {
-        ctx.strokeStyle = colors.bgSurface;
-        ctx.lineWidth = 1.5 / globalScale;
-        ctx.stroke();
-      }
+      // Crisp ring separates overlapping nodes.
+      ctx.strokeStyle = colors.bgBase;
+      ctx.lineWidth = 1.2 / globalScale;
+      ctx.globalAlpha = dimmed ? 0.25 : 1;
+      ctx.stroke();
+      ctx.globalAlpha = 1;
 
       // Label
       if (globalScale > 0.5 || isHovered) {
@@ -297,23 +355,27 @@ export function GraphPage() {
         if (n.type === 'sentence' || n.type === 'pinyin') {
           // Label below node
           ctx.fillStyle = colors.textTertiary;
+          ctx.globalAlpha = dimmed ? 0.3 : 1;
           ctx.fillText(label, x, y + size + fontSize * 0.8);
+          ctx.globalAlpha = 1;
         } else {
-          // Character/word label inside/on node
+          // Character/word label inside the node
           const charSize = Math.max(14 / globalScale, 3);
           ctx.font = `bold ${charSize}px "SF Pro", system-ui, sans-serif`;
           ctx.fillStyle = '#ffffff';
+          ctx.globalAlpha = dimmed ? 0.4 : 1;
           ctx.fillText(label, x, y + 1);
+          ctx.globalAlpha = 1;
 
-          // English below
+          // English below, only when zoomed in or hovered
           if (globalScale > 1.2 || isHovered) {
             ctx.font = `${fontSize * 0.85}px "SF Pro", system-ui, sans-serif`;
             ctx.fillStyle = colors.textTertiary;
+            ctx.globalAlpha = dimmed ? 0.3 : 1;
             const eng =
-              n.english.length > 15
-                ? n.english.slice(0, 14) + '…'
-                : n.english;
+              n.english.length > 15 ? n.english.slice(0, 14) + '…' : n.english;
             ctx.fillText(eng, x, y + size + fontSize);
+            ctx.globalAlpha = 1;
           }
         }
       }
@@ -325,71 +387,88 @@ export function GraphPage() {
     (link: any, ctx: CanvasRenderingContext2D, globalScale: number) => {
       const source = link.source as any;
       const target = link.target as any;
-      if (!source.x || !target.x) return;
+      if (source.x == null || target.x == null) return;
+
+      const l = link as GraphLink;
+      const touchesHovered =
+        hoveredNode !== null && (source.id === hoveredNode.id || target.id === hoveredNode.id);
+      const dimmed = hoveredNode !== null && !touchesHovered;
+      const opacity = dimmed ? '0d' : touchesHovered ? 'cc' : '33';
 
       ctx.beginPath();
       ctx.moveTo(source.x, source.y);
       ctx.lineTo(target.x, target.y);
 
-      const l = link as GraphLink;
       if (l.type === 'character-of') {
-        ctx.strokeStyle = colors.character + '33';
-        ctx.lineWidth = 1.5 / globalScale;
+        ctx.strokeStyle = colors.character + opacity;
+        ctx.lineWidth = (touchesHovered ? 2 : 1.5) / globalScale;
       } else if (l.type === 'same-pinyin') {
-        ctx.strokeStyle = colors.pinyin + '26';
-        ctx.lineWidth = 1 / globalScale;
+        ctx.strokeStyle = colors.pinyin + opacity;
+        ctx.lineWidth = (touchesHovered ? 1.6 : 1) / globalScale;
         ctx.setLineDash([4 / globalScale, 4 / globalScale]);
       } else {
-        ctx.strokeStyle = colors.textTertiary + '26';
-        ctx.lineWidth = 0.8 / globalScale;
+        ctx.strokeStyle = colors.textTertiary + opacity;
+        ctx.lineWidth = (touchesHovered ? 1.6 : 0.8) / globalScale;
       }
 
       ctx.stroke();
       ctx.setLineDash([]);
     },
-    [colors]
+    [colors, hoveredNode]
   );
 
   return (
-    <div className="h-screen flex flex-col" style={{ background: 'var(--bg-base)' }}>
-      {/* Header */}
-      <div
-        className="px-3 sm:px-4 pt-9 pb-0.5 backdrop-blur"
-        style={{ background: 'var(--bg-surface)', borderBottom: `1px solid var(--border)` }}
+    <div
+      className="fixed inset-0 overflow-hidden"
+      style={{
+        background: `radial-gradient(ellipse at 50% 45%, var(--bg-surface) 0%, var(--bg-base) 70%, var(--bg-inset) 100%)`,
+      }}
+    >
+      {/* Floating Back button — top-left, sits over the canvas.
+          top-12 clears App.tsx's global top bar (h-10 + some padding). */}
+      <button
+        onClick={() => navigate('/')}
+        className="absolute top-12 left-3 z-40 px-3 py-1.5 rounded-full text-xs font-medium transition-colors backdrop-blur-sm"
+        style={{
+          background: 'color-mix(in srgb, var(--bg-surface) 85%, transparent)',
+          color: 'var(--text-secondary)',
+          border: '1px solid var(--border)',
+        }}
       >
-        <div className="flex items-center justify-between mb-0.5">
-          <button
-            onClick={() => navigate('/')}
-            className="px-3 py-1 rounded-lg text-sm transition-colors"
-            style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
-          >
-            &larr; Back
-          </button>
-          <h1 className="text-lg font-medium" style={{ color: 'var(--text-primary)' }}>
-            Graph
-          </h1>
-          <div className="w-16" />
-        </div>
-        <div className="flex items-center justify-center gap-3 sm:gap-4 text-xs" style={{ color: 'var(--text-tertiary)' }}>
-          {([
-            { label: 'Words', color: colors.word },
-            { label: 'Characters', color: colors.character },
-            { label: 'Sentences', color: colors.sentence },
-            { label: 'Pinyin', color: colors.pinyin },
-          ]).map((item) => (
-            <span key={item.label} className="flex items-center gap-1.5">
-              <span className="inline-block w-2 h-2 rounded-full" style={{ background: item.color }} />
-              {item.label}
-            </span>
-          ))}
-        </div>
+        ← Back
+      </button>
+
+      {/* Floating legend — bottom-right pill */}
+      <div
+        className="absolute bottom-3 right-3 z-40 px-3 py-2 rounded-xl text-xs backdrop-blur-sm flex flex-col gap-1.5"
+        style={{
+          background: 'color-mix(in srgb, var(--bg-surface) 85%, transparent)',
+          border: '1px solid var(--border)',
+          color: 'var(--text-tertiary)',
+        }}
+      >
+        {([
+          { label: 'Words', color: colors.word },
+          { label: 'Characters', color: colors.character },
+          { label: 'Sentences', color: colors.sentence },
+          { label: 'Pinyin', color: colors.pinyin },
+        ]).map((item) => (
+          <span key={item.label} className="flex items-center gap-2">
+            <span className="inline-block w-2 h-2 rounded-full" style={{ background: item.color, boxShadow: `0 0 6px ${item.color}` }} />
+            {item.label}
+          </span>
+        ))}
       </div>
 
-      {/* Hover tooltip */}
+      {/* Hover tooltip — same top-12 offset to clear the global chrome. */}
       {hoveredNode && (
         <div
-          className="absolute top-16 left-1/2 -translate-x-1/2 z-40 px-4 py-2.5 rounded-xl shadow-2xl pointer-events-none backdrop-blur-sm"
-          style={{ background: 'var(--bg-surface)', border: `1px solid var(--border)`, color: 'var(--text-primary)' }}
+          className="absolute top-12 left-1/2 -translate-x-1/2 z-40 px-4 py-2.5 rounded-xl shadow-2xl pointer-events-none backdrop-blur-sm"
+          style={{
+            background: 'color-mix(in srgb, var(--bg-surface) 92%, transparent)',
+            border: `1px solid var(--border)`,
+            color: 'var(--text-primary)',
+          }}
         >
           <div className="flex items-center gap-3">
             <span className="text-2xl">{hoveredNode.label}</span>
@@ -401,9 +480,22 @@ export function GraphPage() {
         </div>
       )}
 
-      {/* Graph */}
-      <div ref={containerRef} className="flex-1 relative">
-        {graphData.nodes.length === 0 ? (
+      {/* Graph canvas — fills the viewport */}
+      <div ref={containerRef} className="absolute inset-0">
+        {loading ? (
+          <div className="flex items-center justify-center h-full" style={{ color: 'var(--text-tertiary)' }}>
+            <div className="flex flex-col items-center gap-3">
+              <div
+                className="w-10 h-10 rounded-full animate-spin"
+                style={{
+                  border: '2px solid var(--border)',
+                  borderTopColor: 'var(--accent)',
+                }}
+              />
+              <div className="text-xs">Building graph…</div>
+            </div>
+          </div>
+        ) : graphData.nodes.length === 0 ? (
           <div className="flex items-center justify-center h-full" style={{ color: 'var(--text-tertiary)' }}>
             No data yet. Add some sentences first.
           </div>

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -191,22 +191,7 @@ async function buildGraphData(): Promise<GraphData> {
     });
   }
 
-  // Hide orphaned meaning nodes — rows that no longer appear in any
-  // sentence token, character link, or pinyin cluster after deletes.
-  // Meanings are reusable by design so deleting a sentence doesn't
-  // delete the Meaning row, but once nothing references a meaning it
-  // just clutters the graph with disconnected dots.
-  const connectedIds = new Set<string>();
-  for (const link of graphLinks) {
-    connectedIds.add(link.source);
-    connectedIds.add(link.target);
-  }
-  const visibleNodes = nodes.filter((n) => {
-    if (n.type === 'sentence' || n.type === 'pinyin') return true;
-    return connectedIds.has(n.id);
-  });
-
-  return { nodes: visibleNodes, links: graphLinks };
+  return { nodes, links: graphLinks };
 }
 
 // ============================================================

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -268,17 +268,14 @@ export function GraphPage() {
     return () => window.removeEventListener('resize', updateSize);
   }, []);
 
-  // Zoom to fit once the force simulation has had time to lay nodes out.
-  // A single zoom after ~1s gets the camera close; a second at ~2.5s
-  // re-centers after the sim cools so the final view isn't off-screen.
+  // zoomToFit is driven by onEngineStop (set on ForceGraph2D below), so
+  // the camera lands once the simulation has actually settled rather
+  // than on a wall-clock timer that might fire before nodes finish
+  // moving. We arm a once-per-load flag so the user's manual pan/zoom
+  // isn't yanked back every time the sim retriggers.
+  const autoFittedRef = useRef(false);
   useEffect(() => {
-    if (graphData.nodes.length === 0 || !fgRef.current) return;
-    const first = setTimeout(() => fgRef.current?.zoomToFit(400, 80), 1000);
-    const settle = setTimeout(() => fgRef.current?.zoomToFit(600, 80), 2500);
-    return () => {
-      clearTimeout(first);
-      clearTimeout(settle);
-    };
+    autoFittedRef.current = false;
   }, [graphData]);
 
   const handleNodeClick = useCallback(
@@ -527,6 +524,11 @@ export function GraphPage() {
             d3VelocityDecay={0.3}
             warmupTicks={50}
             cooldownTicks={200}
+            onEngineStop={() => {
+              if (autoFittedRef.current) return;
+              autoFittedRef.current = true;
+              fgRef.current?.zoomToFit(500, 80);
+            }}
           />
         )}
       </div>

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -482,20 +482,20 @@ export function GraphPage() {
               : '33';
       const widthMul = touchesHovered ? 1.5 : inSeenSubgraph ? 1.3 : 1;
 
+      // Uniform base width across link types — differentiation is
+      // carried by color (and dash pattern for pinyin).
       ctx.beginPath();
       ctx.moveTo(source.x, source.y);
       ctx.lineTo(target.x, target.y);
+      ctx.lineWidth = (1.2 * widthMul) / globalScale;
 
       if (l.type === 'character-of') {
         ctx.strokeStyle = colors.character + opacity;
-        ctx.lineWidth = (1.5 * widthMul) / globalScale;
       } else if (l.type === 'same-pinyin') {
         ctx.strokeStyle = colors.pinyin + opacity;
-        ctx.lineWidth = (1 * widthMul) / globalScale;
         ctx.setLineDash([4 / globalScale, 4 / globalScale]);
       } else {
         ctx.strokeStyle = colors.textTertiary + opacity;
-        ctx.lineWidth = (0.9 * widthMul) / globalScale;
       }
 
       ctx.stroke();

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -191,7 +191,22 @@ async function buildGraphData(): Promise<GraphData> {
     });
   }
 
-  return { nodes, links: graphLinks };
+  // Hide orphaned meaning nodes — rows that no longer appear in any
+  // sentence token, character link, or pinyin cluster after deletes.
+  // Meanings are reusable by design so deleting a sentence doesn't
+  // delete the Meaning row, but once nothing references a meaning it
+  // just clutters the graph with disconnected dots.
+  const connectedIds = new Set<string>();
+  for (const link of graphLinks) {
+    connectedIds.add(link.source);
+    connectedIds.add(link.target);
+  }
+  const visibleNodes = nodes.filter((n) => {
+    if (n.type === 'sentence' || n.type === 'pinyin') return true;
+    return connectedIds.has(n.id);
+  });
+
+  return { nodes: visibleNodes, links: graphLinks };
 }
 
 // ============================================================

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -348,35 +348,46 @@ export function GraphPage() {
       // Label
       if (globalScale > 0.5 || isHovered) {
         const label = n.label;
-        ctx.font = `${n.type === 'pinyin' ? 'italic ' : ''}${fontSize}px "SF Pro", system-ui, sans-serif`;
+        const isSingleChar = label.length === 1;
+        // A single character can live inside the node; multi-character
+        // words don't fit, so render them below like sentences/pinyin.
+        const labelInside =
+          (n.type === 'character' || n.type === 'component' || n.type === 'word') && isSingleChar;
+
         ctx.textAlign = 'center';
         ctx.textBaseline = 'middle';
 
-        if (n.type === 'sentence' || n.type === 'pinyin') {
-          // Label below node
-          ctx.fillStyle = colors.textTertiary;
-          ctx.globalAlpha = dimmed ? 0.3 : 1;
-          ctx.fillText(label, x, y + size + fontSize * 0.8);
-          ctx.globalAlpha = 1;
-        } else {
-          // Character/word label inside the node
-          const charSize = Math.max(14 / globalScale, 3);
+        if (labelInside) {
+          // Size the glyph to fit inside the circle. Chinese characters
+          // render at roughly their point size wide/tall, so aiming for
+          // ~1.35× the radius keeps the glyph comfortably inside the ring.
+          // Still clamp to a readable floor so tiny nodes don't become
+          // unreadable pixel blobs when zoomed out.
+          const charSize = Math.min(size * 1.35, 16 / globalScale);
           ctx.font = `bold ${charSize}px "SF Pro", system-ui, sans-serif`;
           ctx.fillStyle = '#ffffff';
           ctx.globalAlpha = dimmed ? 0.4 : 1;
           ctx.fillText(label, x, y + 1);
           ctx.globalAlpha = 1;
 
-          // English below, only when zoomed in or hovered
           if (globalScale > 1.2 || isHovered) {
             ctx.font = `${fontSize * 0.85}px "SF Pro", system-ui, sans-serif`;
             ctx.fillStyle = colors.textTertiary;
             ctx.globalAlpha = dimmed ? 0.3 : 1;
-            const eng =
-              n.english.length > 15 ? n.english.slice(0, 14) + '…' : n.english;
+            const eng = n.english.length > 15 ? n.english.slice(0, 14) + '…' : n.english;
             ctx.fillText(eng, x, y + size + fontSize);
             ctx.globalAlpha = 1;
           }
+        } else {
+          // Below-node label (sentences, pinyin clusters, multi-char words).
+          ctx.font = `${n.type === 'pinyin' ? 'italic ' : 'bold '}${fontSize}px "SF Pro", system-ui, sans-serif`;
+          ctx.fillStyle =
+            n.type === 'pinyin' || n.type === 'sentence'
+              ? colors.textTertiary
+              : colors.textPrimary;
+          ctx.globalAlpha = dimmed ? 0.3 : 1;
+          ctx.fillText(label, x, y + size + fontSize * 0.8);
+          ctx.globalAlpha = 1;
         }
       }
     },

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -59,25 +59,6 @@ function getThemeColors() {
   };
 }
 
-/** Mix two hex colors in RGB space; t=0 → a, t=1 → b. Used for node
- *  highlights (lighter color toward the top-left for a gradient sheen). */
-function mixColor(a: string, b: string, t: number): string {
-  const parse = (c: string) => {
-    const h = c.replace('#', '');
-    const n = h.length === 3 ? h.split('').map((ch) => ch + ch).join('') : h;
-    return [
-      parseInt(n.slice(0, 2), 16) || 0,
-      parseInt(n.slice(2, 4), 16) || 0,
-      parseInt(n.slice(4, 6), 16) || 0,
-    ];
-  };
-  const [ar, ag, ab] = parse(a);
-  const [br, bg, bb] = parse(b);
-  const mix = (x: number, y: number) => Math.round(x + (y - x) * t);
-  const hex = (n: number) => n.toString(16).padStart(2, '0');
-  return `#${hex(mix(ar, br))}${hex(mix(ag, bg))}${hex(mix(ab, bb))}`;
-}
-
 function getNodeColor(type: GraphNode['type'], colors: ReturnType<typeof getThemeColors>): string {
   switch (type) {
     case 'word': return colors.word;
@@ -251,6 +232,21 @@ export function GraphPage() {
     neighborsById.current = map;
   }, [graphData]);
 
+  // Tune the d3-force simulation once data has loaded.
+  //   - Weaker repulsion keeps disconnected islands from drifting to
+  //     opposite corners with no counterforce to pull them back.
+  //   - Link distance + strength control how tightly connected nodes
+  //     cluster. The defaults are too loose for our small graphs.
+  useEffect(() => {
+    const fg = fgRef.current;
+    if (!fg || graphData.nodes.length === 0) return;
+    const charge = fg.d3Force('charge') as { strength: (s: number) => unknown } | undefined;
+    charge?.strength(-40);
+    const link = fg.d3Force('link') as { distance: (d: number) => unknown } | undefined;
+    link?.distance(32);
+    fg.d3ReheatSimulation();
+  }, [graphData]);
+
   // Re-read colors when theme changes
   useEffect(() => {
     const observer = new MutationObserver(() => setColors(getThemeColors()));
@@ -317,27 +313,20 @@ export function GraphPage() {
       const fontSize = Math.max(10 / globalScale, 2);
       const nodeColor = getNodeColor(n.type, colors);
 
-      // Soft ambient glow on every node so the canvas feels alive even
-      // without hover. Stronger glow + highlight on hovered/neighbor.
-      ctx.shadowColor = nodeColor;
-      ctx.shadowBlur = isHovered ? 24 : isNeighbor ? 12 : 6;
-
-      // Radial gradient fill for a bit of dimensionality.
-      const grad = ctx.createRadialGradient(
-        x - size * 0.3,
-        y - size * 0.3,
-        size * 0.2,
-        x,
-        y,
-        size,
-      );
-      grad.addColorStop(0, mixColor(nodeColor, '#ffffff', 0.35));
-      grad.addColorStop(1, nodeColor);
+      // Matte flat fill — no gradient, no ambient glow. Glow only when
+      // the user is inspecting this node (hover) or its direct neighbor.
+      if (isHovered) {
+        ctx.shadowColor = nodeColor;
+        ctx.shadowBlur = 16;
+      } else if (isNeighbor) {
+        ctx.shadowColor = nodeColor;
+        ctx.shadowBlur = 6;
+      }
 
       ctx.beginPath();
       ctx.arc(x, y, size, 0, 2 * Math.PI);
-      ctx.fillStyle = grad;
-      ctx.globalAlpha = dimmed ? 0.18 : isHovered ? 1 : 0.92;
+      ctx.fillStyle = nodeColor;
+      ctx.globalAlpha = dimmed ? 0.18 : 1;
       ctx.fill();
       ctx.globalAlpha = 1;
       ctx.shadowBlur = 0;

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -460,12 +460,27 @@ export function GraphPage() {
         hoveredNode !== null && (source.id === hoveredNode.id || target.id === hoveredNode.id);
       const dimmedByHover = hoveredNode !== null && !touchesHovered;
       const fogged = fogEnabled && !source.seen && !target.seen && !touchesHovered;
+      // When fog is on, links entirely inside the studied subgraph
+      // pop as the active layer — more saturated + thicker than the
+      // baseline, short of the hover-highlight tier.
+      const inSeenSubgraph =
+        fogEnabled && source.seen && target.seen && !touchesHovered;
       // Opacity packed as a two-char hex suffix on the stroke color.
       //   fogged:        05  (barely visible — ambient background)
       //   hover-dimmed:  0d  (dim, but more visible than fog)
+      //   seen subgraph: 80  (studied content, pops without hover)
       //   touches hover: cc  (highlighted)
-      //   default:       33  (baseline)
-      const opacity = fogged ? '05' : dimmedByHover ? '0d' : touchesHovered ? 'cc' : '33';
+      //   default:       33  (baseline, fog off)
+      const opacity = fogged
+        ? '05'
+        : dimmedByHover
+          ? '0d'
+          : touchesHovered
+            ? 'cc'
+            : inSeenSubgraph
+              ? '80'
+              : '33';
+      const widthMul = touchesHovered ? 1.5 : inSeenSubgraph ? 1.3 : 1;
 
       ctx.beginPath();
       ctx.moveTo(source.x, source.y);
@@ -473,14 +488,14 @@ export function GraphPage() {
 
       if (l.type === 'character-of') {
         ctx.strokeStyle = colors.character + opacity;
-        ctx.lineWidth = (touchesHovered ? 2 : 1.5) / globalScale;
+        ctx.lineWidth = (1.5 * widthMul) / globalScale;
       } else if (l.type === 'same-pinyin') {
         ctx.strokeStyle = colors.pinyin + opacity;
-        ctx.lineWidth = (touchesHovered ? 1.6 : 1) / globalScale;
+        ctx.lineWidth = (1 * widthMul) / globalScale;
         ctx.setLineDash([4 / globalScale, 4 / globalScale]);
       } else {
         ctx.strokeStyle = colors.textTertiary + opacity;
-        ctx.lineWidth = (touchesHovered ? 1.6 : 0.8) / globalScale;
+        ctx.lineWidth = (0.9 * widthMul) / globalScale;
       }
 
       ctx.stroke();

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -5,6 +5,7 @@ import * as repo from '../db/repo';
 import { useNavigationStore } from '../stores/navigationStore';
 import { MeaningCard } from '../components/MeaningCard';
 import { getMeaningPinyin } from '../lib/meaningPinyin';
+import { numericStringToDiacritic } from '../services/toneSandhi';
 
 // ============================================================
 // Graph data types
@@ -170,14 +171,17 @@ async function buildGraphData(): Promise<GraphData> {
     }
   }
 
-  // Only show pinyin nodes that connect 2+ characters
+  // Only show pinyin nodes that connect 2+ characters.
+  // Node ID keeps the numeric form so navigation lookups still work;
+  // the label renders the diacritic form for readability (zài not zai4).
   for (const [pinyin, meaningIds] of pinyinGroups) {
     if (meaningIds.length < 2) continue;
     const nodeId = `p-${pinyin}`;
+    const diacritic = numericStringToDiacritic(pinyin);
     nodes.push({
       id: nodeId,
-      label: pinyin,
-      pinyin: pinyin,
+      label: diacritic,
+      pinyin: diacritic,
       english: `${meaningIds.length} characters`,
       type: 'pinyin',
       weight: meaningIds.length,

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -259,6 +259,11 @@ export function GraphPage() {
   });
   useEffect(() => {
     localStorage.setItem('mandao_graph_fog', String(fogEnabled));
+    // Once the force simulation has cooled, the canvas stops painting
+    // on its own. Toggling fog changes the paint callbacks' behavior
+    // but won't show until we ask the graph to redraw.
+    const fg = fgRef.current as unknown as { refresh?: () => void } | undefined;
+    fg?.refresh?.();
   }, [fogEnabled]);
   const containerRef = useRef<HTMLDivElement>(null);
   const fgRef = useRef<ForceGraphMethods | undefined>(undefined);
@@ -441,7 +446,7 @@ export function GraphPage() {
         }
       }
     },
-    [hoveredNode, colors]
+    [hoveredNode, colors, fogEnabled]
   );
 
   const paintLink = useCallback(
@@ -481,7 +486,7 @@ export function GraphPage() {
       ctx.stroke();
       ctx.setLineDash([]);
     },
-    [colors, hoveredNode]
+    [colors, hoveredNode, fogEnabled]
   );
 
   return (


### PR DESCRIPTION
## Summary

Three related changes bundled because they all shipped together while iterating on the graph page:

### 1. Graph visual redesign (`src/pages/GraphPage.tsx`)
- Drop the chunky header bar; canvas fills the viewport edge-to-edge.
- Floating Back button (top-left), fog toggle (bottom-left), legend pill (bottom-right), hover tooltip (top-center).
- Matte flat-fill nodes (no gradients); ambient glow only on hover and direct neighbors.
- Character glyphs render inside single-char nodes only at zoom > 1.0 so low-zoom reads as pure color blobs.
- Pinyin cluster nodes label with diacritics (`zài`) instead of the numeric form (`zai4`), via `numericStringToDiacritic`.
- `onEngineStop` drives `zoomToFit` once per load, replacing the brittle wall-clock `setTimeout(500)`.
- Tuned d3-force: `charge.strength(-40)`, `link.distance(32)` — disconnected islands stay in the same frame instead of drifting apart.

### 2. Fog feature
- Persisted `localStorage('mandao_graph_fog')` toggle. Default on.
- Studied subgraph = sentences with any reviewed SRS card (`reps > 0`), their meanings, and the transitive closure down through `meaning_links` (a studied compound word's character children count as studied).
- Fogged nodes render as pure color blobs regardless of zoom. Fogged edges still render, just at low opacity, so the graph's shape stays visible.
- Hover overrides fog on the hovered node + direct neighbors.
- Note: `seen` is snapshotted at `buildGraphData` time — in-session reviews don't un-fog until the page remounts.

### 3. Orphan-meaning cascade on sentence delete (`src/db/*`, `src/lib/cleanOrphanedMeanings.ts`)
- When a sentence is deleted, `findOrphanClosure` computes the transitive closure of meanings that are no longer referenced by any surviving `sentence_token` or non-orphan `meaning_link`, and removes them + their incident links.
- Split into a pure `computeOrphanClosure` helper + a thin Dexie wrapper, so the algorithm is unit-testable without IndexedDB. 9 tests cover: empty input, bare orphan, still-referenced, non-orphan parent, transitive closure, diamond, living-parent protection, token-on-child preservation, and order-insensitivity.
- `enqueueOrphanDeletes` uses a single `localDb.outbox.bulkAdd` transaction instead of `Promise.all` over per-op enqueues — matters for the backfill sweep on old accounts.
- New DevTools helper `window.__cleanOrphanedMeanings()` for historical cleanup of Meaning rows left behind by pre-fix deletes. O(whole corpus); run once per user.

## Test plan
- [ ] Open `/graph` → nodes fill the viewport, studied subgraph is bright, unstudied is fogged.
- [ ] Toggle fog button → dim/undim animates on the already-rendered graph (no rebuild).
- [ ] Zoom in past ~1.0 → single-char glyphs appear on studied nodes only.
- [ ] Hover a fogged node → label reveals; neighbors light up; links thicken.
- [ ] Delete a sentence from Browse → reload `/graph` → any meanings only referenced by that sentence are gone (plus their compound-word children).
- [ ] Run `await window.__cleanOrphanedMeanings()` in DevTools on an old account → console reports a non-zero sweep.
- [ ] `npm run test` → 93/93 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)