### PR TITLE
Audio Diagnostic card in Settings (mobile-friendly debugging)

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -19,6 +19,8 @@ import { importFromApkg, downloadApkgExport, analyzeApkg, type ApkgFieldInfo } f
 import * as repo from '../db/repo';
 import type { Deck } from '../db/schema';
 import { localDb } from '../db/localDb';
+import { supabase } from '../lib/supabase';
+import { AUDIO_BUCKET } from '../lib/audioStorage';
 import {
   useAudioCacheSettingsStore,
   RECORDING_CAP_SEC_MIN,
@@ -1317,6 +1319,9 @@ function DataSection() {
       {/* Offline audio cache */}
       <AudioCacheCard />
 
+      {/* Audio playback diagnostic */}
+      <AudioDiagnosticCard />
+
       {/* Install Mandao as a PWA */}
       <InstallCard />
 
@@ -1684,6 +1689,220 @@ function InstallCard() {
           <strong>Add to Dock…</strong>.
         </p>
       )}
+    </SectionCard>
+  );
+}
+
+// ────────────────────────────────────────────────────────────
+// Audio playback diagnostic
+// ────────────────────────────────────────────────────────────
+
+type DiagStatus = 'ok' | 'fail';
+interface DiagStep {
+  name: string;
+  status: DiagStatus;
+  detail: string;
+}
+
+const ERROR_CODE_NAMES: Record<number, string> = {
+  1: 'ABORTED',
+  2: 'NETWORK',
+  3: 'DECODE',
+  4: 'SRC_NOT_SUPPORTED',
+};
+
+function AudioDiagnosticCard() {
+  const [steps, setSteps] = useState<DiagStep[]>([]);
+  const [running, setRunning] = useState(false);
+
+  const run = async () => {
+    setRunning(true);
+    const out: DiagStep[] = [];
+    const push = (s: DiagStep) => {
+      out.push(s);
+      setSteps([...out]);
+    };
+
+    try {
+      // 1. Find a recording with a server-side path
+      const recs = await localDb.audioRecordings.toArray();
+      const rec =
+        recs.find((r) => r.storagePath && r.mimeType === 'audio/mpeg') ||
+        recs.find((r) => r.storagePath);
+      if (!rec || !rec.storagePath) {
+        push({
+          name: 'Find recording',
+          status: 'fail',
+          detail: `No recording with storagePath in local DB (${recs.length} total)`,
+        });
+        return;
+      }
+      push({
+        name: 'Find recording',
+        status: 'ok',
+        detail: `${rec.name} • ${rec.mimeType} • ${rec.storagePath}`,
+      });
+
+      // 2. Local cache lookup
+      const cached = await localDb.audioBlobs.get(rec.id);
+      push({
+        name: 'Local cache',
+        status: 'ok',
+        detail: cached
+          ? `Hit (${(cached.sizeBytes / 1024).toFixed(1)} KB cached)`
+          : 'Miss — will fetch from Storage',
+      });
+
+      // 3. Auth check
+      const { data: userData, error: userErr } = await supabase.auth.getUser();
+      if (userErr || !userData?.user) {
+        push({
+          name: 'Auth',
+          status: 'fail',
+          detail: userErr?.message || 'No signed-in user',
+        });
+        return;
+      }
+      push({
+        name: 'Auth',
+        status: 'ok',
+        detail: `Signed in as ${userData.user.id.slice(0, 8)}…`,
+      });
+
+      // 4. Signed URL generation
+      const t1 = performance.now();
+      const { data: urlData, error: urlErr } = await supabase.storage
+        .from(AUDIO_BUCKET)
+        .createSignedUrl(rec.storagePath, 60);
+      const t1Ms = Math.round(performance.now() - t1);
+      if (urlErr || !urlData?.signedUrl) {
+        push({
+          name: 'Signed URL',
+          status: 'fail',
+          detail: `${urlErr?.message || 'Empty response'} (${t1Ms}ms)`,
+        });
+        return;
+      }
+      push({
+        name: 'Signed URL',
+        status: 'ok',
+        detail: `Generated in ${t1Ms}ms`,
+      });
+
+      // 5. Network fetch
+      const t2 = performance.now();
+      let blob: Blob;
+      try {
+        const resp = await fetch(urlData.signedUrl);
+        const t2Ms = Math.round(performance.now() - t2);
+        if (!resp.ok) {
+          push({
+            name: 'Fetch bytes',
+            status: 'fail',
+            detail: `HTTP ${resp.status} ${resp.statusText} (${t2Ms}ms)`,
+          });
+          return;
+        }
+        blob = await resp.blob();
+        push({
+          name: 'Fetch bytes',
+          status: 'ok',
+          detail: `${(blob.size / 1024).toFixed(1)} KB • ${blob.type || '(no Content-Type)'} • ${t2Ms}ms`,
+        });
+      } catch (e) {
+        push({
+          name: 'Fetch bytes',
+          status: 'fail',
+          detail: e instanceof Error ? e.message : 'Network error',
+        });
+        return;
+      }
+
+      // 6. Decode test — try to load the blob into an Audio element
+      const url = URL.createObjectURL(blob);
+      const audio = new Audio(url);
+      const decodeResult = await new Promise<DiagStep>((resolve) => {
+        const cleanup = () => URL.revokeObjectURL(url);
+        audio.oncanplay = () => {
+          cleanup();
+          const dur = Number.isFinite(audio.duration) ? audio.duration.toFixed(2) : '?';
+          resolve({
+            name: 'Decode',
+            status: 'ok',
+            detail: `Playable (duration ${dur}s)`,
+          });
+        };
+        audio.onerror = () => {
+          cleanup();
+          const code = audio.error?.code;
+          const name = code ? ERROR_CODE_NAMES[code] || 'unknown' : 'no error info';
+          resolve({
+            name: 'Decode',
+            status: 'fail',
+            detail: `MediaError ${code ?? '?'} (${name})${audio.error?.message ? ' — ' + audio.error.message : ''}`,
+          });
+        };
+        // Timeout in case neither event fires (rare, but seen in some iOS versions)
+        setTimeout(() => {
+          cleanup();
+          resolve({
+            name: 'Decode',
+            status: 'fail',
+            detail: 'Timeout after 5s — neither canplay nor error fired',
+          });
+        }, 5000);
+      });
+      push(decodeResult);
+    } catch (e) {
+      push({
+        name: 'Diagnostic',
+        status: 'fail',
+        detail: e instanceof Error ? e.message : String(e),
+      });
+    } finally {
+      setRunning(false);
+    }
+  };
+
+  return (
+    <SectionCard
+      title="Audio Diagnostic"
+      description="Walks through the audio pipeline (auth, signed URL, fetch, decode) and reports each step's result. Useful when recordings won't play on a particular device."
+    >
+      <div className="space-y-3">
+        <button
+          onClick={() => {
+            setSteps([]);
+            run();
+          }}
+          disabled={running}
+          className="px-3 py-1.5 rounded-lg text-sm font-medium transition-colors disabled:opacity-50"
+          style={{ background: 'var(--accent)', color: 'var(--text-inverted)' }}
+        >
+          {running ? 'Running…' : 'Run diagnostic'}
+        </button>
+        {steps.length > 0 && (
+          <ol
+            className="text-xs font-mono space-y-1.5 p-3 rounded-lg"
+            style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+          >
+            {steps.map((s, i) => (
+              <li
+                key={i}
+                style={{
+                  color: s.status === 'fail' ? 'var(--danger, #e53e3e)' : 'var(--text-secondary)',
+                  wordBreak: 'break-word',
+                }}
+              >
+                <span style={{ fontWeight: 600 }}>
+                  {s.status === 'ok' ? '✓' : '✗'} {s.name}:
+                </span>{' '}
+                {s.detail}
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
     </SectionCard>
   );
 }


### PR DESCRIPTION
## Summary

Adds a self-service \"Audio Diagnostic\" card to **Settings → Data** so users can debug audio playback failures on devices where console access is hard or impossible (iOS Chrome especially).

When tapped, the diagnostic walks through:

1. **Find recording** — confirms a local \`audio_recordings\` row exists with a \`storagePath\`
2. **Local cache** — reports whether the bytes are already cached in \`audioBlobs\` (hit/miss)
3. **Auth** — confirms \`supabase.auth.getUser()\` returns a signed-in user
4. **Signed URL** — calls \`Storage.createSignedUrl\`, times the round-trip
5. **Fetch bytes** — downloads the blob via the signed URL; reports HTTP status, size, Content-Type, wall time
6. **Decode** — feeds the blob to a fresh \`Audio\` element and waits for \`canplay\` or \`error\`; reports \`MediaError\` codes by name (\`ABORTED\`/\`NETWORK\`/\`DECODE\`/\`SRC_NOT_SUPPORTED\`). 5-second timeout safety net.

Each step renders inline as it completes; failures go red. The whole result is screenshot-friendly so support requests can include the readout.

## Why

We couldn't pin down why iOS audio playback fails (works on desktop, fails on iPhone) without seeing the actual failure mode. Console access on iPhone Chrome doesn't exist; on iPhone Safari it requires plugging into a Mac. This card surfaces the same info as a one-tap action.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] Run the diagnostic on desktop (everything works) → all six steps green
- [ ] Run on iPhone Safari → identifies which step fails
- [ ] Run on iPhone Chrome → identifies which step fails
- [ ] No recordings case: graceful failure message at step 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)