### PR TITLE
Settings toggle for the audio debug overlay

### DIFF
--- a/src/components/AudioDebugOverlay.tsx
+++ b/src/components/AudioDebugOverlay.tsx
@@ -21,10 +21,13 @@ export function AudioDebugOverlay() {
   const [collapsed, setCollapsed] = useState(false);
 
   useEffect(() => {
-    setEnabled(audioDebugEnabled());
-    if (!audioDebugEnabled()) return;
-    const refresh = () => setLog(getAudioDebugLog());
+    const refresh = () => {
+      setEnabled(audioDebugEnabled());
+      setLog(getAudioDebugLog());
+    };
     refresh();
+    // subscribeAudioDebug fires on both log events AND when
+    // setAudioDebugEnabled toggles, so we re-check enabled state too.
     return subscribeAudioDebug(refresh);
   }, []);
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -26,6 +26,8 @@ import {
   isAudioUnlocked,
   playBlob,
   _getSharedAudioForDiagnostic,
+  audioDebugEnabled,
+  setAudioDebugEnabled,
 } from '../services/audioRecording';
 import {
   useAudioCacheSettingsStore,
@@ -1722,6 +1724,7 @@ function AudioDiagnosticCard() {
   const [running, setRunning] = useState(false);
   const [realPathLog, setRealPathLog] = useState<string[]>([]);
   const [realPathRunning, setRealPathRunning] = useState(false);
+  const [debugOn, setDebugOn] = useState(audioDebugEnabled);
   // Eagerly-loaded blob mirrors how SentenceAudioControls populates its
   // blobMap on mount, so the "no unlock, sync" test can reproduce the
   // exact synchronous code path that fails in Browse.
@@ -2083,6 +2086,28 @@ function AudioDiagnosticCard() {
       description="Walks through the audio pipeline (auth, signed URL, fetch, decode) and reports each step's result. Useful when recordings won't play on a particular device."
     >
       <div className="space-y-3">
+        <div
+          className="flex items-center justify-between p-2 rounded"
+          style={{ background: 'var(--bg-inset)' }}
+        >
+          <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+            Floating debug overlay (live audio events)
+          </span>
+          <button
+            onClick={() => {
+              setAudioDebugEnabled(!debugOn);
+              setDebugOn(!debugOn);
+            }}
+            className="px-2.5 py-1 rounded text-xs font-medium transition-colors"
+            style={{
+              background: debugOn ? 'var(--danger, #e53e3e)' : 'var(--accent)',
+              color: 'var(--text-inverted)',
+            }}
+          >
+            {debugOn ? 'Disable' : 'Enable'}
+          </button>
+        </div>
+
         <button
           onClick={() => {
             // Synchronously prime audio in the click gesture so the play

--- a/src/services/audioRecording.ts
+++ b/src/services/audioRecording.ts
@@ -310,6 +310,15 @@ export function audioDebugPush(line: string): void {
   debugPush(line);
 }
 
+/** Imperative toggle for the floating audio debug overlay. Flipping
+ *  this from a button bypasses the URL-flag friction on mobile. */
+export function setAudioDebugEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  if (enabled) sessionStorage.setItem('mandao_audio_debug', '1');
+  else sessionStorage.removeItem('mandao_audio_debug');
+  for (const cb of debugListeners) { try { cb(); } catch { /* noop */ } }
+}
+
 /** Real 50ms silent-amplitude MP3 served from /public. iOS plays it
  *  successfully and the user hears nothing. */
 const SILENT_MP3_URL = '/silent.mp3';


### PR DESCRIPTION
## Summary

URL-flag activation (\`?audioDebug=1\`) is friction-prone on mobile — easy to typo as \`&audioDebug=1\` without a leading \`?\`, which makes react-router match no route and the page goes blank below the top bar.

Add a button toggle in Settings → Audio Diagnostic that flips the same \`sessionStorage\` flag. Tap once, overlay appears live (no reload). Tap again, it disappears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)