### PR TITLE
Skip speechSynthesis.cancel() when no speech active (fixes mobile audio)

### DIFF
--- a/src/components/SentenceAudioControls.tsx
+++ b/src/components/SentenceAudioControls.tsx
@@ -120,7 +120,18 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
   const stopAll = () => {
     stopPlaybackRef.current?.();
     stopPlaybackRef.current = null;
-    stopSpeaking();
+    // Only cancel speechSynthesis when there's actually speech to cancel.
+    // Calling speechSynthesis.cancel() on iOS — even with no active
+    // speech — briefly resets the shared audio session, which aborts a
+    // freshly-started HTMLMediaElement playback. That was silencing
+    // every Browse / Cards recording tap on iPhone.
+    if (
+      typeof window !== 'undefined' &&
+      window.speechSynthesis &&
+      (window.speechSynthesis.speaking || window.speechSynthesis.pending)
+    ) {
+      stopSpeaking();
+    }
     setPlayingId(null);
   };
 


### PR DESCRIPTION
## Summary

Real bug this time, isolated by the diagnostic.

**Test result:** \"Test play (no unlock, sync)\" works on iPhone. That diagnostic mirrors Browse's exact play code path — same \`playBlob\` on the same shared Audio element, no \`unlockAudio\`, no awaits. So \`playBlob\` itself works fine on iOS.

**The difference:** Browse's \`playRecording\` calls \`stopAll()\` before \`playBlob\`. \`stopAll()\` calls \`stopSpeaking()\` → \`speechSynthesis.cancel()\` — **every time, even on first tap when nothing is speaking**. The diagnostic doesn't.

## Why that matters on iOS

iOS WebKit's \`speechSynthesis\` and \`HTMLMediaElement\` share the same audio output session. \`speechSynthesis.cancel()\` causes the system to briefly reset that session, even when there's no active speech. A freshly-started \`audio.play()\` on a blob URL gets aborted during the reset window. Result: the user sees the play icon flick to stop and back to play within milliseconds (\`playBlob\`'s \`.catch(cleanup)\` runs → \`onEnded\` → \`setPlayingId(null)\`).

## Fix

Gate the cancel: only call \`stopSpeaking()\` when \`speechSynthesis.speaking || speechSynthesis.pending\` is true. On a fresh tap with no active TTS, skip it — iOS doesn't bounce the audio session, and the blob play succeeds.

## Note on PR #133

PR #133 (stopPropagation) was based on a wrong reading of the JSX — \`SentenceAudioControls\` is a sibling of BrowsePage's row button, not nested inside it, so click-bubbling to the row was never happening. The stopPropagation change is harmless defensive code so I'm leaving it in place.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] iPhone Safari: tap Anki recording in Browse → plays through cleanly
- [ ] iPhone Chrome: tap Anki recording in Browse → plays through cleanly
- [ ] After playing default TTS first, then tapping a recording: TTS still gets canceled, recording plays
- [ ] Desktop: regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)