### PR TITLE
Clarify install banner copy + handle iOS non-Safari

### DIFF
--- a/src/components/InstallBanner.tsx
+++ b/src/components/InstallBanner.tsx
@@ -115,34 +115,65 @@ const InstallIconSvg = (
   </svg>
 );
 
+/** iOS-style Share icon: square with arrow pointing up out the top.
+ *  Helps users find the right button in Safari's bottom toolbar. */
+const ShareIconSvg = (
+  <svg
+    width="14"
+    height="14"
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth="2"
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+    style={{ display: 'inline-block', verticalAlign: '-2px' }}
+  >
+    <path d="M4 12v7a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-7" />
+    <polyline points="16 6 12 2 8 6" />
+    <line x1="12" y1="2" x2="12" y2="15" />
+  </svg>
+);
+
 function BannerCopy({ platform }: { platform: Platform }) {
   if (platform === 'promptable') {
     return (
       <span>
-        <strong>Install Mandao</strong> to keep your offline audio cache from being evicted by the browser.
+        <strong>Install Mandao</strong> to launch it from your home screen and keep its data resilient to browser cleanup.
       </span>
     );
   }
   if (platform === 'chrome-address-bar') {
     return (
       <span>
-        <strong>Install Mandao</strong> for a smoother offline experience: click the install icon{' '}
-        {InstallIconSvg} in your address bar.
+        <strong>Install Mandao</strong> to launch it from your dock or start menu: click the install icon{' '}
+        {InstallIconSvg} in the address bar.
       </span>
     );
   }
   if (platform === 'ios-safari') {
+    // iOS Safari is the one platform where install meaningfully changes
+    // cache durability (without it, ITP wipes IndexedDB after ~7 days).
     return (
       <span>
-        <strong>Install Mandao</strong> so your offline audio survives between sessions: tap{' '}
-        <strong>Share</strong> → <strong>Add to Home Screen</strong>.
+        <strong>Install Mandao</strong> so your offline audio doesn't expire after a week: tap the Share button{' '}
+        {ShareIconSvg} at the bottom, then <strong>Add to Home Screen</strong>.
+      </span>
+    );
+  }
+  if (platform === 'ios-other-browser') {
+    return (
+      <span>
+        <strong>Install Mandao on iOS</strong>: open this page in Safari (Share {ShareIconSvg} →{' '}
+        <strong>Open in Safari</strong>), then tap Share → <strong>Add to Home Screen</strong>.
       </span>
     );
   }
   if (platform === 'macos-safari') {
     return (
       <span>
-        <strong>Install Mandao</strong> for a smoother offline experience: in Safari's menu bar, choose{' '}
+        <strong>Install Mandao</strong> to launch it from your dock: in Safari's menu bar, choose{' '}
         <strong>File</strong> → <strong>Add to Dock</strong>.
       </span>
     );

--- a/src/lib/pwaInstall.ts
+++ b/src/lib/pwaInstall.ts
@@ -36,8 +36,11 @@ export type Platform =
    *  recently installed/uninstalled and Chrome is in cooldown. We fall back
    *  to pointing at the address-bar icon. */
   | 'chrome-address-bar'
-  /** iOS Safari (or any iOS browser, since they're all WebKit) — show "Share → Add to Home Screen". */
+  /** iOS Safari proper — show "Share → Add to Home Screen". */
   | 'ios-safari'
+  /** iOS Chrome / Firefox / Edge — install requires Safari on iOS, so we
+   *  redirect users there before they can use Add to Home Screen. */
+  | 'ios-other-browser'
   /** macOS Safari 14+ — show "File → Add to Dock". */
   | 'macos-safari'
   /** Firefox / in-app browsers / anything else — no install path; hide UI. */
@@ -75,7 +78,7 @@ export function isStandalone(): boolean {
 }
 
 const DEV_OVERRIDE_KEY = 'mandao_pwa_dev_platform';
-const VALID_PLATFORMS: Platform[] = ['installed', 'promptable', 'chrome-address-bar', 'ios-safari', 'macos-safari', 'no-install'];
+const VALID_PLATFORMS: Platform[] = ['installed', 'promptable', 'chrome-address-bar', 'ios-safari', 'ios-other-browser', 'macos-safari', 'no-install'];
 
 // Run once at module load: a `?pwa=ios-safari` URL pins a platform for the
 // session via sessionStorage so it survives client-side nav. `?pwa=` clears.
@@ -108,11 +111,17 @@ export function getPlatform(): Platform {
   const isIOS =
     /iPhone|iPad|iPod/.test(ua) ||
     (ua.includes('Mac') && typeof document !== 'undefined' && 'ontouchend' in document);
-  // All iOS browsers use WebKit, but in-app browsers (Instagram, Twitter,
-  // etc.) don't have a Share menu users can install from — hide rather
-  // than mislead.
+  // All iOS browsers use WebKit, but Apple gates Add-to-Home-Screen to
+  // Safari only — Chrome/Firefox/Edge on iOS don't have it. Detect those
+  // by their Apple-mandated UA suffixes and route to a separate copy that
+  // tells the user to open in Safari first. In-app browsers (Instagram,
+  // Twitter, etc.) don't have a Share menu users can install from — hide
+  // rather than mislead.
   const isInAppBrowser = /(FBAN|FBAV|Instagram|Twitter|Line|WeChat)/i.test(ua);
-  if (isIOS && !isInAppBrowser) return 'ios-safari';
+  if (isIOS && !isInAppBrowser) {
+    const isIOSOtherBrowser = /CriOS\/|FxiOS\/|EdgiOS\//.test(ua);
+    return isIOSOtherBrowser ? 'ios-other-browser' : 'ios-safari';
+  }
 
   // Desktop Safari 14+ supports install via File → Add to Dock but doesn't
   // expose the prompt event. Detect by Safari + Mac, no iOS.

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1640,7 +1640,9 @@ function InstallCard() {
       description={
         installed
           ? 'Mandao is installed on this device.'
-          : 'Install Mandao to keep your offline audio cache from being evicted between sessions, and to launch from your home screen / dock without browser chrome.'
+          : platform === 'ios-safari' || platform === 'ios-other-browser'
+            ? "Install Mandao to your home screen so its offline audio cache isn't auto-evicted by iOS Safari."
+            : 'Install Mandao to launch it from your home screen / dock without browser chrome.'
       }
     >
       {installed && (
@@ -1666,7 +1668,14 @@ function InstallCard() {
       )}
       {platform === 'ios-safari' && (
         <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-          Tap <strong>Share</strong> at the bottom of Safari, then{' '}
+          Tap the <strong>Share</strong> button (a square with an upward arrow) at the bottom of
+          Safari, then scroll down and tap <strong>Add to Home Screen</strong>.
+        </p>
+      )}
+      {platform === 'ios-other-browser' && (
+        <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+          On iOS, only Safari can install web apps to the home screen. Tap the Share button
+          in this browser, choose <strong>Open in Safari</strong>, then in Safari tap Share →{' '}
           <strong>Add to Home Screen</strong>.
         </p>
       )}


### PR DESCRIPTION
## Summary

Two real bugs in the install banner copy from #121:

1. **iPhone Chrome / Firefox / Edge can't install via Add to Home Screen** — Apple gates that to Safari only. We were showing the Safari-only instructions to all iOS browsers, which don't work outside Safari. Add a new \`'ios-other-browser'\` platform that tells the user to open the page in Safari first.
2. **The "offline audio survives between sessions" framing was misleading on Chromium and macOS Safari** — the cache works fine without install on those (no aggressive ITP eviction). That value prop only really applies to iOS Safari, so keep it there and reframe everywhere else around home-screen / dock launching.

Plus a small clarity fix:

3. Add an inline **Share-icon SVG** in the iOS copy so users can recognize the right button in Safari's bottom toolbar.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] iPhone Safari: still shows iOS Safari banner with Share + Add to Home Screen, now with visible Share icon
- [ ] iPhone Chrome / Firefox: shows new \`ios-other-browser\` banner pointing to "Open in Safari" first
- [ ] Desktop / Android Chrome: banner copy is now about home-screen launching, not audio expiry
- [ ] Settings → Data → Install Mandao: description varies by platform

🤖 Generated with [Claude Code](https://claude.com/claude-code)