### PR TITLE
Audio debug: sniff blob format + surface MediaError code

### DIFF
--- a/src/services/audioRecording.ts
+++ b/src/services/audioRecording.ts
@@ -352,9 +352,64 @@ export function isAudioUnlocked(): boolean {
  * Play an audio blob. Returns a stop() function. Revokes the object URL
  * when playback ends or is stopped.
  */
+const MEDIA_ERROR_NAMES: Record<number, string> = {
+  1: 'ABORTED',
+  2: 'NETWORK',
+  3: 'DECODE',
+  4: 'SRC_NOT_SUPPORTED',
+};
+
+/** Inspect the first ~32 bytes of a blob to identify the actual file
+ *  format. Catches the common case where Anki imports stamp every
+ *  unknown extension as `audio/mpeg` but the bytes are really Ogg /
+ *  AAC / M4A / etc. — iOS rejects any of those with NotSupportedError
+ *  while desktop browsers are forgiving and decode them anyway. */
+function sniffAudioFormat(b: Uint8Array): string {
+  if (b.length < 4) return 'too-short';
+  if (b[0] === 0x49 && b[1] === 0x44 && b[2] === 0x33) return 'mp3 (ID3v2)';
+  if (b[0] === 0xff && (b[1] & 0xe0) === 0xe0) {
+    // MPEG sync: layer bits distinguish MP3 (layer III, layer ≠ 0) from
+    // ADTS-AAC (layer = 0).
+    const layer = (b[1] >> 1) & 0x03;
+    return layer === 0 ? 'aac (ADTS)' : 'mp3 (MPEG audio)';
+  }
+  if (b.length >= 8 && b[4] === 0x66 && b[5] === 0x74 && b[6] === 0x79 && b[7] === 0x70) return 'mp4/m4a (ftyp)';
+  if (b[0] === 0x4f && b[1] === 0x67 && b[2] === 0x67 && b[3] === 0x53) return 'ogg (Vorbis/Opus/Speex)';
+  if (b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46) return 'wav (RIFF)';
+  if (b[0] === 0x66 && b[1] === 0x4c && b[2] === 0x61 && b[3] === 0x43) return 'flac';
+  if (b[0] === 0x1a && b[1] === 0x45 && b[2] === 0xdf && b[3] === 0xa3) return 'webm/matroska';
+  return 'unknown';
+}
+
 export function playBlob(blob: Blob, onEnded?: () => void): () => void {
   const audio = getSharedAudio();
   debugPush(`playBlob() called — blob ${blob.size}B ${blob.type}; element paused=${audio.paused} muted=${audio.muted}`);
+
+  // Sniff first 32 bytes asynchronously and log the detected format.
+  // Fire-and-forget — we MUST NOT await before audio.play(), or iOS
+  // gesture context is lost. The log line lands a few ms after the
+  // play attempt; that's fine for diagnosis.
+  if (audioDebugEnabled()) {
+    blob.slice(0, 32).arrayBuffer().then((buf) => {
+      const b = new Uint8Array(buf);
+      const hex = Array.from(b, (x) => x.toString(16).padStart(2, '0')).join(' ');
+      const detected = sniffAudioFormat(b);
+      const claimed = blob.type || '(none)';
+      debugPush(`bytes[0..32]: ${hex}`);
+      debugPush(`format: claimed=${claimed} actual=${detected}`);
+      const expectedPrefix =
+        claimed === 'audio/mpeg' ? 'mp3'
+        : claimed === 'audio/mp4' ? 'mp4'
+        : claimed === 'audio/ogg' ? 'ogg'
+        : claimed === 'audio/wav' ? 'wav'
+        : claimed === 'audio/flac' ? 'flac'
+        : claimed === 'audio/webm' ? 'webm'
+        : '';
+      if (expectedPrefix && !detected.startsWith(expectedPrefix)) {
+        debugPush(`WARNING: MIME/format mismatch — iOS will likely reject this blob`);
+      }
+    }).catch((e) => debugPush(`byte sniff failed: ${(e as Error).message}`));
+  }
 
   // Bring the element fully back to a clean state before assigning a
   // new source. iOS Safari rejects subsequent plays with
@@ -419,7 +474,13 @@ export function playBlob(blob: Blob, onEnded?: () => void): () => void {
     .then(() => debugPush(`audio.play() resolved`))
     .catch((e: unknown) => {
       const err = e as { name?: string; message?: string };
-      debugPush(`audio.play() rejected: ${err?.name ?? '?'} ${err?.message ?? ''}`);
+      const mediaErr = audio.error
+        ? `MediaError code=${audio.error.code} (${MEDIA_ERROR_NAMES[audio.error.code] ?? '?'})`
+        : 'no MediaError set';
+      debugPush(
+        `audio.play() rejected: ${err?.name ?? '?'} ${err?.message ?? ''}; ${mediaErr}; ` +
+          `networkState=${audio.networkState} readyState=${audio.readyState}`,
+      );
       cleanup();
     });
 


### PR DESCRIPTION
## Summary

Four independent reviewer agents converged on the same theory after the most recent \`NotSupportedError\` trace: **the failing Anki recordings probably aren't actually MP3**. The \`mimeFromAudioFilename\` helper at \`src/services/ankiApkg.ts:100\` defaults every unknown extension to \`audio/mpeg\`, so any Anki deck shipping \`.opus\` / \`.spx\` / \`.m4a\` (or \`.mp3\` files containing other-codec bytes) all get stamped \`audio/mpeg\`. Desktop browsers are forgiving and decode them anyway; iOS Safari's strict MP3 decoder rejects with \`NotSupportedError\` from \`play()\` directly, before ever firing an \`error\` event.

The diagnostic happens to play a real-MP3 recording (the first \`audio/mpeg\` with \`storagePath\`); Browse fails on whichever recording the user taps. The two pick different files.

## Changes

Diagnostic-only — no behavior change for non-debug users.

1. **\`sniffAudioFormat\`** — reads first 32 bytes of each blob asynchronously in \`playBlob\` (fire-and-forget; we must NOT await before \`play()\` or iOS gesture is lost). Logs the hex prefix, the detected format, and a \`WARNING\` when the actual format doesn't match the claimed MIME. Detection covers MP3 (ID3v2 / frame sync), ADTS-AAC, MP4 / M4A (\`ftyp\`), Ogg, WAV, FLAC, WebM/Matroska.

2. **Enhanced \`play().catch\` log** — now includes \`audio.error.code\` mapped to the HTML5 MediaError name (\`ABORTED\` / \`NETWORK\` / \`DECODE\` / \`SRC_NOT_SUPPORTED\`), plus \`networkState\` and \`readyState\`. Disambiguates whether the rejection is the resource-selection algorithm rejecting the source (code 4 + networkState 3) vs another failure mode.

## What we expect to see on iPhone

If the theory is right, the failing recordings will show one of:

| Hex prefix | What it means |
|---|---|
| \`4F 67 67 53\` | Ogg container (Opus / Vorbis / Speex) — iOS can't play any of these, no matter the labeling |
| \`?? ?? ?? ?? 66 74 79 70\` | M4A / MP4 mislabeled as MP3 |
| \`FF F1\` / \`FF F9\` | ADTS-AAC mislabeled as MP3 |
| \`52 49 46 46\` | WAV mislabeled |

Plus \`MediaError code=4 (SRC_NOT_SUPPORTED)\` confirms iOS rejected the source format.

If they show \`49 44 33\` (real MP3 with ID3 tag) or \`FF FB\` (MP3 frame sync) and *still* fail, the bytes are real MP3 but iOS's decoder doesn't like something specific (VBR header, sample rate, etc.) — different fix path.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] User runs the failing recording in Browse on iPhone with debug overlay enabled
- [ ] Pastes back the \`format:\` line and the enhanced \`play() rejected\` line — those will tell us the real format and the real iOS error

🤖 Generated with [Claude Code](https://claude.com/claude-code)