### PR TITLE
Confirm modal on top-bar Sign out

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ function App() {
   const [ready, setReady] = useState(false);
   const [hydrating, setHydrating] = useState(false);
   const [hydrationError, setHydrationError] = useState<string | null>(null);
+  const [confirmSignOut, setConfirmSignOut] = useState(false);
   const step = useTutorialStore((s) => s.step);
   const advance = useTutorialStore((s) => s.advance);
   const { user, loading: authLoading, needsPasswordReset, initialize, signOut } = useAuthStore();
@@ -143,7 +144,7 @@ function App() {
             Settings
           </Link>
           <button
-            onClick={signOut}
+            onClick={() => setConfirmSignOut(true)}
             className="px-2 sm:px-2.5 py-1 rounded-md text-xs transition-colors"
             style={{ color: 'var(--text-tertiary)' }}
           >
@@ -155,6 +156,12 @@ function App() {
         <SyncErrorBanner />
         <InstallBanner />
         {step === 0 && <IntroModal onDone={advance} />}
+        {confirmSignOut && (
+          <SignOutConfirm
+            onConfirm={() => { setConfirmSignOut(false); signOut(); }}
+            onCancel={() => setConfirmSignOut(false)}
+          />
+        )}
         <Routes>
           <Route
             path="/"
@@ -174,6 +181,41 @@ function App() {
         </Routes>
       </div>
     </BrowserRouter>
+  );
+}
+
+function SignOutConfirm({ onConfirm, onCancel }: { onConfirm: () => void; onCancel: () => void }) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      style={{ background: 'rgba(0, 0, 0, 0.5)' }}
+      onClick={onCancel}
+    >
+      <div
+        className="surface rounded-lg p-5 max-w-xs w-full space-y-4"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <p className="text-sm" style={{ color: 'var(--text-primary)' }}>
+          Sign out of Mandao?
+        </p>
+        <div className="flex gap-2 justify-end">
+          <button
+            onClick={onCancel}
+            className="px-3 py-1.5 rounded text-sm transition-colors"
+            style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+          >
+            Cancel
+          </button>
+          <button
+            onClick={onConfirm}
+            className="px-3 py-1.5 rounded text-sm font-medium transition-colors"
+            style={{ background: 'var(--accent)', color: 'var(--text-inverted)' }}
+          >
+            Sign out
+          </button>
+        </div>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Tapping the **Sign out** button in the top header signed out immediately — too easy to hit accidentally, especially on mobile where it sits right next to the Settings link. Wrap it in a small modal: *\"Sign out of Mandao?\"* with **Cancel** / **Sign out** buttons.

Backdrop click also cancels.

The Settings → Account sign-out flow keeps its own pending-changes confirmation (\"X changes haven't synced yet — sign out anyway?\"), which addresses a different concern.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] Tap Sign out in top bar → modal appears
- [ ] Tap Cancel → modal dismisses, no sign-out
- [ ] Tap backdrop → modal dismisses, no sign-out
- [ ] Tap Sign out (in modal) → signed out
- [ ] Settings → Account sign-out flow unchanged (pending-changes prompt still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)