### PR TITLE
Add ?audioDebug=1 floating overlay for mobile audio diagnosis

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { ThemeToggle } from './components/ThemeToggle';
 import { SyncIndicator } from './components/SyncIndicator';
 import { SyncErrorBanner } from './components/SyncErrorBanner';
 import { InstallBanner } from './components/InstallBanner';
+import { AudioDebugOverlay } from './components/AudioDebugOverlay';
 import { useTutorialStore } from './stores/tutorialStore';
 import { useAuthStore } from './stores/authStore';
 import './stores/themeStore';
@@ -172,6 +173,7 @@ function App() {
           <Route path="/auth/callback" element={<Navigate to="/" replace />} />
           <Route path="/reset-password" element={<Navigate to="/" replace />} />
         </Routes>
+        <AudioDebugOverlay />
       </div>
     </BrowserRouter>
   );

--- a/src/components/AudioDebugOverlay.tsx
+++ b/src/components/AudioDebugOverlay.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from 'react';
+import {
+  audioDebugEnabled,
+  getAudioDebugLog,
+  subscribeAudioDebug,
+  clearAudioDebugLog,
+} from '../services/audioRecording';
+
+/**
+ * Floating overlay that surfaces every audio playback event in real
+ * time. Activated by visiting any URL with `?audioDebug=1` once
+ * (sticky for the rest of the session via sessionStorage).
+ *
+ * Mounted at the app root so it stays visible across navigation —
+ * tap a recording in Browse, see the events live without DevTools.
+ * Removed for production once the bug is identified.
+ */
+export function AudioDebugOverlay() {
+  const [enabled, setEnabled] = useState(audioDebugEnabled);
+  const [log, setLog] = useState<string[]>(getAudioDebugLog);
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    setEnabled(audioDebugEnabled());
+    if (!audioDebugEnabled()) return;
+    const refresh = () => setLog(getAudioDebugLog());
+    refresh();
+    return subscribeAudioDebug(refresh);
+  }, []);
+
+  if (!enabled) return null;
+
+  return (
+    <div
+      className="fixed z-[9999] text-xs font-mono"
+      style={{
+        bottom: 8,
+        left: 8,
+        right: 8,
+        maxHeight: collapsed ? 28 : '40vh',
+        overflow: 'hidden',
+        background: 'rgba(0, 0, 0, 0.85)',
+        color: '#9eff9e',
+        border: '1px solid #444',
+        borderRadius: 4,
+        padding: '2px 6px',
+      }}
+    >
+      <div className="flex items-center justify-between" style={{ color: '#fff', borderBottom: collapsed ? 'none' : '1px solid #333', paddingBottom: 2, marginBottom: collapsed ? 0 : 2 }}>
+        <span>audio debug ({log.length})</span>
+        <span className="flex gap-2">
+          <button onClick={() => clearAudioDebugLog()} style={{ color: '#aaa' }}>clear</button>
+          <button onClick={() => setCollapsed((c) => !c)} style={{ color: '#aaa' }}>
+            {collapsed ? '▲' : '▼'}
+          </button>
+        </span>
+      </div>
+      {!collapsed && (
+        <div style={{ overflowY: 'auto', maxHeight: 'calc(40vh - 24px)' }}>
+          {log.length === 0 ? (
+            <div style={{ color: '#666' }}>(no events yet — tap a play button)</div>
+          ) : (
+            log.map((line, i) => (
+              <div key={i} style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>{line}</div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SentenceAudioControls.tsx
+++ b/src/components/SentenceAudioControls.tsx
@@ -7,6 +7,7 @@ import {
   isAudioRecordingSupported,
   playBlob,
   startRecording,
+  audioDebugPush,
   type RecordingHandle,
   type RecordingResult,
 } from '../services/audioRecording';
@@ -104,9 +105,11 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
   };
 
   useEffect(() => {
+    audioDebugPush(`SentenceAudioControls mount/effect for ${sentenceId.slice(0, 8)}`);
     const cancelledRef = { current: false };
     loadRecordingsAndBlobs(cancelledRef);
     return () => {
+      audioDebugPush(`SentenceAudioControls UNMOUNT/cleanup for ${sentenceId.slice(0, 8)} — calling stopPlaybackRef`);
       cancelledRef.current = true;
       stopPlaybackRef.current?.();
       stopSpeaking();
@@ -157,6 +160,7 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
   // unlockAudio, the first thing iOS sees on this element is the user's
   // blob play, which it accepts cleanly.
   const playRecording = (rec: AudioRecording) => {
+    audioDebugPush(`playRecording clicked: ${rec.name} (${rec.id.slice(0, 8)}); playingId=${playingId}; blobMap has ${blobMap.size} entries; cached=${blobMap.has(rec.id)}`);
     if (playingId === rec.id) { stopAll(); return; }
     stopAll();
 

--- a/src/services/audioRecording.ts
+++ b/src/services/audioRecording.ts
@@ -261,6 +261,55 @@ export function _getSharedAudioForDiagnostic(): HTMLAudioElement {
   return getSharedAudio();
 }
 
+/** Global debug log buffer. Populated when ?audioDebug=1 is on the URL.
+ *  A debug overlay reads this to show what's happening during playback. */
+const DEBUG_RING_SIZE = 200;
+const debugLog: string[] = [];
+const debugListeners = new Set<() => void>();
+
+function isDebugEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  if (sessionStorage.getItem('mandao_audio_debug') === '1') return true;
+  if (new URLSearchParams(window.location.search).get('audioDebug') === '1') {
+    sessionStorage.setItem('mandao_audio_debug', '1');
+    return true;
+  }
+  return false;
+}
+
+function debugPush(line: string) {
+  if (!isDebugEnabled()) return;
+  const stamp = new Date().toLocaleTimeString().slice(-8) + '.' + String(Date.now() % 1000).padStart(3, '0');
+  debugLog.push(`[${stamp}] ${line}`);
+  if (debugLog.length > DEBUG_RING_SIZE) debugLog.shift();
+  for (const cb of debugListeners) { try { cb(); } catch { /* noop */ } }
+}
+
+export function getAudioDebugLog(): string[] {
+  return debugLog.slice();
+}
+
+export function clearAudioDebugLog() {
+  debugLog.length = 0;
+  for (const cb of debugListeners) { try { cb(); } catch { /* noop */ } }
+}
+
+export function subscribeAudioDebug(cb: () => void): () => void {
+  debugListeners.add(cb);
+  return () => debugListeners.delete(cb);
+}
+
+export function audioDebugEnabled(): boolean {
+  return isDebugEnabled();
+}
+
+/** Write a line to the audio debug log when ?audioDebug=1 is set. No-op
+ *  in normal operation. Called from SentenceAudioControls and similar
+ *  to surface what's happening alongside playBlob's own events. */
+export function audioDebugPush(line: string): void {
+  debugPush(line);
+}
+
 /** Real 50ms silent-amplitude MP3 served from /public. iOS plays it
  *  successfully and the user hears nothing. */
 const SILENT_MP3_URL = '/silent.mp3';
@@ -296,6 +345,8 @@ export function isAudioUnlocked(): boolean {
  */
 export function playBlob(blob: Blob, onEnded?: () => void): () => void {
   const audio = getSharedAudio();
+  debugPush(`playBlob() called — blob ${blob.size}B ${blob.type}; element paused=${audio.paused} muted=${audio.muted}`);
+
   // Stop whatever is playing on the shared element.
   try { audio.pause(); } catch { /* noop */ }
   if (pendingObjectUrl) {
@@ -307,10 +358,36 @@ export function playBlob(blob: Blob, onEnded?: () => void): () => void {
   pendingObjectUrl = url;
   audio.src = url;
 
+  // Hook every interesting event when debug is on.
+  let trackedListeners: Array<{ type: string; fn: EventListener }> | null = null;
+  if (audioDebugEnabled()) {
+    trackedListeners = [];
+    const events = ['loadstart', 'loadedmetadata', 'loadeddata', 'canplay', 'play', 'playing', 'pause', 'ended', 'error', 'stalled', 'suspend', 'abort', 'emptied'];
+    for (const evt of events) {
+      const fn = () => {
+        let detail = '';
+        if (evt === 'error') {
+          const code = audio.error?.code;
+          detail = ` (MediaError ${code})`;
+        }
+        if (evt === 'pause') {
+          detail = ` (currentTime=${audio.currentTime.toFixed(2)}s)`;
+        }
+        debugPush(`event: ${evt}${detail}`);
+      };
+      audio.addEventListener(evt, fn);
+      trackedListeners.push({ type: evt, fn });
+    }
+  }
+
   let stopped = false;
   const cleanup = () => {
     if (stopped) return;
     stopped = true;
+    debugPush(`cleanup() — currentTime=${audio.currentTime.toFixed(2)}s readyState=${audio.readyState}`);
+    if (trackedListeners) {
+      for (const l of trackedListeners) audio.removeEventListener(l.type, l.fn);
+    }
     if (pendingObjectUrl === url) {
       URL.revokeObjectURL(url);
       pendingObjectUrl = null;
@@ -319,9 +396,16 @@ export function playBlob(blob: Blob, onEnded?: () => void): () => void {
   };
   audio.onended = cleanup;
   audio.onerror = cleanup;
-  audio.play().catch(cleanup);
+  audio.play()
+    .then(() => debugPush(`audio.play() resolved`))
+    .catch((e: unknown) => {
+      const err = e as { name?: string; message?: string };
+      debugPush(`audio.play() rejected: ${err?.name ?? '?'} ${err?.message ?? ''}`);
+      cleanup();
+    });
 
   return () => {
+    debugPush(`stop() called externally`);
     try { audio.pause(); } catch { /* noop */ }
     cleanup();
   };


### PR DESCRIPTION
## Summary

After several wrong theories about why mobile audio fails in Browse / Cards, switch from theorizing to direct instrumentation: a debug log baked into the actual production code path, surfaced via a floating overlay visible on every page when \`?audioDebug=1\` is on the URL.

## How to use

1. Visit any page with \`?audioDebug=1\` once (e.g. \`https://your-app.app/?audioDebug=1\`). The flag is sticky via \`sessionStorage\` for the rest of the tab's session, so navigation back to Browse / Cards keeps it on.
2. A small black overlay appears at the bottom of every page.
3. Tap a recording's play button.
4. Read the event log live, or screenshot it.

## What gets logged

- \`SentenceAudioControls\` mount/unmount (catches the cleanup-eats-playback theory)
- \`playRecording\` click + state (playingId, blobMap size, whether tapped recording is cached)
- \`playBlob\` entry + element state (paused, muted, src)
- Every HTMLMediaElement event during playback: \`loadstart\`, \`loadedmetadata\`, \`canplay\`, \`play\`, \`playing\`, \`pause\`, \`ended\`, \`error\`, \`stalled\`, \`suspend\`, \`abort\`, \`emptied\` — with timing, currentTime, and MediaError code where relevant
- \`play()\` promise resolution / rejection (with error name + message)
- \`cleanup()\` with currentTime / readyState — tells us *which* path fired the cleanup
- External \`stop()\` calls

## Why a debug overlay vs. more theory

Three of my last five PRs fixed the wrong thing. This eliminates guessing — once we see the actual failure events on iPhone, the real bug is obvious. No more dart-throwing.

## After we identify the bug

Will gate the overlay behind a build flag (or remove entirely) once the underlying issue is fixed. The plumbing in \`audioRecording.ts\` is small enough to leave behind for future debugging.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] Visit production with \`?audioDebug=1\`, tap a recording in Browse, paste back the event log

🤖 Generated with [Claude Code](https://claude.com/claude-code)