### PR TITLE
Store audioBlobs as ArrayBuffer to dodge iOS Blob-body eviction

### DIFF
--- a/src/db/localDb.ts
+++ b/src/db/localDb.ts
@@ -114,15 +114,23 @@ class MandaoDb extends Dexie {
         for (const rec of recs) {
           const oldBlob = (rec as AudioRecording & { blob?: Blob }).blob;
           if (oldBlob instanceof Blob) {
-            const ts = rec.createdAt ?? Date.now();
-            moves.push({
-              recordingId: rec.id,
-              blob: oldBlob,
-              mimeType: rec.mimeType ?? oldBlob.type ?? 'audio/webm',
-              sizeBytes: oldBlob.size,
-              fetchedAt: ts,
-              lastPlayedAt: ts,
-            });
+            try {
+              const data = await oldBlob.arrayBuffer();
+              if (data.byteLength > 0) {
+                const ts = rec.createdAt ?? Date.now();
+                moves.push({
+                  recordingId: rec.id,
+                  data,
+                  mimeType: rec.mimeType ?? oldBlob.type ?? 'audio/webm',
+                  sizeBytes: data.byteLength,
+                  fetchedAt: ts,
+                  lastPlayedAt: ts,
+                });
+              }
+            } catch {
+              // Blob body already evicted by WebKit — drop, the row will
+              // re-download from Storage on next play.
+            }
             // bulkPut replaces the whole row, so dropping `blob` from the
             // copy is enough to remove it from IDB.
             const next = { ...rec } as AudioRecording & { blob?: Blob };
@@ -132,8 +140,61 @@ class MandaoDb extends Dexie {
         }
         if (moves.length > 0) {
           await tx.table('audioBlobs').bulkPut(moves);
+        }
+        if (cleared.length > 0) {
           await tx.table('audioRecordings').bulkPut(cleared);
         }
+      });
+
+    // v6: rewrite audioBlobs entries that still carry a Blob in `blob` to
+    // store an ArrayBuffer in `data`. iOS WebKit evicts Blob bodies
+    // (sidecar files) separately from their IDB records — surfacing as
+    // `audio.play()` rejecting with NotSupportedError on previously-good
+    // entries — while ArrayBuffers live inside the record itself and
+    // can't be evicted independently. Bumping the schema version forces
+    // every existing client to re-shape its cache. See the AudioBlob
+    // type comment in src/db/schema.ts for details.
+    this.version(6)
+      .stores({
+        // No index changes; bumping version + this upgrade is the point.
+        audioBlobs: 'recordingId, lastPlayedAt, fetchedAt',
+      })
+      .upgrade(async (tx) => {
+        const table = tx.table('audioBlobs');
+        const rows = await table.toArray();
+        const updates: AudioBlob[] = [];
+        const drops: string[] = [];
+        for (const row of rows) {
+          // Already in new shape — nothing to do.
+          if (row.data instanceof ArrayBuffer) continue;
+          const oldBlob = (row as AudioBlob & { blob?: Blob }).blob;
+          if (!(oldBlob instanceof Blob)) {
+            // Neither shape — corrupt row, drop it.
+            drops.push(row.recordingId);
+            continue;
+          }
+          try {
+            const data = await oldBlob.arrayBuffer();
+            if (data.byteLength === 0) {
+              drops.push(row.recordingId);
+              continue;
+            }
+            updates.push({
+              recordingId: row.recordingId,
+              data,
+              mimeType: row.mimeType ?? oldBlob.type ?? 'audio/webm',
+              sizeBytes: data.byteLength,
+              fetchedAt: row.fetchedAt,
+              lastPlayedAt: row.lastPlayedAt,
+            });
+          } catch {
+            // Blob body has been evicted — there's nothing to migrate.
+            // Drop the metadata row so the next play re-fetches fresh.
+            drops.push(row.recordingId);
+          }
+        }
+        if (drops.length > 0) await table.bulkDelete(drops);
+        if (updates.length > 0) await table.bulkPut(updates);
       });
   }
 }

--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -545,23 +545,30 @@ export async function getAllAudioRecordings(): Promise<AudioRecording[]> {
 // Audio blobs (client-only cache for AudioRecording bytes)
 // ============================================================
 
-/** Build an AudioBlob entry with the standard mime fallback chain and
- *  matched fetchedAt/lastPlayedAt timestamps. Centralized so the four
- *  insert sites (insert, fetch, prefetch, migration) can't drift. */
-export function makeAudioBlobEntry(
+/** Build an AudioBlob entry from a Blob, reading its bytes into an
+ *  ArrayBuffer for storage. Async because Blob.arrayBuffer() is async.
+ *  See AudioBlob type comment in schema.ts for why we don't store the
+ *  Blob directly. */
+export async function makeAudioBlobEntry(
   recordingId: string,
   blob: Blob,
   mimeType?: string,
   ts: number = Date.now(),
-): AudioBlob {
+): Promise<AudioBlob> {
+  const data = await blob.arrayBuffer();
   return {
     recordingId,
-    blob,
+    data,
     mimeType: mimeType ?? blob.type ?? 'audio/webm',
-    sizeBytes: blob.size,
+    sizeBytes: data.byteLength,
     fetchedAt: ts,
     lastPlayedAt: ts,
   };
+}
+
+/** Reconstruct a playable Blob from a cached AudioBlob entry. */
+export function audioBlobToBlob(entry: AudioBlob): Blob {
+  return new Blob([entry.data], { type: entry.mimeType });
 }
 
 export async function getAudioBlob(recordingId: string): Promise<AudioBlob | undefined> {

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -425,7 +425,7 @@ export async function insertAudioRecording(
   await local.insertAudioRecording(rec);
   if (blob) {
     await local.putAudioBlob(
-      local.makeAudioBlobEntry(rec.id, blob, rec.mimeType, rec.createdAt),
+      await local.makeAudioBlobEntry(rec.id, blob, rec.mimeType, rec.createdAt),
     );
   }
   await enqueue({ op: 'upsertAudioRecording', payload: audioUpsertPayload(rec) });
@@ -473,12 +473,16 @@ export async function deleteAudioRecording(id: string) {
  */
 export async function fetchAudioBlob(id: string): Promise<Blob | null> {
   const cached = await local.getAudioBlob(id);
-  if (cached) {
+  if (cached && cached.data && cached.data.byteLength > 0) {
     // Don't await — touching the LRU timestamp is a best-effort hint;
     // a slow IDB write shouldn't delay playback.
     void local.touchAudioBlob(id);
-    return cached.blob;
+    return local.audioBlobToBlob(cached);
   }
+  // If the cache row exists but the data is missing/empty (shouldn't
+  // happen with ArrayBuffer storage but defensive against migration
+  // edge cases), drop it so the fetch path replaces it cleanly.
+  if (cached) await local.deleteAudioBlob(id);
 
   const rec = await local.getAudioRecording(id);
   if (!rec?.storagePath) return null;
@@ -493,7 +497,7 @@ export async function fetchAudioBlob(id: string): Promise<Blob | null> {
     const resp = await fetch(data.signedUrl);
     if (!resp.ok) return null;
     const blob = await resp.blob();
-    await local.putAudioBlob(local.makeAudioBlobEntry(id, blob, rec.mimeType));
+    await local.putAudioBlob(await local.makeAudioBlobEntry(id, blob, rec.mimeType));
     return blob;
   } catch {
     return null;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -104,10 +104,19 @@ export interface AudioRecording {
  * Never synced to the server. Used both for offline playback (cached on
  * fetch / prefetch) and as the staging area for locally-recorded clips that
  * haven't been uploaded yet.
+ *
+ * Bytes are stored as an `ArrayBuffer` rather than a `Blob` deliberately:
+ * iOS WebKit stores Blob bodies as separate sidecar files alongside the
+ * IndexedDB record and evicts those bodies independently from the record
+ * under storage / memory pressure. The result is a record whose `blob`
+ * field is a `Blob` object whose backing bytes have been freed —
+ * `audio.play()` then rejects with `NotSupportedError`. ArrayBuffers live
+ * inside the IDB record itself, so they can't be evicted separately.
+ * Reconstruct the `Blob` from `data` + `mimeType` at playback time.
  */
 export interface AudioBlob {
   recordingId: string;
-  blob: Blob;
+  data: ArrayBuffer;
   mimeType: string;
   sizeBytes: number;
   /** When the blob first landed in the cache (createdAt for local clips, fetch time for pulled ones). */

--- a/src/db/syncEngine.ts
+++ b/src/db/syncEngine.ts
@@ -15,6 +15,7 @@ import { AUDIO_BUCKET, removeStorageObjects } from '../lib/audioStorage';
 import { localDb, type SyncOp } from './localDb';
 import type { FailedOp } from '../stores/syncStore';
 import { runAudioPrefetch } from '../services/audioPrefetch';
+import { audioBlobToBlob } from './localRepo';
 
 /** Sync error that preserves the Postgres code so the outbox can tell
  *  permanent (CHECK violation, missing column) apart from transient
@@ -299,7 +300,7 @@ async function pushUpsertAudioRecording(op: SyncOp): Promise<void> {
     storagePath = `${userId}/${payload.id}.${ext}`;
     const { error: uploadErr } = await supabase.storage
       .from(AUDIO_BUCKET)
-      .upload(storagePath, cachedBlob.blob, {
+      .upload(storagePath, audioBlobToBlob(cachedBlob), {
         contentType: payload.mimeType,
         upsert: true,
       });

--- a/src/services/audioPrefetch.ts
+++ b/src/services/audioPrefetch.ts
@@ -132,7 +132,7 @@ async function fetchAndStore(rec: AudioRecording): Promise<number> {
     return 0;
   }
 
-  const entry = local.makeAudioBlobEntry(rec.id, blob, rec.mimeType);
+  const entry = await local.makeAudioBlobEntry(rec.id, blob, rec.mimeType);
 
   try {
     await local.putAudioBlob(entry);


### PR DESCRIPTION
## Summary

The recurring iOS audio bug — \"open the other context, audio breaks; clear cache to recover\" — has finally been pinned down to a likely root cause via a four-agent diagnostic: **iOS WebKit stores Blob bodies as separate sidecar files alongside their IndexedDB record, and evicts those bodies independently from the metadata under storage / memory pressure** (including app switching). The cache row remains, but its \`blob\` field's backing bytes are gone. \`audio.play()\` then rejects with \`NotSupportedError\` despite \`readyState=0\` and no preceding \`error\` event — exactly the trace from the live debug overlay.

ArrayBuffers, by contrast, live inside the IDB record itself and can't be evicted separately.

## Changes

- **\`AudioBlob.blob: Blob\` → \`AudioBlob.data: ArrayBuffer\`** (\`src/db/schema.ts\`). Reconstruct the Blob at playback time from \`data\` + \`mimeType\`.
- **New helper \`audioBlobToBlob(entry)\`** in \`src/db/localRepo.ts\` for the reconstruction.
- **\`makeAudioBlobEntry(...)\` is now async** (because \`Blob.arrayBuffer()\` is async) and stores the bytes as ArrayBuffer.
- **\`repo.fetchAudioBlob\`** defensively evicts cache rows whose \`data\` is missing or empty (e.g., from a half-migrated row), forcing a fresh fetch instead of silent failure.
- **\`syncEngine.pushUpsertAudioRecording\`** reconstructs a Blob from the stored ArrayBuffer for upload to Supabase Storage.
- **\`audioPrefetch.fetchAndStore\`** awaits the now-async \`makeAudioBlobEntry\`.
- **Dexie schema bumped v5 → v6** with two-stage migration:
  - **v5** (still runs for users coming from v4): converts \`audio_recordings.blob\` to \`audioBlobs.data: ArrayBuffer\` directly. Drops rows whose Blob body has already been evicted.
  - **v6** (new — runs for current v5 users): rewrites \`audioBlobs\` entries that still carry a \`blob\` field, converting to \`data: ArrayBuffer\`. Drops rows whose Blob bytes are gone, so the next play re-fetches from Storage.

## Why this should work

- The cross-context bug isn't really cross-context. Each context independently hits the OS-level eviction at different times (often when the user switches apps, putting the previously-foreground context under memory pressure).
- Storing as ArrayBuffer keeps the bytes locked to the IDB record. iOS WebKit can still evict the entire row under extreme pressure, but only as a unit — there's no \"ghost row with no body\" failure mode.
- Diagnostic evidence supports this: every prior failure had \`event: emptied → play → loadstart → NotSupportedError\` with \`readyState=0\` (HAVE_NOTHING). That's exactly what a Blob with an evicted body looks like.

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [x] \`npm run build\` clean
- [ ] Desktop: audio plays after migration, no regression
- [ ] iPhone Safari + PWA + Chrome: open the app in any one, switch to another, switch back — audio in all three should keep working without manual cache clearing
- [ ] Verify the v6 migration runs cleanly on existing data (no errors in console at startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)