### PR TITLE
Audio diagnostic: probe play() + switch unlock track to WAV

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -21,6 +21,7 @@ import type { Deck } from '../db/schema';
 import { localDb } from '../db/localDb';
 import { supabase } from '../lib/supabase';
 import { AUDIO_BUCKET } from '../lib/audioStorage';
+import { unlockAudio, isAudioUnlocked } from '../services/audioRecording';
 import {
   useAudioCacheSettingsStore,
   RECORDING_CAP_SEC_MIN,
@@ -1818,41 +1819,87 @@ function AudioDiagnosticCard() {
         return;
       }
 
-      // 6. Decode test — try to load the blob into an Audio element
+      // 6. Unlock check — were we able to prime audio for iOS?
+      push({
+        name: 'iOS audio unlock',
+        status: isAudioUnlocked() ? 'ok' : 'fail',
+        detail: isAudioUnlocked()
+          ? 'Shared Audio element is unlocked'
+          : 'unlockAudio() did not complete — silent priming failed',
+      });
+
+      // 7. Play test — actually call .play() (muted) and watch every
+      // relevant event. iOS deliberately doesn't fire `canplay` until
+      // play() is invoked, so the previous "decode" check would always
+      // time out on iOS even when audio works fine.
       const url = URL.createObjectURL(blob);
-      const audio = new Audio(url);
-      const decodeResult = await new Promise<DiagStep>((resolve) => {
-        const cleanup = () => URL.revokeObjectURL(url);
-        audio.oncanplay = () => {
-          cleanup();
+      const audio = new Audio();
+      audio.preload = 'auto';
+      audio.muted = true;
+      const events: string[] = [];
+      const trackedEvents = [
+        'loadstart',
+        'loadedmetadata',
+        'loadeddata',
+        'canplay',
+        'canplaythrough',
+        'play',
+        'playing',
+        'error',
+        'stalled',
+        'suspend',
+      ];
+      for (const evt of trackedEvents) {
+        audio.addEventListener(evt, () => events.push(evt));
+      }
+      audio.src = url;
+
+      const playResult = await new Promise<DiagStep>((resolve) => {
+        const cleanup = () => {
+          try { audio.pause(); } catch {/*noop*/}
+          URL.revokeObjectURL(url);
+        };
+        audio.addEventListener('playing', () => {
           const dur = Number.isFinite(audio.duration) ? audio.duration.toFixed(2) : '?';
-          resolve({
-            name: 'Decode',
-            status: 'ok',
-            detail: `Playable (duration ${dur}s)`,
-          });
-        };
-        audio.onerror = () => {
           cleanup();
-          const code = audio.error?.code;
-          const name = code ? ERROR_CODE_NAMES[code] || 'unknown' : 'no error info';
           resolve({
-            name: 'Decode',
-            status: 'fail',
-            detail: `MediaError ${code ?? '?'} (${name})${audio.error?.message ? ' — ' + audio.error.message : ''}`,
+            name: 'Play test',
+            status: 'ok',
+            detail: `Playing • duration ${dur}s • events: ${events.join(' → ')}`,
           });
-        };
-        // Timeout in case neither event fires (rare, but seen in some iOS versions)
+        });
+        audio.addEventListener('error', () => {
+          const code = audio.error?.code;
+          const name = code ? ERROR_CODE_NAMES[code] || 'unknown' : 'no info';
+          cleanup();
+          resolve({
+            name: 'Play test',
+            status: 'fail',
+            detail: `MediaError ${code ?? '?'} (${name}) • events: ${events.join(' → ') || 'none'}`,
+          });
+        });
+        const playPromise = audio.play();
+        if (playPromise && typeof playPromise.catch === 'function') {
+          playPromise.catch((e: unknown) => {
+            const err = e as { name?: string; message?: string };
+            cleanup();
+            resolve({
+              name: 'Play test',
+              status: 'fail',
+              detail: `play() rejected: ${err?.name ?? '?'} — ${err?.message ?? ''} • events: ${events.join(' → ') || 'none'}`,
+            });
+          });
+        }
         setTimeout(() => {
           cleanup();
           resolve({
-            name: 'Decode',
+            name: 'Play test',
             status: 'fail',
-            detail: 'Timeout after 5s — neither canplay nor error fired',
+            detail: `Timeout after 5s — events: ${events.join(' → ') || 'none'}`,
           });
         }, 5000);
       });
-      push(decodeResult);
+      push(playResult);
     } catch (e) {
       push({
         name: 'Diagnostic',
@@ -1872,6 +1919,10 @@ function AudioDiagnosticCard() {
       <div className="space-y-3">
         <button
           onClick={() => {
+            // Synchronously prime audio in the click gesture so the play
+            // step can succeed on iOS later (where async work between
+            // the click and audio.play() severs the gesture context).
+            unlockAudio();
             setSteps([]);
             run();
           }}

--- a/src/services/audioRecording.ts
+++ b/src/services/audioRecording.ts
@@ -247,11 +247,11 @@ function getSharedAudio(): HTMLAudioElement {
   return sharedAudio;
 }
 
-/** Tiny silent MP3 (~100 bytes) used to "unlock" iOS audio on first
- *  interaction. iOS allows audio.play() inside a gesture, but only the
- *  first one — after that the element stays unlocked for the page. */
-const SILENT_MP3 =
-  'data:audio/mpeg;base64,SUQzBAAAAAAAI1RTU0UAAAAPAAADTGF2ZjU4Ljc2LjEwMAAAAAAAAAAAAAAA//tQAAAAAAAAAAAAAAAAAAAAAAASW5mbwAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+/** Smallest valid silent WAV (~60 bytes). WAV is the most universally
+ *  decoded format on iOS — picky MP3 frame parsing is a known pitfall
+ *  for unlock-style data URLs, so we avoid it. */
+const SILENT_WAV =
+  'data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAVFYAAFRWAAABAAgAZGF0YQAAAAA=';
 
 /**
  * Call from inside a user-gesture handler (any click / touchstart) to
@@ -262,7 +262,7 @@ export function unlockAudio(): void {
   if (audioUnlocked) return;
   const audio = getSharedAudio();
   audio.muted = true;
-  audio.src = SILENT_MP3;
+  audio.src = SILENT_WAV;
   const p = audio.play();
   // Older browsers return undefined; newer ones return a promise.
   Promise.resolve(p)
@@ -277,6 +277,11 @@ export function unlockAudio(): void {
       audio.muted = false;
       // Wasn't a real gesture, or browser denied — try again next click.
     });
+}
+
+/** True after at least one successful unlock. Useful for diagnostics. */
+export function isAudioUnlocked(): boolean {
+  return audioUnlocked;
 }
 
 /**


### PR DESCRIPTION
## Summary

Following the on-phone diagnostic readout (\"Decode: Timeout after 5s — neither canplay nor error fired\"), two improvements:

1. **The previous \`canplay\`-based \"Decode\" check is meaningless on iOS.** iOS Safari deliberately doesn't load audio data until you call \`.play()\` (battery-saving lazy load), so \`canplay\` never fires from setting \`src\` alone. The diagnostic was asking a question iOS won't answer.

   Replace with a **\"Play test\"** that calls \`.play()\` (muted) and reports the full sequence of HTMLMediaElement events that fire — \`loadstart → loadedmetadata → loadeddata → canplay → playing\`, or whichever subset. Distinguishes:
   - \`playing\` event → codec OK, audio works
   - \`error\` event → \`MediaError\` code by name (DECODE / SRC_NOT_SUPPORTED / etc.)
   - \`play()\` rejection → \`NotAllowedError\` (gesture issue) or similar
   - Timeout with event list → identifies which stage hung

2. **Switch \`unlockAudio()\` priming track from MP3 to WAV.** iOS has known issues parsing tiny MP3 frame data URLs; WAV decodes reliably at any size. The previous priming might have been silently failing on iOS, leaving the shared Audio element locked. Adds an \"iOS audio unlock\" step to the diagnostic so we can see whether priming actually succeeded.

The diagnostic button now also calls \`unlockAudio()\` synchronously in the click handler so the play step has gesture context.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] Desktop: all seven steps green; play test reports event sequence
- [ ] iPhone Safari: identifies real failure mode (most likely either unlock fails, or play() rejects with NotAllowedError, or error event fires with a MediaError code)
- [ ] iPhone Chrome: same

🤖 Generated with [Claude Code](https://claude.com/claude-code)