### PR TITLE
playBlob: hard-reset shared Audio element before new src (fixes iOS NotSupportedError)

### DIFF
--- a/src/services/audioRecording.ts
+++ b/src/services/audioRecording.ts
@@ -356,8 +356,18 @@ export function playBlob(blob: Blob, onEnded?: () => void): () => void {
   const audio = getSharedAudio();
   debugPush(`playBlob() called — blob ${blob.size}B ${blob.type}; element paused=${audio.paused} muted=${audio.muted}`);
 
-  // Stop whatever is playing on the shared element.
+  // Bring the element fully back to a clean state before assigning a
+  // new source. iOS Safari rejects subsequent plays with
+  // NotSupportedError when the element's prior src was set (and
+  // especially after the previous URL was revoked) — the transition
+  // from the old src to the new one trips an internal "source isn't
+  // ready" check that surfaces as the play() promise rejecting. The
+  // remove+load pair forces the element to discard the old source
+  // synchronously so the new src is the only thing in flight.
   try { audio.pause(); } catch { /* noop */ }
+  audio.removeAttribute('src');
+  try { audio.load(); } catch { /* noop */ }
+
   if (pendingObjectUrl) {
     URL.revokeObjectURL(pendingObjectUrl);
     pendingObjectUrl = null;


### PR DESCRIPTION
## Summary

Actual bug, finally caught by the live debug overlay on iPhone. The event log showed:

\`\`\`
event: emptied
event: play
event: loadstart
audio.play() rejected: NotSupportedError
\`\`\`

When the shared \`Audio\` element had a prior \`src\` (from any earlier play — the diagnostic test, the default TTS button, etc.), assigning a new \`src\` fired an \`emptied\` event for the old source. iOS Safari then rejected the \`play()\` with \`NotSupportedError\` because the element was caught in a transitional state — the old (often already-revoked) blob URL's internal cleanup was still in flight when the new \`play()\` ran.

The reason \"Test play (no unlock, sync)\" worked: it was the *first* play after page load. No prior src, no emptied event, clean transition. Browse always had a prior src from something else, so it always hit the bug.

## Fix

Bring the element to a clean state before assigning the new src:

\`\`\`ts
try { audio.pause(); } catch {}
audio.removeAttribute('src');
try { audio.load(); } catch {}
// ...then assign new url
\`\`\`

\`removeAttribute('src') + load()\` synchronously discards the old source so the new src is the only thing in flight when \`play()\` runs.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] iPhone Safari: tap recording in Browse after running diagnostic → plays
- [ ] iPhone Chrome: same
- [ ] Multiple successive plays on iPhone: all work
- [ ] Desktop: regression check

🤖 Generated with [Claude Code](https://claude.com/claude-code)