### PR TITLE
Fix audio playback on iOS / mobile WebKit

### DIFF
--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -19,6 +19,7 @@ import {
 import {
   startStreamingRecognitionWithAudio,
   playBlob,
+  unlockAudio,
   type StreamingWithAudioHandle,
 } from '../services/audioRecording';
 import { getRecordingCapMs } from '../stores/audioCacheSettingsStore';
@@ -264,6 +265,7 @@ export function ReviewCard() {
   };
 
   const handlePlayRecording = () => {
+    unlockAudio();
     if (recordingBlob) playBlob(recordingBlob);
   };
 

--- a/src/components/SentenceAudioControls.tsx
+++ b/src/components/SentenceAudioControls.tsx
@@ -7,6 +7,7 @@ import {
   isAudioRecordingSupported,
   playBlob,
   startRecording,
+  unlockAudio,
   type RecordingHandle,
   type RecordingResult,
 } from '../services/audioRecording';
@@ -118,6 +119,10 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
   };
 
   const playRecording = async (rec: AudioRecording) => {
+    // Synchronously, inside the click gesture: unlock iOS audio before
+    // the async fetch can sever the gesture context.
+    unlockAudio();
+
     if (playingId === rec.id) { stopAll(); return; }
     if (downloadingId === rec.id) return;
     stopAll();

--- a/src/services/audioRecording.ts
+++ b/src/services/audioRecording.ts
@@ -226,22 +226,90 @@ export function formatDuration(ms: number | undefined): string {
 }
 
 /**
- * Play an audio blob. Returns a stop() function.
- * Revokes the object URL when playback ends or is stopped.
+ * Single shared Audio element for all blob playback.
+ *
+ * iOS Safari grants playback permission per-element on the first .play()
+ * within a user gesture, then allows subsequent plays on that element
+ * even when triggered after async work (e.g., await fetchAudioBlob).
+ * Creating a new Audio() per play would re-trigger the gesture check
+ * every time, which silently fails on iOS once the user-gesture context
+ * is lost across an `await`.
+ */
+let sharedAudio: HTMLAudioElement | null = null;
+let pendingObjectUrl: string | null = null;
+let audioUnlocked = false;
+
+function getSharedAudio(): HTMLAudioElement {
+  if (!sharedAudio) {
+    sharedAudio = new Audio();
+    sharedAudio.preload = 'auto';
+  }
+  return sharedAudio;
+}
+
+/** Tiny silent MP3 (~100 bytes) used to "unlock" iOS audio on first
+ *  interaction. iOS allows audio.play() inside a gesture, but only the
+ *  first one — after that the element stays unlocked for the page. */
+const SILENT_MP3 =
+  'data:audio/mpeg;base64,SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4Ljc2LjEwMAAAAAAAAAAAAAAA//tQAAAAAAAAAAAAAAAAAAAAAAASW5mbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+
+/**
+ * Call from inside a user-gesture handler (any click / touchstart) to
+ * unlock audio playback for the rest of the session. No-op after the
+ * first successful unlock. Safe to call repeatedly.
+ */
+export function unlockAudio(): void {
+  if (audioUnlocked) return;
+  const audio = getSharedAudio();
+  audio.muted = true;
+  audio.src = SILENT_MP3;
+  const p = audio.play();
+  // Older browsers return undefined; newer ones return a promise.
+  Promise.resolve(p)
+    .then(() => {
+      audio.pause();
+      audio.muted = false;
+      audio.removeAttribute('src');
+      audio.load();
+      audioUnlocked = true;
+    })
+    .catch(() => {
+      audio.muted = false;
+      // Wasn't a real gesture, or browser denied — try again next click.
+    });
+}
+
+/**
+ * Play an audio blob. Returns a stop() function. Revokes the object URL
+ * when playback ends or is stopped.
  */
 export function playBlob(blob: Blob, onEnded?: () => void): () => void {
+  const audio = getSharedAudio();
+  // Stop whatever is playing on the shared element.
+  try { audio.pause(); } catch {}
+  if (pendingObjectUrl) {
+    URL.revokeObjectURL(pendingObjectUrl);
+    pendingObjectUrl = null;
+  }
+
   const url = URL.createObjectURL(blob);
-  const audio = new Audio(url);
+  pendingObjectUrl = url;
+  audio.src = url;
+
   let stopped = false;
   const cleanup = () => {
     if (stopped) return;
     stopped = true;
-    URL.revokeObjectURL(url);
+    if (pendingObjectUrl === url) {
+      URL.revokeObjectURL(url);
+      pendingObjectUrl = null;
+    }
     onEnded?.();
   };
   audio.onended = cleanup;
   audio.onerror = cleanup;
   audio.play().catch(cleanup);
+
   return () => {
     try { audio.pause(); } catch {}
     cleanup();


### PR DESCRIPTION
## Summary

iOS Safari (and every iOS browser, since they all use WebKit) silently rejects \`audio.play()\` when the user-gesture context has been lost across an \`await\`. Our playback path was:

1. user clicks Play
2. \`await fetchAudioBlob(id)\` ← gesture lost
3. \`new Audio(url); audio.play()\` ← rejected silently, no sound

Manifested as: audio doesn't play on iPhone Safari or iPhone Chrome (web tab or installed PWA), but works fine on desktop where the gesture rule isn't enforced.

## Fix (both in \`src/services/audioRecording.ts\`)

1. **Single shared \`Audio\` element** across all blob playback. iOS grants playback permission per-element on the first \`.play()\` within a gesture; subsequent plays on the same element are allowed even after async work. Creating a fresh \`new Audio()\` per click was forcing a re-grant every time.
2. **\`unlockAudio()\`** plays a tiny silent MP3 data URL through the shared element. Called synchronously inside the click handler (\`SentenceAudioControls.playRecording\` and \`ReviewCard.handlePlayRecording\`) before the async \`fetchAudioBlob\`. The silent play primes iOS, then the real \`play()\` after the fetch is allowed.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] iPhone Safari: tap any audio recording → plays
- [ ] iPhone Safari (installed as PWA): same → plays
- [ ] iPhone Chrome: tap any audio recording → plays
- [ ] Desktop Chrome / Safari: regression check, still works
- [ ] Multiple recordings in succession on iPhone: all play, not just first

🤖 Generated with [Claude Code](https://claude.com/claude-code)