### PR TITLE
Stop click bubbling out of SentenceAudioControls (fixes Browse audio)

### DIFF
--- a/src/components/SentenceAudioControls.tsx
+++ b/src/components/SentenceAudioControls.tsx
@@ -264,7 +264,15 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
   const defaultActive = playingId === 'default';
 
   return (
-    <div className={`inline-flex flex-col items-center gap-1 ${className}`}>
+    <div
+      className={`inline-flex flex-col items-center gap-1 ${className}`}
+      // Stop click bubbling: parents like BrowsePage wrap the whole sentence
+      // row in a `<button>` whose onClick toggles expansion. Without this,
+      // tapping a play / record button inside us would also fire the parent
+      // collapse handler, which unmounts this component and triggers our
+      // useEffect cleanup — pausing audio milliseconds after it starts.
+      onClick={(e) => e.stopPropagation()}
+    >
       <div className="inline-flex flex-wrap items-start justify-center gap-3">
         {/* Default Google TTS */}
         <div className="flex flex-col items-center">


### PR DESCRIPTION
## Summary

The bug behind every previous failed fix attempt for mobile audio.

## Diagnosis

After many false starts, the diagnostic data lined up:

1. \"Test play (real path)\" played audio successfully on iPhone
2. \"Test play (no unlock, sync)\" — the diagnostic that mirrors Browse's exact code path — **also worked** on iPhone
3. So \`playBlob\` and the shared Audio element are fine on iPhone
4. User reported the play icon visibly **blinks red → speaker** on tap

The blink means \`playRecording\` IS firing \`setPlayingId(rec.id)\`, then \`setPlayingId(null)\` runs almost immediately. \`setPlayingId(null)\` only happens via \`playBlob\`'s \`onEnded\` callback, which fires from \`cleanup\`, which runs when the stop-fn returned by \`playBlob\` is called.

Who's calling that stop fn during a fresh tap?

## The actual bug

\`BrowsePage\` wraps each sentence row in:

\`\`\`jsx
<button onClick={() => handleExpand(s.id)}>      // <-- the entire row is one big button
  ... sentence content ...
</button>
{expandedId === s.id && (
  <div>
    ...
    <SentenceAudioControls sentenceId={s.id} ... />  // <-- mounted only while expanded
  </div>
)}
\`\`\`

When the user taps a play button inside \`SentenceAudioControls\`:

1. The click bubbles up to the outer row \`<button>\`
2. \`handleExpand\` runs → since the row is *already* expanded, it toggles closed
3. \`expandedId\` becomes \`null\`, the conditional unmounts the inner panel
4. \`SentenceAudioControls\`'s \`useEffect\` cleanup fires → \`stopPlaybackRef.current?.()\`
5. That calls \`audio.pause()\` + \`onEnded\` → \`setPlayingId(null)\` → icon flips back

All within milliseconds. The audio is canceled before the user hears it.

## Why each previous fix missed this

- \`unlockAudio\` tweaks (silent WAV, real MP3, removed entirely) — bug is in the parent, not the audio code
- Synchronous \`blobMap\` (PR #129) — same, the fast-path was never the issue
- Muted-then-unmute — same
- Browser DevTools wouldn't have helped much either: the cleanup fires *correctly*, just at the wrong time

The diagnostic \"Test play\" buttons worked because **they're not inside a parent that collapses on click**. Same code path, different parent — opposite outcome.

## Fix

Wrap the rendered output of \`SentenceAudioControls\` in a single \`<div onClick={(e) => e.stopPropagation()}>\`. All click events inside the component stay local; the parent row button no longer collapses on inner taps. Audio plays through normally.

## Why this didn't break desktop

Desktop browsers complete more of the audio playback before the unmount cleanup interrupts it (faster decode, less aggressive teardown), so users got at least a partial fragment of audio — enough to hear something. Mobile WebKit cancels audio more aggressively on element pause, so the same bug produced silence.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] iPhone Safari: tap Anki recording in Browse → plays through
- [ ] iPhone Chrome: tap Anki recording in Browse → plays through
- [ ] Desktop: regression check, audio still plays
- [ ] Tapping the row outside the play button still expands/collapses normally
- [ ] Cards (review): tap recording during review → plays through

🤖 Generated with [Claude Code](https://claude.com/claude-code)