### PR TITLE
Fix Chrome-on-Mac iOS false-detection + tighten install copy

### DIFF
--- a/src/components/InstallBanner.tsx
+++ b/src/components/InstallBanner.tsx
@@ -157,16 +157,16 @@ function BannerCopy({ platform }: { platform: Platform }) {
     // cache durability (without it, ITP wipes IndexedDB after ~7 days).
     return (
       <span>
-        <strong>Install Mandao</strong> so your offline audio doesn't expire after a week: tap the Share button{' '}
-        {ShareIconSvg} at the bottom, then <strong>Add to Home Screen</strong>.
+        <strong>Install Mandao</strong>: press the Share button {ShareIconSvg} at the bottom, then{' '}
+        <strong>Add to Home Screen</strong>.
       </span>
     );
   }
   if (platform === 'ios-other-browser') {
     return (
       <span>
-        <strong>Install Mandao on iOS</strong>: open this page in Safari (Share {ShareIconSvg} →{' '}
-        <strong>Open in Safari</strong>), then tap Share → <strong>Add to Home Screen</strong>.
+        <strong>Install Mandao on iOS</strong>: open this page in Safari, press Share{' '}
+        {ShareIconSvg}, then <strong>Add to Home Screen</strong>.
       </span>
     );
   }

--- a/src/lib/pwaInstall.ts
+++ b/src/lib/pwaInstall.ts
@@ -107,10 +107,13 @@ export function getPlatform(): Platform {
   if (getDeferred()) return 'promptable';
 
   const ua = navigator.userAgent;
-  // iPadOS 13+ reports as Mac. The touch sniff is the standard workaround.
+  // iPadOS 13+ reports as Macintosh; differentiate from real desktop Mac
+  // by hardware touch points (iPad = 5, desktop Mac = 0). Don't use
+  // `ontouchend in document` — Chromium on desktop exposes touch APIs by
+  // default regardless of hardware, so that check false-positives.
   const isIOS =
     /iPhone|iPad|iPod/.test(ua) ||
-    (ua.includes('Mac') && typeof document !== 'undefined' && 'ontouchend' in document);
+    (/Macintosh/.test(ua) && (navigator.maxTouchPoints ?? 0) > 1);
   // All iOS browsers use WebKit, but Apple gates Add-to-Home-Screen to
   // Safari only — Chrome/Firefox/Edge on iOS don't have it. Detect those
   // by their Apple-mandated UA suffixes and route to a separate copy that

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1668,15 +1668,14 @@ function InstallCard() {
       )}
       {platform === 'ios-safari' && (
         <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-          Tap the <strong>Share</strong> button (a square with an upward arrow) at the bottom of
-          Safari, then scroll down and tap <strong>Add to Home Screen</strong>.
+          Press the <strong>Share</strong> button (a square with an upward arrow) at the bottom of
+          Safari, then <strong>Add to Home Screen</strong>.
         </p>
       )}
       {platform === 'ios-other-browser' && (
         <p className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-          On iOS, only Safari can install web apps to the home screen. Tap the Share button
-          in this browser, choose <strong>Open in Safari</strong>, then in Safari tap Share →{' '}
-          <strong>Add to Home Screen</strong>.
+          On iOS, only Safari can install web apps. Open this page in Safari, then press
+          Share → <strong>Add to Home Screen</strong>.
         </p>
       )}
       {platform === 'macos-safari' && (


### PR DESCRIPTION
## Summary

Two fixes following mobile testing of #122:

1. **Bug: Chrome on desktop Mac was getting routed into the iOS install banner** ("open this page in Safari"). The iPadOS-detection heuristic was \`UA includes 'Mac' AND 'ontouchend' in document\`, but Chromium on desktop Mac exposes touch APIs by default regardless of hardware, so the second check false-positived. Replace with \`navigator.maxTouchPoints > 1\`, which reads actual hardware touch capability (5 on iPad, 0 on a regular Mac). iPadOS-pretending-to-be-Mac is still caught.

2. **Tighten iOS copy to action-first** per user feedback. Old: *"Install Mandao so your offline audio doesn't expire after a week: tap the Share button [icon] at the bottom, then Add to Home Screen."* New: *"Install Mandao: press the Share button [icon], then Add to Home Screen."* Same simplification in the iOS-other-browser and Settings copy.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] Desktop Chrome on Mac: install banner no longer shows iOS copy
- [ ] iPad (real, in Safari with desktop UA setting): still detected as iOS
- [ ] iPhone Safari: shorter, action-first copy renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)