### PR TITLE
Drop unlockAudio() from play handlers — was the iOS bug

### DIFF
--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -19,7 +19,6 @@ import {
 import {
   startStreamingRecognitionWithAudio,
   playBlob,
-  unlockAudio,
   type StreamingWithAudioHandle,
 } from '../services/audioRecording';
 import { getRecordingCapMs } from '../stores/audioCacheSettingsStore';
@@ -265,7 +264,6 @@ export function ReviewCard() {
   };
 
   const handlePlayRecording = () => {
-    unlockAudio();
     if (recordingBlob) playBlob(recordingBlob);
   };
 

--- a/src/components/SentenceAudioControls.tsx
+++ b/src/components/SentenceAudioControls.tsx
@@ -7,7 +7,6 @@ import {
   isAudioRecordingSupported,
   playBlob,
   startRecording,
-  unlockAudio,
   type RecordingHandle,
   type RecordingResult,
 } from '../services/audioRecording';
@@ -135,16 +134,18 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
     setPlayingId((cur) => (cur === 'default' ? null : cur));
   };
 
-  // Synchronous when the blob is already in blobMap (the common case after
-  // the eager load on mount). This keeps the click → audio.play() chain
-  // inside iOS's user-gesture context. Falls back to async fetch only if
-  // the eager load hasn't finished yet — in which case we'd lose the
-  // gesture, but at least desktop and the second tap will work.
+  // Synchronous when the blob is already in blobMap (the common case
+  // after the eager load on mount). The click → audio.play() chain stays
+  // inside iOS's user-gesture context and uses the blob URL as the FIRST
+  // play of the shared element — iOS authorizes it on first sight.
+  //
+  // We deliberately do NOT call unlockAudio() here: it sets src to
+  // /silent.mp3 and starts a play, then this function immediately
+  // overrides src and starts another play. iOS rejects the rapid
+  // src-swap-mid-load and never authorizes the element. Without
+  // unlockAudio, the first thing iOS sees on this element is the user's
+  // blob play, which it accepts cleanly.
   const playRecording = (rec: AudioRecording) => {
-    // Belt-and-suspenders: prime the shared Audio element on iOS in case
-    // the synchronous path falls through to async.
-    unlockAudio();
-
     if (playingId === rec.id) { stopAll(); return; }
     stopAll();
 


### PR DESCRIPTION
## Summary

Diagnostic data: \"Test play (real path)\" plays audio successfully on iPhone, while Browse / Cards using the same \`playBlob\` on the same shared Audio element doesn't. The asymmetry isn't in the underlying audio code — it's in the call **sequence**.

### Test play (works on iPhone)

\`\`\`ts
unlockAudio();                      // sync: audio.src='/silent.mp3', audio.play()
void (async () => {
  await ...;                        // Dexie reads — silent.mp3 has time to load
  playBlob(blob);                   // changes src, plays
})();
\`\`\`

### Browse playRecording (fails on iPhone)

\`\`\`ts
unlockAudio();                      // sync: audio.src='/silent.mp3', audio.play()
playBlob(blob);                     // IMMEDIATELY: pause(), src=blobUrl, play()
\`\`\`

iOS rejects the rapid src-swap-mid-load. silent.mp3 never gets through enough of its play to authorize the element (its play is canceled before \`playing\` fires), and the immediate blob \`play()\` in the same gesture is treated as if no prior gesture authorization existed.

## Fix

Don't call \`unlockAudio()\` at all from the play handlers. Let \`playBlob\`'s \`audio.play()\` with the user's blob URL be the **first** play of the shared element in this gesture — iOS sees a clean \`click → audio.src=blobUrl; audio.play()\`, exactly the pattern it accepts.

\`unlockAudio()\` itself is kept (still useful for the diagnostic and for any future call site that wants to pre-warm the element); just no longer called inline before each play.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] Desktop: regression check, audio still plays
- [ ] iPhone Safari: tap Anki recording in Browse → plays
- [ ] iPhone Chrome: tap Anki recording in Browse → plays
- [ ] iPhone Safari: tap recording during card review → plays

🤖 Generated with [Claude Code](https://claude.com/claude-code)