### PR TITLE
Offline audio cache with cap + LRU eviction (closes #117)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,12 @@ function App() {
   // Separate effect so it is not torn down by the hydration effect's cleanup.
   useEffect(() => {
     if (!userId || !ready) return;
+    // Best-effort: ask the browser to mark our IndexedDB as persistent so
+    // cached audio survives storage pressure / iOS ITP eviction. Granted
+    // heuristically; we don't gate anything on the result.
+    if (navigator.storage?.persist) {
+      navigator.storage.persist().catch(() => {});
+    }
     startSyncListeners();
     runSync();
     return () => stopSyncListeners();

--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -21,6 +21,7 @@ import {
   playBlob,
   type StreamingWithAudioHandle,
 } from '../services/audioRecording';
+import { getRecordingCapMs } from '../stores/audioCacheSettingsStore';
 import { compareCharacters, matchPercent, type CharResult } from '../lib/charCompare';
 import { lookupPinyinForChars } from '../lib/pinyinLookup';
 import { getMeaningPinyin } from '../lib/meaningPinyin';
@@ -250,6 +251,10 @@ export function ReviewCard() {
     try {
       const handle = await startStreamingRecognitionWithAudio({
         onInterim: (text) => setRecognizedText(text),
+        maxDurationMs: getRecordingCapMs(),
+        onDurationCap: () => {
+          if (streamHandleRef.current) handleSpeakMic();
+        },
       });
       streamHandleRef.current = handle;
       setIsListening(true);

--- a/src/components/SentenceAudioControls.tsx
+++ b/src/components/SentenceAudioControls.tsx
@@ -121,20 +121,16 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
     if (downloadingId === rec.id) return;
     stopAll();
 
-    let blob = rec.blob;
-    if (!blob) {
-      setDownloadingId(rec.id);
-      try {
-        const fetched = await repo.fetchAudioBlob(rec.id);
-        if (!fetched) {
-          setError('Could not load this recording.');
-          return;
-        }
-        blob = fetched;
-        await refresh();
-      } finally {
-        setDownloadingId((cur) => (cur === rec.id ? null : cur));
+    setDownloadingId(rec.id);
+    let blob: Blob | null = null;
+    try {
+      blob = await repo.fetchAudioBlob(rec.id);
+      if (!blob) {
+        setError('Could not load this recording.');
+        return;
       }
+    } finally {
+      setDownloadingId((cur) => (cur === rec.id ? null : cur));
     }
 
     setPlayingId(rec.id);
@@ -179,13 +175,12 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
       id: uuid(),
       sentenceId,
       name,
-      blob: pendingClip.blob,
       mimeType: pendingClip.mimeType,
       durationMs: pendingClip.durationMs,
       source: 'manual',
       createdAt: Date.now(),
     };
-    await repo.insertAudioRecording(rec);
+    await repo.insertAudioRecording(rec, pendingClip.blob);
     setPendingClip(null);
     setPendingName('');
     await refresh();

--- a/src/components/SentenceAudioControls.tsx
+++ b/src/components/SentenceAudioControls.tsx
@@ -10,6 +10,7 @@ import {
   type RecordingHandle,
   type RecordingResult,
 } from '../services/audioRecording';
+import { getRecordingCapMs } from '../stores/audioCacheSettingsStore';
 
 const SpeakerIcon = (
   <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
@@ -145,7 +146,18 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
     setError('');
     if (pendingClip || recordHandle) return;
     try {
-      const handle = await startRecording();
+      const handle = await startRecording({
+        maxDurationMs: getRecordingCapMs(),
+        onDurationCap: () => {
+          // Auto-finalize when the cap fires; mirrors what handleStopRecord does.
+          handle.stop().then((result) => {
+            recordHandleRef.current = null;
+            setRecordHandle(null);
+            setPendingClip(result);
+            setPendingName(defaultName());
+          }).catch(() => {});
+        },
+      });
       recordHandleRef.current = handle;
       setRecordHandle(handle);
     } catch (e: any) {

--- a/src/db/hydrate.ts
+++ b/src/db/hydrate.ts
@@ -56,6 +56,7 @@ export async function hydrateLocalDb(): Promise<void> {
       localDb.decks,
       localDb.reviewLogs,
       localDb.audioRecordings,
+      localDb.audioBlobs,
       localDb.syncMeta,
     ],
     async () => {
@@ -68,6 +69,9 @@ export async function hydrateLocalDb(): Promise<void> {
         localDb.decks.clear(),
         localDb.reviewLogs.clear(),
         localDb.audioRecordings.clear(),
+        // Cached bytes belong to the previous account; drop them so a
+        // re-hydration doesn't carry stale audio (and stale cap usage).
+        localDb.audioBlobs.clear(),
       ]);
 
       await Promise.all([

--- a/src/db/localDb.ts
+++ b/src/db/localDb.ts
@@ -123,6 +123,8 @@ class MandaoDb extends Dexie {
               fetchedAt: ts,
               lastPlayedAt: ts,
             });
+            // bulkPut replaces the whole row, so dropping `blob` from the
+            // copy is enough to remove it from IDB.
             const next = { ...rec } as AudioRecording & { blob?: Blob };
             delete next.blob;
             cleared.push(next);

--- a/src/db/localDb.ts
+++ b/src/db/localDb.ts
@@ -8,6 +8,7 @@ import type {
   Deck,
   ReviewLog,
   AudioRecording,
+  AudioBlob,
   MeaningFlag,
 } from './schema';
 
@@ -54,6 +55,7 @@ class MandaoDb extends Dexie {
   outbox!: Table<SyncOp, number>;
   syncMeta!: Table<SyncMeta, string>;
   audioRecordings!: Table<AudioRecording, string>;
+  audioBlobs!: Table<AudioBlob, string>;
   meaningFlags!: Table<MeaningFlag, string>;
 
   constructor() {
@@ -97,6 +99,40 @@ class MandaoDb extends Dexie {
     this.version(4).stores({
       meaningFlags: 'id, meaningId, headword, flagKind, resolvedAt, createdAt',
     });
+
+    // v5: split audio bytes off audio_recordings into a client-only
+    // audioBlobs table. Keeps cache state (lastPlayedAt, sizeBytes) out of
+    // the synced row and lets us enumerate / sum / evict cleanly.
+    this.version(5)
+      .stores({
+        audioBlobs: 'recordingId, lastPlayedAt, fetchedAt',
+      })
+      .upgrade(async (tx) => {
+        const recs = await tx.table('audioRecordings').toArray();
+        const moves: AudioBlob[] = [];
+        const cleared: AudioRecording[] = [];
+        for (const rec of recs) {
+          const oldBlob = (rec as AudioRecording & { blob?: Blob }).blob;
+          if (oldBlob instanceof Blob) {
+            const ts = rec.createdAt ?? Date.now();
+            moves.push({
+              recordingId: rec.id,
+              blob: oldBlob,
+              mimeType: rec.mimeType ?? oldBlob.type ?? 'audio/webm',
+              sizeBytes: oldBlob.size,
+              fetchedAt: ts,
+              lastPlayedAt: ts,
+            });
+            const next = { ...rec } as AudioRecording & { blob?: Blob };
+            delete next.blob;
+            cleared.push(next);
+          }
+        }
+        if (moves.length > 0) {
+          await tx.table('audioBlobs').bulkPut(moves);
+          await tx.table('audioRecordings').bulkPut(cleared);
+        }
+      });
   }
 }
 
@@ -129,6 +165,7 @@ export async function clearLocalDb(): Promise<void> {
       localDb.outbox,
       localDb.syncMeta,
       localDb.audioRecordings,
+      localDb.audioBlobs,
       localDb.meaningFlags,
     ],
     async () => {
@@ -143,6 +180,7 @@ export async function clearLocalDb(): Promise<void> {
         localDb.outbox.clear(),
         localDb.syncMeta.clear(),
         localDb.audioRecordings.clear(),
+        localDb.audioBlobs.clear(),
         localDb.meaningFlags.clear(),
       ]);
     }

--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -545,6 +545,25 @@ export async function getAllAudioRecordings(): Promise<AudioRecording[]> {
 // Audio blobs (client-only cache for AudioRecording bytes)
 // ============================================================
 
+/** Build an AudioBlob entry with the standard mime fallback chain and
+ *  matched fetchedAt/lastPlayedAt timestamps. Centralized so the four
+ *  insert sites (insert, fetch, prefetch, migration) can't drift. */
+export function makeAudioBlobEntry(
+  recordingId: string,
+  blob: Blob,
+  mimeType?: string,
+  ts: number = Date.now(),
+): AudioBlob {
+  return {
+    recordingId,
+    blob,
+    mimeType: mimeType ?? blob.type ?? 'audio/webm',
+    sizeBytes: blob.size,
+    fetchedAt: ts,
+    lastPlayedAt: ts,
+  };
+}
+
 export async function getAudioBlob(recordingId: string): Promise<AudioBlob | undefined> {
   return localDb.audioBlobs.get(recordingId);
 }

--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -13,6 +13,7 @@ import type {
   Deck,
   ReviewLog,
   AudioRecording,
+  AudioBlob,
   MeaningFlag,
 } from './schema';
 
@@ -268,6 +269,7 @@ export async function deleteSentenceById(id: string): Promise<void> {
       localDb.srsCards,
       localDb.reviewLogs,
       localDb.audioRecordings,
+      localDb.audioBlobs,
     ],
     async () => {
       const cards = await localDb.srsCards.where('sentenceId').equals(id).toArray();
@@ -277,6 +279,11 @@ export async function deleteSentenceById(id: string): Promise<void> {
       }
       await localDb.srsCards.where('sentenceId').equals(id).delete();
       await localDb.sentenceTokens.where('sentenceId').equals(id).delete();
+      const recs = await localDb.audioRecordings.where('sentenceId').equals(id).toArray();
+      const recIds = recs.map((r) => r.id);
+      if (recIds.length > 0) {
+        await localDb.audioBlobs.bulkDelete(recIds);
+      }
       await localDb.audioRecordings.where('sentenceId').equals(id).delete();
       await localDb.sentences.delete(id);
     }
@@ -475,6 +482,7 @@ export async function deleteAllUserData(): Promise<void> {
       localDb.decks,
       localDb.reviewLogs,
       localDb.audioRecordings,
+      localDb.audioBlobs,
     ],
     async () => {
       await Promise.all([
@@ -486,6 +494,7 @@ export async function deleteAllUserData(): Promise<void> {
         localDb.meaningLinks.clear(),
         localDb.decks.clear(),
         localDb.audioRecordings.clear(),
+        localDb.audioBlobs.clear(),
       ]);
     }
   );
@@ -526,6 +535,68 @@ export async function deleteAudioRecording(id: string): Promise<void> {
 export async function getAllAudioStoragePaths(): Promise<string[]> {
   const rows = await localDb.audioRecordings.toArray();
   return rows.map((r) => r.storagePath).filter((p): p is string => !!p);
+}
+
+export async function getAllAudioRecordings(): Promise<AudioRecording[]> {
+  return localDb.audioRecordings.toArray();
+}
+
+// ============================================================
+// Audio blobs (client-only cache for AudioRecording bytes)
+// ============================================================
+
+export async function getAudioBlob(recordingId: string): Promise<AudioBlob | undefined> {
+  return localDb.audioBlobs.get(recordingId);
+}
+
+export async function putAudioBlob(entry: AudioBlob): Promise<void> {
+  await localDb.audioBlobs.put(entry);
+}
+
+export async function touchAudioBlob(recordingId: string): Promise<void> {
+  await localDb.audioBlobs.update(recordingId, { lastPlayedAt: Date.now() });
+}
+
+export async function deleteAudioBlob(recordingId: string): Promise<void> {
+  await localDb.audioBlobs.delete(recordingId);
+}
+
+export async function deleteAudioBlobs(recordingIds: string[]): Promise<void> {
+  if (recordingIds.length === 0) return;
+  await localDb.audioBlobs.bulkDelete(recordingIds);
+}
+
+export async function clearAudioBlobs(): Promise<void> {
+  await localDb.audioBlobs.clear();
+}
+
+export async function getAudioCacheUsage(): Promise<{ totalBytes: number; count: number }> {
+  let totalBytes = 0;
+  let count = 0;
+  await localDb.audioBlobs.each((b) => {
+    totalBytes += b.sizeBytes;
+    count += 1;
+  });
+  return { totalBytes, count };
+}
+
+/** Recording IDs already cached locally — used by prefetch to skip work. */
+export async function getCachedAudioRecordingIds(): Promise<Set<string>> {
+  const ids = (await localDb.audioBlobs.toCollection().primaryKeys()) as string[];
+  return new Set(ids);
+}
+
+/** LRU eviction candidates: ascending lastPlayedAt. Each yields a sizeBytes
+ *  to stop iterating once enough has been freed. */
+export async function getAudioBlobsSortedByLru(): Promise<
+  Array<{ recordingId: string; sizeBytes: number; lastPlayedAt: number }>
+> {
+  const rows = await localDb.audioBlobs.orderBy('lastPlayedAt').toArray();
+  return rows.map((r) => ({
+    recordingId: r.recordingId,
+    sizeBytes: r.sizeBytes,
+    lastPlayedAt: r.lastPlayedAt,
+  }));
 }
 
 // ============================================================

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -10,7 +10,7 @@
 import * as local from './localRepo';
 import { localDb, type SyncOp } from './localDb';
 import { supabase } from '../lib/supabase';
-import { removeStorageObjects } from '../lib/audioStorage';
+import { AUDIO_BUCKET, removeStorageObjects } from '../lib/audioStorage';
 import { getDeviceId, scheduleSyncSoon } from './syncEngine';
 import {
   getUserId as getRemoteUserId,
@@ -424,15 +424,9 @@ export async function insertAudioRecording(
 ) {
   await local.insertAudioRecording(rec);
   if (blob) {
-    const ts = rec.createdAt ?? Date.now();
-    await local.putAudioBlob({
-      recordingId: rec.id,
-      blob,
-      mimeType: rec.mimeType ?? blob.type ?? 'audio/webm',
-      sizeBytes: blob.size,
-      fetchedAt: ts,
-      lastPlayedAt: ts,
-    });
+    await local.putAudioBlob(
+      local.makeAudioBlobEntry(rec.id, blob, rec.mimeType, rec.createdAt),
+    );
   }
   await enqueue({ op: 'upsertAudioRecording', payload: audioUpsertPayload(rec) });
 }
@@ -492,22 +486,14 @@ export async function fetchAudioBlob(id: string): Promise<Blob | null> {
   // longer expiry just widens the leak window (browser history, HAR
   // exports, extensions) for what is otherwise per-user private content.
   const { data, error } = await supabase.storage
-    .from('audio-recordings')
+    .from(AUDIO_BUCKET)
     .createSignedUrl(rec.storagePath, 60);
   if (error || !data?.signedUrl) return null;
   try {
     const resp = await fetch(data.signedUrl);
     if (!resp.ok) return null;
     const blob = await resp.blob();
-    const now = Date.now();
-    await local.putAudioBlob({
-      recordingId: id,
-      blob,
-      mimeType: rec.mimeType ?? blob.type ?? 'audio/webm',
-      sizeBytes: blob.size,
-      fetchedAt: now,
-      lastPlayedAt: now,
-    });
+    await local.putAudioBlob(local.makeAudioBlobEntry(id, blob, rec.mimeType));
     return blob;
   } catch {
     return null;

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -418,8 +418,22 @@ function audioUpsertPayload(rec: import('./schema').AudioRecording) {
   };
 }
 
-export async function insertAudioRecording(rec: import('./schema').AudioRecording) {
+export async function insertAudioRecording(
+  rec: import('./schema').AudioRecording,
+  blob?: Blob,
+) {
   await local.insertAudioRecording(rec);
+  if (blob) {
+    const ts = rec.createdAt ?? Date.now();
+    await local.putAudioBlob({
+      recordingId: rec.id,
+      blob,
+      mimeType: rec.mimeType ?? blob.type ?? 'audio/webm',
+      sizeBytes: blob.size,
+      fetchedAt: ts,
+      lastPlayedAt: ts,
+    });
+  }
   await enqueue({ op: 'upsertAudioRecording', payload: audioUpsertPayload(rec) });
 }
 
@@ -446,6 +460,7 @@ export async function deleteAudioRecording(id: string) {
   }
 
   await local.deleteAudioRecording(id);
+  await local.deleteAudioBlob(id);
   await enqueue({
     op: 'deleteEntity',
     payload: { entity_type: 'audio_recording', entity_id: id },
@@ -457,11 +472,20 @@ export async function deleteAudioRecording(id: string) {
 }
 
 /**
- * Lazy-fetch a recording's Blob via a short-lived signed URL and cache it
- * back into Dexie so future plays skip the network. Returns null on failure
- * (no row, no storagePath, or network error).
+ * Get a recording's Blob, hitting the audioBlobs cache first and only
+ * falling through to a Storage signed-URL fetch on miss. Updates
+ * lastPlayedAt on hit so LRU eviction can prefer cold entries. Returns
+ * null on failure (no row, no storagePath, or network error).
  */
 export async function fetchAudioBlob(id: string): Promise<Blob | null> {
+  const cached = await local.getAudioBlob(id);
+  if (cached) {
+    // Don't await — touching the LRU timestamp is a best-effort hint;
+    // a slow IDB write shouldn't delay playback.
+    void local.touchAudioBlob(id);
+    return cached.blob;
+  }
+
   const rec = await local.getAudioRecording(id);
   if (!rec?.storagePath) return null;
   // Short TTL: the URL is consumed immediately by the fetch below, so a
@@ -475,7 +499,15 @@ export async function fetchAudioBlob(id: string): Promise<Blob | null> {
     const resp = await fetch(data.signedUrl);
     if (!resp.ok) return null;
     const blob = await resp.blob();
-    await local.updateAudioRecording(id, { blob });
+    const now = Date.now();
+    await local.putAudioBlob({
+      recordingId: id,
+      blob,
+      mimeType: rec.mimeType ?? blob.type ?? 'audio/webm',
+      sizeBytes: blob.size,
+      fetchedAt: now,
+      lastPlayedAt: now,
+    });
     return blob;
   } catch {
     return null;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -76,19 +76,18 @@ export interface Sentence {
  * User- or voice-captured audio clip attached to a sentence.
  * Multiple recordings per sentence are supported; each has a user-given name.
  *
- * The blob lives in IndexedDB; the server row points at a Storage object.
- * Invariant: at least one of `blob` or `storagePath` is always set.
- *   - Locally-created (pre-upload): blob set, storagePath undefined.
- *   - Pulled from server (pre-play): storagePath set, blob undefined.
- *   - After first play on a pulled row: both set (blob cached).
+ * The metadata row syncs with the server; the actual bytes live in the
+ * `audioBlobs` table (client-only cache, see AudioBlob below).
+ * Invariant: at least one of an audioBlobs entry or `storagePath` exists.
+ *   - Locally-created (pre-upload): audioBlobs entry, no storagePath.
+ *   - Pulled from server (pre-play): storagePath, no audioBlobs entry.
+ *   - After first play / prefetch on a pulled row: both.
  */
 export interface AudioRecording {
   id: string;
   sentenceId: string;
   /** User-facing label, e.g. "My voice", "Native speaker". */
   name: string;
-  /** Raw audio data. Undefined until lazily fetched on rows pulled from the server. */
-  blob?: Blob;
   /** Path inside the `audio-recordings` Storage bucket, e.g. `{user_id}/{id}.webm`. */
   storagePath?: string;
   mimeType: string;
@@ -98,6 +97,23 @@ export interface AudioRecording {
   createdAt: number;
   updatedAt?: number;
   usn?: number;
+}
+
+/**
+ * Client-only cache entry for an AudioRecording's bytes. Keyed by recordingId.
+ * Never synced to the server. Used both for offline playback (cached on
+ * fetch / prefetch) and as the staging area for locally-recorded clips that
+ * haven't been uploaded yet.
+ */
+export interface AudioBlob {
+  recordingId: string;
+  blob: Blob;
+  mimeType: string;
+  sizeBytes: number;
+  /** When the blob first landed in the cache (createdAt for local clips, fetch time for pulled ones). */
+  fetchedAt: number;
+  /** Updated on each play; tiebreaks LRU eviction. Initialized to fetchedAt. */
+  lastPlayedAt: number;
 }
 
 /** Junction table: links sentences to meanings, preserving token order. */

--- a/src/db/syncEngine.ts
+++ b/src/db/syncEngine.ts
@@ -410,6 +410,7 @@ async function pullOnePage(): Promise<boolean> {
       localDb.decks,
       localDb.reviewLogs,
       localDb.audioRecordings,
+      localDb.audioBlobs,
       localDb.syncMeta,
     ],
     async () => {

--- a/src/db/syncEngine.ts
+++ b/src/db/syncEngine.ts
@@ -14,6 +14,7 @@ import { supabase } from '../lib/supabase';
 import { AUDIO_BUCKET, removeStorageObjects } from '../lib/audioStorage';
 import { localDb, type SyncOp } from './localDb';
 import type { FailedOp } from '../stores/syncStore';
+import { runAudioPrefetch } from '../services/audioPrefetch';
 
 /** Sync error that preserves the Postgres code so the outbox can tell
  *  permanent (CHECK violation, missing column) apart from transient
@@ -285,18 +286,20 @@ async function pushUpsertAudioRecording(op: SyncOp): Promise<void> {
 
   const rec = await localDb.audioRecordings.get(payload.id);
   if (!rec) return;
+  const cachedBlob = await localDb.audioBlobs.get(payload.id);
   // Nothing local to upload and nothing on the server either.
-  if (!rec.blob && !rec.storagePath) return;
+  if (!cachedBlob && !rec.storagePath) return;
 
   const userId = getCachedUserIdOrThrow();
   const isFirstUpload = !rec.storagePath;
   let storagePath = rec.storagePath;
   if (isFirstUpload) {
+    if (!cachedBlob) return; // shouldn't happen: !storagePath && !cachedBlob already returned
     const ext = extensionFromMime(payload.mimeType);
     storagePath = `${userId}/${payload.id}.${ext}`;
     const { error: uploadErr } = await supabase.storage
       .from(AUDIO_BUCKET)
-      .upload(storagePath, rec.blob!, {
+      .upload(storagePath, cachedBlob.blob, {
         contentType: payload.mimeType,
         upsert: true,
       });
@@ -461,13 +464,10 @@ async function pullOnePage(): Promise<boolean> {
       }
       trackRows(changes.review_logs);
 
-      // Audio recordings: server wins for metadata, but preserve any local
-      // blob (the wire row has none, and we don't want to drop cached bytes).
+      // Audio recordings: server wins for metadata. Cached bytes live in
+      // the audioBlobs table (keyed by id), so we can write rows directly.
       if (audioRows.length > 0) {
-        const mapped = audioRows.map(audioRecordingFromRow);
-        const existing = await localDb.audioRecordings.bulkGet(mapped.map((r) => r.id));
-        const merged = mapped.map((r, i) => ({ ...r, blob: existing[i]?.blob }));
-        await localDb.audioRecordings.bulkPut(merged);
+        await localDb.audioRecordings.bulkPut(audioRows.map(audioRecordingFromRow));
       }
       trackRows(audioRows);
 
@@ -482,6 +482,11 @@ async function pullOnePage(): Promise<boolean> {
             }
             await localDb.srsCards.where('sentenceId').equals(entity_id).delete();
             await localDb.sentenceTokens.where('sentenceId').equals(entity_id).delete();
+            const recs = await localDb.audioRecordings.where('sentenceId').equals(entity_id).toArray();
+            const recIds = recs.map((r) => r.id);
+            if (recIds.length > 0) {
+              await localDb.audioBlobs.bulkDelete(recIds);
+            }
             await localDb.audioRecordings.where('sentenceId').equals(entity_id).delete();
             await localDb.sentences.delete(entity_id);
             break;
@@ -516,8 +521,9 @@ async function pullOnePage(): Promise<boolean> {
             await localDb.sentenceTokens.delete(entity_id);
             break;
           case 'audio_recording':
-            // Row delete drops the local blob too; the server already wiped
-            // the Storage object via the delete trigger.
+            // The server already wiped the Storage object via the delete
+            // trigger; drop our metadata row and any cached bytes too.
+            await localDb.audioBlobs.delete(entity_id);
             await localDb.audioRecordings.delete(entity_id);
             break;
         }
@@ -576,6 +582,9 @@ export async function runSync(): Promise<void> {
     }
     // When stuck > 0, setFailed already set status='error' + errorMessage,
     // so a separate setError(...) call would duplicate the signal.
+
+    // Fire-and-forget prefetch of newly-available audio.
+    void runAudioPrefetch();
   } catch (e: any) {
     console.error('Sync failed:', e);
     store.setError(e.message || 'Sync failed');

--- a/src/pages/AddSentencePage.tsx
+++ b/src/pages/AddSentencePage.tsx
@@ -558,13 +558,12 @@ export function AddSentencePage() {
           id: uuid(),
           sentenceId: createdSentenceId,
           name: pendingVoiceClipName.trim() || 'My voice',
-          blob: pendingVoiceClip.blob,
           mimeType: pendingVoiceClip.mimeType,
           durationMs: pendingVoiceClip.durationMs,
           source: 'voice-input',
           createdAt: Date.now(),
         };
-        try { await repo.insertAudioRecording(rec); } catch {}
+        try { await repo.insertAudioRecording(rec, pendingVoiceClip.blob); } catch {}
       }
 
       // Tutorial mode: seed remaining sentences in the background, then advance

--- a/src/pages/AddSentencePage.tsx
+++ b/src/pages/AddSentencePage.tsx
@@ -31,6 +31,7 @@ import {
   type RecordingResult,
   type StreamingWithAudioHandle,
 } from '../services/audioRecording';
+import { getRecordingCapMs } from '../stores/audioCacheSettingsStore';
 import { pinyin as toPinyin } from 'pinyin-pro';
 import { computeTokenCoverage } from '../services/tokenCoverage';
 import { v4 as uuid } from 'uuid';
@@ -221,6 +222,11 @@ export function AddSentencePage() {
     try {
       const handle = await startStreamingRecognitionWithAudio({
         onInterim: (text) => setVoiceInterim(text),
+        maxDurationMs: getRecordingCapMs(),
+        onDurationCap: () => {
+          // Auto-finalize when the cap fires by re-running the toggle path.
+          if (streamingHandleRef.current) handleVoiceInput();
+        },
       });
       streamingHandleRef.current = handle;
       setListening(true);

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -21,6 +21,8 @@ import type { Deck } from '../db/schema';
 import { localDb } from '../db/localDb';
 import {
   useAudioCacheSettingsStore,
+  RECORDING_CAP_SEC_MIN,
+  RECORDING_CAP_SEC_MAX,
   type AudioCacheCapMB,
 } from '../stores/audioCacheSettingsStore';
 import { getAudioCacheUsage } from '../db/localRepo';
@@ -1364,11 +1366,15 @@ function formatMB(bytes: number): string {
 function AudioCacheCard() {
   const capMB = useAudioCacheSettingsStore((s) => s.capMB);
   const setCapMB = useAudioCacheSettingsStore((s) => s.setCapMB);
+  const recordingCapSec = useAudioCacheSettingsStore((s) => s.recordingCapSec);
+  const setRecordingCapSec = useAudioCacheSettingsStore((s) => s.setRecordingCapSec);
   const [usage, setUsage] = useState<{ totalBytes: number; count: number }>({
     totalBytes: 0,
     count: 0,
   });
   const [clearing, setClearing] = useState(false);
+  const [downloading, setDownloading] = useState(false);
+  const [confirmAction, setConfirmAction] = useState<'download' | 'clear' | null>(null);
 
   const refresh = useCallback(async () => {
     const u = await getAudioCacheUsage();
@@ -1385,6 +1391,7 @@ function AudioCacheCard() {
 
   const handleClear = async () => {
     setClearing(true);
+    setConfirmAction(null);
     try {
       await clearAudioCache();
       await refresh();
@@ -1395,8 +1402,14 @@ function AudioCacheCard() {
   };
 
   const handlePrefetchNow = async () => {
-    await runAudioPrefetch();
-    await refresh();
+    setDownloading(true);
+    setConfirmAction(null);
+    try {
+      await runAudioPrefetch();
+      await refresh();
+    } finally {
+      setDownloading(false);
+    }
   };
 
   return (
@@ -1452,24 +1465,86 @@ function AudioCacheCard() {
           </p>
         </div>
 
-        {/* Actions */}
-        <div className="flex gap-2 flex-wrap">
-          <button
-            onClick={handlePrefetchNow}
-            className="px-3 py-1.5 rounded-lg text-sm transition-colors"
-            style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
-          >
-            Download missing now
-          </button>
-          <button
-            onClick={handleClear}
-            disabled={clearing || usage.count === 0}
-            className="px-3 py-1.5 rounded-lg text-sm transition-colors disabled:opacity-50"
-            style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
-          >
-            {clearing ? 'Clearing…' : 'Clear cache'}
-          </button>
-        </div>
+        {/* Recording duration cap */}
+        <NumberInput
+          label="Max recording length (seconds)"
+          value={recordingCapSec}
+          onChange={(v) => setRecordingCapSec(v)}
+          min={RECORDING_CAP_SEC_MIN}
+          max={RECORDING_CAP_SEC_MAX}
+          step={1}
+          hint={`Recordings auto-stop at this length. Allowed range: ${RECORDING_CAP_SEC_MIN}–${RECORDING_CAP_SEC_MAX}s.`}
+        />
+
+        {/* Actions with inline confirmation */}
+        {confirmAction === null && (
+          <div className="flex gap-2 flex-wrap">
+            <button
+              onClick={() => setConfirmAction('download')}
+              disabled={downloading}
+              className="px-3 py-1.5 rounded-lg text-sm transition-colors disabled:opacity-50"
+              style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+            >
+              {downloading ? 'Downloading…' : 'Download missing now'}
+            </button>
+            <button
+              onClick={() => setConfirmAction('clear')}
+              disabled={clearing || usage.count === 0}
+              className="px-3 py-1.5 rounded-lg text-sm transition-colors disabled:opacity-50"
+              style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+            >
+              {clearing ? 'Clearing…' : 'Clear cache'}
+            </button>
+          </div>
+        )}
+
+        {confirmAction === 'download' && (
+          <div className="space-y-2">
+            <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+              This will fetch missing recordings up to your storage limit and may use significant network bandwidth.
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={handlePrefetchNow}
+                className="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
+                style={{ background: 'var(--accent)', color: 'var(--text-inverted)' }}
+              >
+                Download
+              </button>
+              <button
+                onClick={() => setConfirmAction(null)}
+                className="px-3 py-1.5 rounded-lg text-sm transition-colors"
+                style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {confirmAction === 'clear' && (
+          <div className="space-y-2">
+            <p className="text-sm font-medium" style={{ color: 'var(--danger, #e53e3e)' }}>
+              Clear all cached audio? Recordings will be re-downloaded from the server next time you play them.
+            </p>
+            <div className="flex gap-2">
+              <button
+                onClick={handleClear}
+                className="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
+                style={{ background: 'var(--danger, #e53e3e)', color: '#fff' }}
+              >
+                Clear cache
+              </button>
+              <button
+                onClick={() => setConfirmAction(null)}
+                className="px-3 py-1.5 rounded-lg text-sm transition-colors"
+                style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
       </div>
     </SectionCard>
   );

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -26,7 +26,12 @@ import {
   type AudioCacheCapMB,
 } from '../stores/audioCacheSettingsStore';
 import { getAudioCacheUsage } from '../db/localRepo';
-import { runAudioPrefetch, clearAudioCache } from '../services/audioPrefetch';
+import {
+  runAudioPrefetch,
+  clearAudioCache,
+  shrinkAudioCacheTo,
+  previewShrink,
+} from '../services/audioPrefetch';
 
 type Section = 'account' | 'srs' | 'display' | 'ai' | 'anki' | 'data';
 
@@ -1375,6 +1380,11 @@ function AudioCacheCard() {
   const [clearing, setClearing] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [confirmAction, setConfirmAction] = useState<'download' | 'clear' | null>(null);
+  const [pendingCap, setPendingCap] = useState<{
+    cap: AudioCacheCapMB;
+    evictCount: number;
+    freedBytes: number;
+  } | null>(null);
 
   const refresh = useCallback(async () => {
     const u = await getAudioCacheUsage();
@@ -1412,10 +1422,36 @@ function AudioCacheCard() {
     }
   };
 
+  const handleCapClick = async (next: AudioCacheCapMB) => {
+    if (next === capMB) return;
+    const nextBytes = next * 1024 * 1024;
+    // Raising the cap (or no current pressure) — apply immediately.
+    if (nextBytes >= usage.totalBytes) {
+      setCapMB(next);
+      return;
+    }
+    // Lowering below current usage — preview evictions and confirm.
+    const preview = await previewShrink(nextBytes);
+    if (preview.evictCount === 0) {
+      setCapMB(next);
+      return;
+    }
+    setPendingCap({ cap: next, evictCount: preview.evictCount, freedBytes: preview.freedBytes });
+  };
+
+  const handleConfirmShrink = async () => {
+    if (!pendingCap) return;
+    const targetBytes = pendingCap.cap * 1024 * 1024;
+    setCapMB(pendingCap.cap);
+    setPendingCap(null);
+    await shrinkAudioCacheTo(targetBytes);
+    await refresh();
+  };
+
   return (
     <SectionCard
       title="Offline Audio"
-      description="Recordings cached on this device for instant, offline playback."
+      description="Recordings stored on this device play instantly and work offline. A larger cache covers more cards without a network round-trip; a smaller one saves device space but requires re-downloading recordings when you play them."
     >
       <div className="space-y-4">
         {/* Usage bar */}
@@ -1449,7 +1485,7 @@ function AudioCacheCard() {
             {CAP_OPTIONS.map((opt) => (
               <button
                 key={opt}
-                onClick={() => setCapMB(opt)}
+                onClick={() => handleCapClick(opt)}
                 className="flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors"
                 style={{
                   background: capMB === opt ? 'var(--accent)' : 'var(--bg-inset)',
@@ -1463,6 +1499,33 @@ function AudioCacheCard() {
           <p className="mt-1.5 text-xs" style={{ color: 'var(--text-tertiary)' }}>
             When the cap is reached, the least-recently-played recordings are evicted first.
           </p>
+          {pendingCap && (
+            <div className="mt-3 p-3 rounded-lg space-y-2" style={{ background: 'var(--bg-inset)' }}>
+              <p className="text-sm font-medium" style={{ color: 'var(--danger, #e53e3e)' }}>
+                Lower to {pendingCap.cap} MB?
+              </p>
+              <p className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+                {pendingCap.evictCount.toLocaleString()}{' '}
+                {pendingCap.evictCount === 1 ? 'recording' : 'recordings'} ({formatMB(pendingCap.freedBytes)}) will be evicted from this device. They can be re-downloaded later.
+              </p>
+              <div className="flex gap-2">
+                <button
+                  onClick={handleConfirmShrink}
+                  className="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors"
+                  style={{ background: 'var(--danger, #e53e3e)', color: '#fff' }}
+                >
+                  Lower limit
+                </button>
+                <button
+                  onClick={() => setPendingCap(null)}
+                  className="px-3 py-1.5 rounded-lg text-sm transition-colors"
+                  style={{ background: 'var(--bg-surface)', color: 'var(--text-secondary)' }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          )}
         </div>
 
         {/* Recording duration cap */}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -19,6 +19,12 @@ import { importFromApkg, downloadApkgExport, analyzeApkg, type ApkgFieldInfo } f
 import * as repo from '../db/repo';
 import type { Deck } from '../db/schema';
 import { localDb } from '../db/localDb';
+import {
+  useAudioCacheSettingsStore,
+  type AudioCacheCapMB,
+} from '../stores/audioCacheSettingsStore';
+import { getAudioCacheUsage } from '../db/localRepo';
+import { runAudioPrefetch, clearAudioCache } from '../services/audioPrefetch';
 
 type Section = 'account' | 'srs' | 'display' | 'ai' | 'anki' | 'data';
 
@@ -1300,6 +1306,9 @@ function DataSection() {
         </div>
       </SectionCard>
 
+      {/* Offline audio cache */}
+      <AudioCacheCard />
+
       {/* Delete account / data */}
       <SectionCard title="Danger Zone" description="Permanently delete all your data. This cannot be undone.">
         {!confirmDelete ? (
@@ -1336,5 +1345,132 @@ function DataSection() {
         )}
       </SectionCard>
     </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────
+// Offline audio cache
+// ────────────────────────────────────────────────────────────
+
+const CAP_OPTIONS: AudioCacheCapMB[] = [100, 200, 500];
+
+function formatMB(bytes: number): string {
+  const mb = bytes / (1024 * 1024);
+  if (mb >= 100) return `${Math.round(mb)} MB`;
+  if (mb >= 10) return `${mb.toFixed(1)} MB`;
+  return `${mb.toFixed(2)} MB`;
+}
+
+function AudioCacheCard() {
+  const capMB = useAudioCacheSettingsStore((s) => s.capMB);
+  const setCapMB = useAudioCacheSettingsStore((s) => s.setCapMB);
+  const [usage, setUsage] = useState<{ totalBytes: number; count: number }>({
+    totalBytes: 0,
+    count: 0,
+  });
+  const [clearing, setClearing] = useState(false);
+
+  const refresh = useCallback(async () => {
+    const u = await getAudioCacheUsage();
+    setUsage(u);
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  const capBytes = capMB * 1024 * 1024;
+  const pct = Math.min(100, (usage.totalBytes / capBytes) * 100);
+  const overCap = usage.totalBytes > capBytes;
+
+  const handleClear = async () => {
+    setClearing(true);
+    try {
+      await clearAudioCache();
+      await refresh();
+    } catch (e) {
+      console.error('Clear cache failed:', e);
+    }
+    setClearing(false);
+  };
+
+  const handlePrefetchNow = async () => {
+    await runAudioPrefetch();
+    await refresh();
+  };
+
+  return (
+    <SectionCard
+      title="Offline Audio"
+      description="Recordings cached on this device for instant, offline playback."
+    >
+      <div className="space-y-4">
+        {/* Usage bar */}
+        <div>
+          <div className="flex justify-between text-sm mb-1.5">
+            <span style={{ color: 'var(--text-secondary)' }}>
+              {formatMB(usage.totalBytes)} of {capMB} MB
+            </span>
+            <span style={{ color: 'var(--text-tertiary)' }}>
+              {usage.count.toLocaleString()} {usage.count === 1 ? 'recording' : 'recordings'}
+            </span>
+          </div>
+          <div
+            className="w-full h-2 rounded-full overflow-hidden"
+            style={{ background: 'var(--bg-inset)' }}
+          >
+            <div
+              className="h-full transition-all"
+              style={{
+                width: `${pct}%`,
+                background: overCap ? 'var(--danger, #e53e3e)' : 'var(--accent)',
+              }}
+            />
+          </div>
+        </div>
+
+        {/* Cap selector */}
+        <div>
+          <label className="block text-sm font-medium mb-2">Storage limit</label>
+          <div className="flex gap-2">
+            {CAP_OPTIONS.map((opt) => (
+              <button
+                key={opt}
+                onClick={() => setCapMB(opt)}
+                className="flex-1 py-2 px-3 rounded-lg text-sm font-medium transition-colors"
+                style={{
+                  background: capMB === opt ? 'var(--accent)' : 'var(--bg-inset)',
+                  color: capMB === opt ? 'var(--text-inverted)' : 'var(--text-secondary)',
+                }}
+              >
+                {opt} MB
+              </button>
+            ))}
+          </div>
+          <p className="mt-1.5 text-xs" style={{ color: 'var(--text-tertiary)' }}>
+            When the cap is reached, the least-recently-played recordings are evicted first.
+          </p>
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 flex-wrap">
+          <button
+            onClick={handlePrefetchNow}
+            className="px-3 py-1.5 rounded-lg text-sm transition-colors"
+            style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+          >
+            Download missing now
+          </button>
+          <button
+            onClick={handleClear}
+            disabled={clearing || usage.count === 0}
+            className="px-3 py-1.5 rounded-lg text-sm transition-colors disabled:opacity-50"
+            style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+          >
+            {clearing ? 'Clearing…' : 'Clear cache'}
+          </button>
+        </div>
+      </div>
+    </SectionCard>
   );
 }

--- a/src/services/ankiApkg.ts
+++ b/src/services/ankiApkg.ts
@@ -459,17 +459,17 @@ export async function importFromApkg(
               continue;
             }
             const mimeType = mimeFromAudioFilename(resolved.filename);
-            const blob = await resolved.entry.async('blob');
+            const rawBlob = await resolved.entry.async('blob');
+            const blob = rawBlob.type ? rawBlob : new Blob([rawBlob], { type: mimeType });
             const rec: AudioRecording = {
               id: uuid(),
               sentenceId,
               name: audioLabel,
-              blob: blob.type ? blob : new Blob([blob], { type: mimeType }),
               mimeType,
               source: 'manual',
               createdAt: Date.now(),
             };
-            await repo.insertAudioRecording(rec);
+            await repo.insertAudioRecording(rec, blob);
           }
         }
 

--- a/src/services/audioPrefetch.ts
+++ b/src/services/audioPrefetch.ts
@@ -205,3 +205,31 @@ function isQuotaExceeded(e: unknown): boolean {
 export async function clearAudioCache(): Promise<void> {
   await local.clearAudioBlobs();
 }
+
+/** Shrink cache to a target byte size by LRU-evicting the oldest-played
+ *  entries. No-op if already under the target. Returns the bytes freed. */
+export async function shrinkAudioCacheTo(targetBytes: number): Promise<number> {
+  const before = (await local.getAudioCacheUsage()).totalBytes;
+  const after = await evictToTarget(targetBytes);
+  return Math.max(0, before - after);
+}
+
+/** Preview what shrinking would evict, without actually doing it. Used by
+ *  the Settings UI to show "X recordings (Y MB) will be deleted" in the
+ *  confirmation prompt. */
+export async function previewShrink(targetBytes: number): Promise<{ evictCount: number; freedBytes: number }> {
+  const usage = await local.getAudioCacheUsage();
+  if (usage.totalBytes <= targetBytes) return { evictCount: 0, freedBytes: 0 };
+
+  const sorted = await local.getAudioBlobsSortedByLru();
+  let evictCount = 0;
+  let freedBytes = 0;
+  let running = usage.totalBytes;
+  for (const entry of sorted) {
+    if (running <= targetBytes) break;
+    evictCount += 1;
+    freedBytes += entry.sizeBytes;
+    running -= entry.sizeBytes;
+  }
+  return { evictCount, freedBytes };
+}

--- a/src/services/audioPrefetch.ts
+++ b/src/services/audioPrefetch.ts
@@ -12,10 +12,10 @@
 import { localDb } from '../db/localDb';
 import { supabase } from '../lib/supabase';
 import * as local from '../db/localRepo';
-import type { AudioRecording, AudioBlob } from '../db/schema';
+import type { AudioRecording } from '../db/schema';
+import { AUDIO_BUCKET } from '../lib/audioStorage';
 import { getAudioCacheCapBytes } from '../stores/audioCacheSettingsStore';
 
-const AUDIO_BUCKET = 'audio-recordings';
 const SIGNED_URL_TTL_SECONDS = 60;
 const CONCURRENCY = 4;
 const RECENT_CREATE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
@@ -132,15 +132,7 @@ async function fetchAndStore(rec: AudioRecording): Promise<number> {
     return 0;
   }
 
-  const now = Date.now();
-  const entry: AudioBlob = {
-    recordingId: rec.id,
-    blob,
-    mimeType: rec.mimeType ?? blob.type ?? 'audio/webm',
-    sizeBytes: blob.size,
-    fetchedAt: now,
-    lastPlayedAt: now,
-  };
+  const entry = local.makeAudioBlobEntry(rec.id, blob, rec.mimeType);
 
   try {
     await local.putAudioBlob(entry);
@@ -160,24 +152,37 @@ async function fetchAndStore(rec: AudioRecording): Promise<number> {
   return entry.sizeBytes;
 }
 
-/** Drop oldest-played entries until total cache size is at or below `targetBytes`.
- *  Returns the post-eviction total. */
-async function evictToTarget(targetBytes: number): Promise<number> {
+/** Pick LRU entries to evict to bring the cache at or below `targetBytes`.
+ *  Pure: doesn't mutate. Reused by both eviction and the Settings preview
+ *  so the count the user sees matches what actually gets deleted. */
+async function selectEvictionCandidates(targetBytes: number): Promise<{
+  ids: string[];
+  freedBytes: number;
+  postTotal: number;
+}> {
   const usage = await local.getAudioCacheUsage();
-  if (usage.totalBytes <= targetBytes) return usage.totalBytes;
-
+  if (usage.totalBytes <= targetBytes) {
+    return { ids: [], freedBytes: 0, postTotal: usage.totalBytes };
+  }
   const sorted = await local.getAudioBlobsSortedByLru();
-  const toDelete: string[] = [];
+  const ids: string[] = [];
+  let freedBytes = 0;
   let running = usage.totalBytes;
   for (const entry of sorted) {
     if (running <= targetBytes) break;
-    toDelete.push(entry.recordingId);
+    ids.push(entry.recordingId);
+    freedBytes += entry.sizeBytes;
     running -= entry.sizeBytes;
   }
-  if (toDelete.length > 0) {
-    await local.deleteAudioBlobs(toDelete);
-  }
-  return running;
+  return { ids, freedBytes, postTotal: running };
+}
+
+/** Drop oldest-played entries until total cache size is at or below `targetBytes`.
+ *  Returns the post-eviction total. */
+async function evictToTarget(targetBytes: number): Promise<number> {
+  const { ids, postTotal } = await selectEvictionCandidates(targetBytes);
+  if (ids.length > 0) await local.deleteAudioBlobs(ids);
+  return postTotal;
 }
 
 /** Sentences whose cards are due now or in the next 24h, across all decks.
@@ -218,18 +223,6 @@ export async function shrinkAudioCacheTo(targetBytes: number): Promise<number> {
  *  the Settings UI to show "X recordings (Y MB) will be deleted" in the
  *  confirmation prompt. */
 export async function previewShrink(targetBytes: number): Promise<{ evictCount: number; freedBytes: number }> {
-  const usage = await local.getAudioCacheUsage();
-  if (usage.totalBytes <= targetBytes) return { evictCount: 0, freedBytes: 0 };
-
-  const sorted = await local.getAudioBlobsSortedByLru();
-  let evictCount = 0;
-  let freedBytes = 0;
-  let running = usage.totalBytes;
-  for (const entry of sorted) {
-    if (running <= targetBytes) break;
-    evictCount += 1;
-    freedBytes += entry.sizeBytes;
-    running -= entry.sizeBytes;
-  }
-  return { evictCount, freedBytes };
+  const { ids, freedBytes } = await selectEvictionCandidates(targetBytes);
+  return { evictCount: ids.length, freedBytes };
 }

--- a/src/services/audioPrefetch.ts
+++ b/src/services/audioPrefetch.ts
@@ -1,0 +1,207 @@
+/**
+ * Eager prefetch of audio recordings into the local audioBlobs cache.
+ *
+ * Strategy:
+ *   1. Enumerate all audioRecordings with a storagePath that aren't already cached.
+ *   2. Order them: due-soon → recently created → rest.
+ *   3. Fetch (with concurrency limit) until the user's configured cap is reached.
+ *   4. On overflow (cap or QuotaExceededError), evict by lastPlayedAt LRU.
+ *
+ * Runs in the background after sync; soft-fails on individual fetch errors.
+ */
+import { localDb } from '../db/localDb';
+import { supabase } from '../lib/supabase';
+import * as local from '../db/localRepo';
+import type { AudioRecording, AudioBlob } from '../db/schema';
+import { getAudioCacheCapBytes } from '../stores/audioCacheSettingsStore';
+
+const AUDIO_BUCKET = 'audio-recordings';
+const SIGNED_URL_TTL_SECONDS = 60;
+const CONCURRENCY = 4;
+const RECENT_CREATE_WINDOW_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+let prefetchInFlight: Promise<void> | null = null;
+
+/**
+ * Run a prefetch pass. Concurrent calls share a single in-flight pass —
+ * callers can fire-and-forget on every sync without piling up work.
+ */
+export function runAudioPrefetch(): Promise<void> {
+  if (prefetchInFlight) return prefetchInFlight;
+  prefetchInFlight = (async () => {
+    try {
+      await prefetchInternal();
+    } catch (e) {
+      console.warn('Audio prefetch failed:', e);
+    } finally {
+      prefetchInFlight = null;
+    }
+  })();
+  return prefetchInFlight;
+}
+
+async function prefetchInternal(): Promise<void> {
+  if (!navigator.onLine) return;
+
+  const cap = getAudioCacheCapBytes();
+  const allRecs = await local.getAllAudioRecordings();
+  const cachedIds = await local.getCachedAudioRecordingIds();
+
+  // Anything without a storagePath is either a local-only clip (already
+  // cached at insert time) or somehow malformed; nothing to fetch.
+  const candidates = allRecs.filter(
+    (r) => !!r.storagePath && !cachedIds.has(r.id)
+  );
+
+  // Build prefetch order using sentenceId → due-soon membership and
+  // createdAt recency. We order outside the DB so we don't keep an open
+  // Dexie cursor across many awaits.
+  const dueSentenceIds = await getDueSentenceIds();
+  const now = Date.now();
+
+  const ordered = candidates
+    .map((r) => ({
+      rec: r,
+      tier: dueSentenceIds.has(r.sentenceId)
+        ? 0
+        : now - r.createdAt < RECENT_CREATE_WINDOW_MS
+          ? 1
+          : 2,
+    }))
+    .sort((a, b) => {
+      if (a.tier !== b.tier) return a.tier - b.tier;
+      // Within a tier, newest first.
+      return b.rec.createdAt - a.rec.createdAt;
+    })
+    .map((entry) => entry.rec);
+
+  if (ordered.length === 0) return;
+
+  // Track running total against the cap, refreshed from the table so we
+  // include whatever is already cached.
+  let { totalBytes } = await local.getAudioCacheUsage();
+
+  // Worker pool: pull from the queue and fetch each in turn.
+  const queue = ordered.slice();
+  const workers: Promise<void>[] = [];
+  for (let i = 0; i < CONCURRENCY; i++) {
+    workers.push(
+      (async () => {
+        while (queue.length > 0) {
+          if (totalBytes >= cap) break;
+          const rec = queue.shift();
+          if (!rec) break;
+          try {
+            const fetchedSize = await fetchAndStore(rec);
+            if (fetchedSize > 0) {
+              totalBytes += fetchedSize;
+              if (totalBytes > cap) {
+                // Evict back below the cap (with a small margin) before
+                // letting more inflights finish.
+                totalBytes = await evictToTarget(Math.floor(cap * 0.9));
+              }
+            }
+          } catch (e) {
+            // Best-effort. One bad URL/network blip shouldn't kill the pass.
+            console.warn(`Prefetch failed for recording ${rec.id}:`, e);
+          }
+        }
+      })()
+    );
+  }
+  await Promise.all(workers);
+}
+
+/** Fetch a single recording's bytes and store them. Returns sizeBytes on
+ *  success, 0 on skip/failure. Throws only on QuotaExceededError so the
+ *  caller can react. */
+async function fetchAndStore(rec: AudioRecording): Promise<number> {
+  if (!rec.storagePath) return 0;
+
+  const { data, error } = await supabase.storage
+    .from(AUDIO_BUCKET)
+    .createSignedUrl(rec.storagePath, SIGNED_URL_TTL_SECONDS);
+  if (error || !data?.signedUrl) return 0;
+
+  let blob: Blob;
+  try {
+    const resp = await fetch(data.signedUrl);
+    if (!resp.ok) return 0;
+    blob = await resp.blob();
+  } catch {
+    return 0;
+  }
+
+  const now = Date.now();
+  const entry: AudioBlob = {
+    recordingId: rec.id,
+    blob,
+    mimeType: rec.mimeType ?? blob.type ?? 'audio/webm',
+    sizeBytes: blob.size,
+    fetchedAt: now,
+    lastPlayedAt: now,
+  };
+
+  try {
+    await local.putAudioBlob(entry);
+  } catch (e: unknown) {
+    if (isQuotaExceeded(e)) {
+      // Recover: aggressively evict and retry once.
+      await evictToTarget(Math.floor(getAudioCacheCapBytes() * 0.5));
+      try {
+        await local.putAudioBlob(entry);
+      } catch {
+        return 0;
+      }
+    } else {
+      return 0;
+    }
+  }
+  return entry.sizeBytes;
+}
+
+/** Drop oldest-played entries until total cache size is at or below `targetBytes`.
+ *  Returns the post-eviction total. */
+async function evictToTarget(targetBytes: number): Promise<number> {
+  const usage = await local.getAudioCacheUsage();
+  if (usage.totalBytes <= targetBytes) return usage.totalBytes;
+
+  const sorted = await local.getAudioBlobsSortedByLru();
+  const toDelete: string[] = [];
+  let running = usage.totalBytes;
+  for (const entry of sorted) {
+    if (running <= targetBytes) break;
+    toDelete.push(entry.recordingId);
+    running -= entry.sizeBytes;
+  }
+  if (toDelete.length > 0) {
+    await local.deleteAudioBlobs(toDelete);
+  }
+  return running;
+}
+
+/** Sentences whose cards are due now or in the next 24h, across all decks.
+ *  Cheap query — pulled directly from Dexie, no scheduler logic involved. */
+async function getDueSentenceIds(): Promise<Set<string>> {
+  const horizon = Date.now() + 24 * 60 * 60 * 1000;
+  const dueCards = await localDb.srsCards
+    .where('due')
+    .belowOrEqual(horizon)
+    .toArray();
+  return new Set(dueCards.map((c) => c.sentenceId));
+}
+
+function isQuotaExceeded(e: unknown): boolean {
+  if (!e || typeof e !== 'object') return false;
+  const err = e as { name?: string; code?: number };
+  return (
+    err.name === 'QuotaExceededError' ||
+    err.code === 22 ||
+    err.code === 1014
+  );
+}
+
+/** Drop the entire cache. Used by Settings → Clear cache. */
+export async function clearAudioCache(): Promise<void> {
+  await local.clearAudioBlobs();
+}

--- a/src/services/audioRecording.ts
+++ b/src/services/audioRecording.ts
@@ -47,13 +47,28 @@ export interface RecordingHandle {
   stop: () => Promise<RecordingResult>;
   /** Abort without producing a blob. */
   cancel: () => void;
+  /** True if the recorder auto-stopped because it hit `maxDurationMs`. */
+  hitDurationCap: () => boolean;
+}
+
+export interface RecordingOptions {
+  /** Hard cap on recording length. The recorder auto-stops when reached.
+   *  Keeps blob size bounded under the Storage 2 MiB cap; default lives in
+   *  the audio settings store. Pass 0 / undefined to disable. */
+  maxDurationMs?: number;
+  /** Optional callback fired when the cap auto-stop kicks in (so the UI
+   *  can finalize and surface a toast). */
+  onDurationCap?: () => void;
 }
 
 /**
  * Start recording audio from the microphone.
- * Returns a handle; call stop() to finalize and get the blob.
+ * Returns a handle; call stop() to finalize and get the blob. If
+ * `maxDurationMs` is set, the recorder auto-stops at that limit.
  */
-export async function startRecording(): Promise<RecordingHandle> {
+export async function startRecording(
+  opts: RecordingOptions = {},
+): Promise<RecordingHandle> {
   if (!isAudioRecordingSupported()) {
     throw new Error('Audio recording is not supported in this browser.');
   }
@@ -65,6 +80,7 @@ export async function startRecording(): Promise<RecordingHandle> {
   const chunks: Blob[] = [];
   const startedAt = Date.now();
   let cancelled = false;
+  let capped = false;
 
   recorder.ondataavailable = (e) => {
     if (e.data && e.data.size > 0) chunks.push(e.data);
@@ -76,26 +92,50 @@ export async function startRecording(): Promise<RecordingHandle> {
     for (const track of stream.getTracks()) track.stop();
   };
 
+  let capTimer: ReturnType<typeof setTimeout> | null = null;
+  if (opts.maxDurationMs && opts.maxDurationMs > 0) {
+    capTimer = setTimeout(() => {
+      capTimer = null;
+      if (cancelled) return;
+      if (recorder.state !== 'inactive') {
+        capped = true;
+        try { recorder.stop(); } catch {}
+        opts.onDurationCap?.();
+      }
+    }, opts.maxDurationMs);
+  }
+  const clearCapTimer = () => {
+    if (capTimer != null) {
+      clearTimeout(capTimer);
+      capTimer = null;
+    }
+  };
+
   const stop = () =>
     new Promise<RecordingResult>((resolve, reject) => {
       if (cancelled) {
+        clearCapTimer();
         reject(new Error('Recording cancelled'));
         return;
       }
       recorder.onstop = () => {
+        clearCapTimer();
         cleanupStream();
         const type = recorder.mimeType || mimeType || 'audio/webm';
         const blob = new Blob(chunks, { type });
         resolve({ blob, mimeType: type, durationMs: Date.now() - startedAt });
       };
       recorder.onerror = (e: any) => {
+        clearCapTimer();
         cleanupStream();
         reject(e?.error || new Error('Recording failed'));
       };
       if (recorder.state !== 'inactive') {
         recorder.stop();
       } else {
-        // Already stopped somehow; produce whatever we have.
+        // Already stopped (e.g. duration cap fired); produce what we have.
+        clearCapTimer();
+        cleanupStream();
         const type = recorder.mimeType || mimeType || 'audio/webm';
         resolve({ blob: new Blob(chunks, { type }), mimeType: type, durationMs: Date.now() - startedAt });
       }
@@ -103,13 +143,14 @@ export async function startRecording(): Promise<RecordingHandle> {
 
   const cancel = () => {
     cancelled = true;
+    clearCapTimer();
     try {
       if (recorder.state !== 'inactive') recorder.stop();
     } catch {}
     cleanupStream();
   };
 
-  return { stop, cancel };
+  return { stop, cancel, hitDurationCap: () => capped };
 }
 
 export interface VoiceWithAudioResult {
@@ -131,12 +172,15 @@ export interface StreamingWithAudioHandle {
  * Add Sentence.
  */
 export async function startStreamingRecognitionWithAudio(
-  opts: StreamingOptions = {}
+  opts: StreamingOptions & RecordingOptions = {}
 ): Promise<StreamingWithAudioHandle> {
   let recHandle: RecordingHandle | null = null;
   if (isAudioRecordingSupported()) {
     try {
-      recHandle = await startRecording();
+      recHandle = await startRecording({
+        maxDurationMs: opts.maxDurationMs,
+        onDurationCap: opts.onDurationCap,
+      });
     } catch {
       recHandle = null;
     }

--- a/src/services/audioRecording.ts
+++ b/src/services/audioRecording.ts
@@ -65,6 +65,11 @@ export interface RecordingOptions {
  * Start recording audio from the microphone.
  * Returns a handle; call stop() to finalize and get the blob. If
  * `maxDurationMs` is set, the recorder auto-stops at that limit.
+ *
+ * The result promise is resolved exactly once by the recorder's onstop /
+ * onerror handlers (registered eagerly, before recorder.start()), so
+ * concurrent stop() calls — e.g., user click racing the cap timer —
+ * share the same outcome instead of overwriting each other's resolvers.
  */
 export async function startRecording(
   opts: RecordingOptions = {},
@@ -82,17 +87,53 @@ export async function startRecording(
   let cancelled = false;
   let capped = false;
 
-  recorder.ondataavailable = (e) => {
-    if (e.data && e.data.size > 0) chunks.push(e.data);
-  };
-
-  recorder.start();
-
   const cleanupStream = () => {
     for (const track of stream.getTracks()) track.stop();
   };
 
   let capTimer: ReturnType<typeof setTimeout> | null = null;
+  const clearCapTimer = () => {
+    if (capTimer != null) {
+      clearTimeout(capTimer);
+      capTimer = null;
+    }
+  };
+
+  let resolveResult: ((r: RecordingResult) => void) | null = null;
+  let rejectResult: ((e: any) => void) | null = null;
+  const resultPromise = new Promise<RecordingResult>((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+
+  recorder.ondataavailable = (e) => {
+    if (e.data && e.data.size > 0) chunks.push(e.data);
+  };
+
+  recorder.onstop = () => {
+    clearCapTimer();
+    cleanupStream();
+    if (cancelled) {
+      rejectResult?.(new Error('Recording cancelled'));
+    } else {
+      const type = recorder.mimeType || mimeType || 'audio/webm';
+      const blob = new Blob(chunks, { type });
+      resolveResult?.({ blob, mimeType: type, durationMs: Date.now() - startedAt });
+    }
+    resolveResult = null;
+    rejectResult = null;
+  };
+
+  recorder.onerror = (e: any) => {
+    clearCapTimer();
+    cleanupStream();
+    rejectResult?.(e?.error || new Error('Recording failed'));
+    resolveResult = null;
+    rejectResult = null;
+  };
+
+  recorder.start();
+
   if (opts.maxDurationMs && opts.maxDurationMs > 0) {
     capTimer = setTimeout(() => {
       capTimer = null;
@@ -104,42 +145,13 @@ export async function startRecording(
       }
     }, opts.maxDurationMs);
   }
-  const clearCapTimer = () => {
-    if (capTimer != null) {
-      clearTimeout(capTimer);
-      capTimer = null;
-    }
-  };
 
-  const stop = () =>
-    new Promise<RecordingResult>((resolve, reject) => {
-      if (cancelled) {
-        clearCapTimer();
-        reject(new Error('Recording cancelled'));
-        return;
-      }
-      recorder.onstop = () => {
-        clearCapTimer();
-        cleanupStream();
-        const type = recorder.mimeType || mimeType || 'audio/webm';
-        const blob = new Blob(chunks, { type });
-        resolve({ blob, mimeType: type, durationMs: Date.now() - startedAt });
-      };
-      recorder.onerror = (e: any) => {
-        clearCapTimer();
-        cleanupStream();
-        reject(e?.error || new Error('Recording failed'));
-      };
-      if (recorder.state !== 'inactive') {
-        recorder.stop();
-      } else {
-        // Already stopped (e.g. duration cap fired); produce what we have.
-        clearCapTimer();
-        cleanupStream();
-        const type = recorder.mimeType || mimeType || 'audio/webm';
-        resolve({ blob: new Blob(chunks, { type }), mimeType: type, durationMs: Date.now() - startedAt });
-      }
-    });
+  const stop = (): Promise<RecordingResult> => {
+    if (recorder.state !== 'inactive') {
+      try { recorder.stop(); } catch {}
+    }
+    return resultPromise;
+  };
 
   const cancel = () => {
     cancelled = true;

--- a/src/stores/audioCacheSettingsStore.ts
+++ b/src/stores/audioCacheSettingsStore.ts
@@ -1,0 +1,50 @@
+import { create } from 'zustand';
+
+const STORAGE_KEY = 'mandao_audio_cache_settings';
+
+export type AudioCacheCapMB = 100 | 200 | 500;
+
+export interface AudioCacheSettings {
+  capMB: AudioCacheCapMB;
+}
+
+const DEFAULTS: AudioCacheSettings = {
+  capMB: 200,
+};
+
+const VALID_CAPS: AudioCacheCapMB[] = [100, 200, 500];
+
+function load(): AudioCacheSettings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { ...DEFAULTS };
+    const parsed = JSON.parse(raw) as Partial<AudioCacheSettings>;
+    const cap = parsed.capMB;
+    if (typeof cap === 'number' && VALID_CAPS.includes(cap as AudioCacheCapMB)) {
+      return { capMB: cap as AudioCacheCapMB };
+    }
+    return { ...DEFAULTS };
+  } catch {
+    return { ...DEFAULTS };
+  }
+}
+
+function save(s: AudioCacheSettings) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+}
+
+interface AudioCacheSettingsState extends AudioCacheSettings {
+  setCapMB: (cap: AudioCacheCapMB) => void;
+}
+
+export const useAudioCacheSettingsStore = create<AudioCacheSettingsState>((set) => ({
+  ...load(),
+  setCapMB: (capMB) => {
+    save({ capMB });
+    set({ capMB });
+  },
+}));
+
+export function getAudioCacheCapBytes(): number {
+  return useAudioCacheSettingsStore.getState().capMB * 1024 * 1024;
+}

--- a/src/stores/audioCacheSettingsStore.ts
+++ b/src/stores/audioCacheSettingsStore.ts
@@ -4,15 +4,29 @@ const STORAGE_KEY = 'mandao_audio_cache_settings';
 
 export type AudioCacheCapMB = 100 | 200 | 500;
 
+/** Hard cap on a single recording's duration. Bounded so we stay safely
+ *  under the 2 MiB per-file Storage limit at any plausible browser bitrate. */
+export const RECORDING_CAP_SEC_MIN = 5;
+export const RECORDING_CAP_SEC_MAX = 60;
+export const RECORDING_CAP_SEC_DEFAULT = 20;
+
 export interface AudioCacheSettings {
   capMB: AudioCacheCapMB;
+  /** Per-recording length cap, in seconds. */
+  recordingCapSec: number;
 }
 
 const DEFAULTS: AudioCacheSettings = {
   capMB: 200,
+  recordingCapSec: RECORDING_CAP_SEC_DEFAULT,
 };
 
 const VALID_CAPS: AudioCacheCapMB[] = [100, 200, 500];
+
+function clampRecordingCap(v: unknown): number {
+  if (typeof v !== 'number' || !Number.isFinite(v)) return RECORDING_CAP_SEC_DEFAULT;
+  return Math.min(RECORDING_CAP_SEC_MAX, Math.max(RECORDING_CAP_SEC_MIN, Math.round(v)));
+}
 
 function load(): AudioCacheSettings {
   try {
@@ -20,10 +34,14 @@ function load(): AudioCacheSettings {
     if (!raw) return { ...DEFAULTS };
     const parsed = JSON.parse(raw) as Partial<AudioCacheSettings>;
     const cap = parsed.capMB;
-    if (typeof cap === 'number' && VALID_CAPS.includes(cap as AudioCacheCapMB)) {
-      return { capMB: cap as AudioCacheCapMB };
-    }
-    return { ...DEFAULTS };
+    const validCap =
+      typeof cap === 'number' && VALID_CAPS.includes(cap as AudioCacheCapMB)
+        ? (cap as AudioCacheCapMB)
+        : DEFAULTS.capMB;
+    return {
+      capMB: validCap,
+      recordingCapSec: clampRecordingCap(parsed.recordingCapSec),
+    };
   } catch {
     return { ...DEFAULTS };
   }
@@ -35,16 +53,28 @@ function save(s: AudioCacheSettings) {
 
 interface AudioCacheSettingsState extends AudioCacheSettings {
   setCapMB: (cap: AudioCacheCapMB) => void;
+  setRecordingCapSec: (sec: number) => void;
 }
 
-export const useAudioCacheSettingsStore = create<AudioCacheSettingsState>((set) => ({
+export const useAudioCacheSettingsStore = create<AudioCacheSettingsState>((set, get) => ({
   ...load(),
   setCapMB: (capMB) => {
-    save({ capMB });
+    const next = { ...get(), capMB };
+    save(next);
     set({ capMB });
+  },
+  setRecordingCapSec: (sec) => {
+    const recordingCapSec = clampRecordingCap(sec);
+    const next = { ...get(), recordingCapSec };
+    save(next);
+    set({ recordingCapSec });
   },
 }));
 
 export function getAudioCacheCapBytes(): number {
   return useAudioCacheSettingsStore.getState().capMB * 1024 * 1024;
+}
+
+export function getRecordingCapMs(): number {
+  return useAudioCacheSettingsStore.getState().recordingCapSec * 1000;
 }


### PR DESCRIPTION
## Summary

Closes #117 and #119. Recordings now play offline and survive page reloads via a client-side cache that the user can size and clear, **and** the recorder is bounded so a stuck mic can't produce an upload that the Storage cap would silently reject.

### Offline cache (#117)

- New `audioBlobs` Dexie table (schema v5, migrates existing cached blobs over) decouples cache state (`sizeBytes`, `lastPlayedAt`) from the synced `audio_recordings` row.
- After every successful sync, `runAudioPrefetch()` fetches missing recordings in priority order — **due-soon → recently created → rest** — with 4-way concurrency, soft-failing on individual errors.
- Cap configurable in Settings (100 / 200 / 500 MB, default 200). When exceeded — or on `QuotaExceededError` — least-recently-played entries are evicted to 90% of cap.
- `fetchAudioBlob()` now serves from cache on hit (touching `lastPlayedAt`) and falls back to a 60s signed URL on miss.
- App calls `navigator.storage.persist()` once per login so the cache survives storage pressure / iOS ITP eviction.

### Recording duration cap (#119)

- New `maxDurationMs` / `onDurationCap` options on `startRecording` and `startStreamingRecognitionWithAudio`. Recorder auto-stops at the cap and notifies the caller, which finalizes the clip naturally.
- Setting lives in the audio settings store: `recordingCapSec`, default 20s, allowed range 5–60s. Adjustable in Settings → Offline Audio.
- All three call sites (`SentenceAudioControls`, `AddSentencePage`, `ReviewCard`) read the cap from the store at start time.

### Settings UX

Settings → Data now has an "Offline Audio" section with:
- Usage bar showing `X MB of Y MB` and recording count
- Storage cap selector: 100 / 200 / 500 MB
- Max recording length input (5–60 s)
- "Download missing now" and "Clear cache" — now both gated behind an inline two-step confirm, mirroring the Danger Zone pattern

## Notable changes

- `AudioRecording.blob` is removed from the type. Three call sites (`SentenceAudioControls`, `AddSentencePage`, `ankiApkg`) now pass blob as a second arg to `repo.insertAudioRecording(rec, blob)`.
- Pull-merge no longer needs to preserve `blob` through server upserts (it isn't on the row anymore), simplifying the audio-row merge path.
- Sentence/recording cascade deletes (both the local path and the graves cascade in `syncEngine`) now drop matching `audioBlobs` entries.

## Follow-ups (separate issues)

- #118 — PWA install nudge for iOS Safari users (meaningfully improves cache durability on iOS)

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test` — 93/93 pass
- [x] `npm run build` clean
- [ ] Manual: record a clip → reload → verify it plays offline (DevTools → Offline)
- [ ] Manual: hold the record button past 20s → confirm it auto-stops and the save dialog appears
- [ ] Manual: change "Max recording length" in Settings → confirm the new cap takes effect
- [ ] Manual: tap "Download missing now" / "Clear cache" → confirm second-tap is required
- [ ] Manual: verify Settings usage bar updates after recording / playing / clearing
- [ ] Manual: verify Dexie v5 migration on an existing account (existing blobs move into `audioBlobs`)
- [ ] Manual: set storage cap to 100 MB on an account with > 100 MB of recordings, confirm LRU eviction kicks in

🤖 Generated with [Claude Code](https://claude.com/claude-code)