### PR TITLE
Restore audio debug overlay (toggle in Settings)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { ThemeToggle } from './components/ThemeToggle';
 import { SyncIndicator } from './components/SyncIndicator';
 import { SyncErrorBanner } from './components/SyncErrorBanner';
 import { InstallBanner } from './components/InstallBanner';
+import { AudioDebugOverlay } from './components/AudioDebugOverlay';
 import { useTutorialStore } from './stores/tutorialStore';
 import { useAuthStore } from './stores/authStore';
 import './stores/themeStore';
@@ -179,6 +180,7 @@ function App() {
           <Route path="/auth/callback" element={<Navigate to="/" replace />} />
           <Route path="/reset-password" element={<Navigate to="/" replace />} />
         </Routes>
+        <AudioDebugOverlay />
       </div>
     </BrowserRouter>
   );

--- a/src/components/AudioDebugOverlay.tsx
+++ b/src/components/AudioDebugOverlay.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import {
+  audioDebugEnabled,
+  getAudioDebugLog,
+  subscribeAudioDebug,
+  clearAudioDebugLog,
+} from '../services/audioRecording';
+
+/**
+ * Floating overlay that surfaces every audio playback event in real
+ * time when debug mode is on. Toggle is in Settings → Data → Audio
+ * Diagnostic. Mounted at the app root so it stays visible across
+ * navigation — tap a recording in Browse, see the events live
+ * without DevTools.
+ */
+export function AudioDebugOverlay() {
+  const [enabled, setEnabled] = useState(audioDebugEnabled);
+  const [log, setLog] = useState<string[]>(getAudioDebugLog);
+  const [collapsed, setCollapsed] = useState(false);
+
+  useEffect(() => {
+    const refresh = () => {
+      setEnabled(audioDebugEnabled());
+      setLog(getAudioDebugLog());
+    };
+    refresh();
+    return subscribeAudioDebug(refresh);
+  }, []);
+
+  if (!enabled) return null;
+
+  return (
+    <div
+      className="fixed z-[9999] text-xs font-mono"
+      style={{
+        bottom: 8,
+        left: 8,
+        right: 8,
+        maxHeight: collapsed ? 28 : '40vh',
+        overflow: 'hidden',
+        background: 'rgba(0, 0, 0, 0.85)',
+        color: '#9eff9e',
+        border: '1px solid #444',
+        borderRadius: 4,
+        padding: '2px 6px',
+      }}
+    >
+      <div
+        className="flex items-center justify-between"
+        style={{
+          color: '#fff',
+          borderBottom: collapsed ? 'none' : '1px solid #333',
+          paddingBottom: 2,
+          marginBottom: collapsed ? 0 : 2,
+        }}
+      >
+        <span>audio debug ({log.length})</span>
+        <span className="flex gap-2">
+          <button onClick={() => clearAudioDebugLog()} style={{ color: '#aaa' }}>clear</button>
+          <button onClick={() => setCollapsed((c) => !c)} style={{ color: '#aaa' }}>
+            {collapsed ? '▲' : '▼'}
+          </button>
+        </span>
+      </div>
+      {!collapsed && (
+        <div style={{ overflowY: 'auto', maxHeight: 'calc(40vh - 24px)' }}>
+          {log.length === 0 ? (
+            <div style={{ color: '#666' }}>(no events yet — tap a play button)</div>
+          ) : (
+            log.map((line, i) => (
+              <div key={i} style={{ wordBreak: 'break-word', whiteSpace: 'pre-wrap' }}>{line}</div>
+            ))
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/SentenceAudioControls.tsx
+++ b/src/components/SentenceAudioControls.tsx
@@ -7,6 +7,7 @@ import {
   isAudioRecordingSupported,
   playBlob,
   startRecording,
+  audioDebugPush,
   type RecordingHandle,
   type RecordingResult,
 } from '../services/audioRecording';
@@ -104,9 +105,11 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
   };
 
   useEffect(() => {
+    audioDebugPush(`SentenceAudioControls mount for ${sentenceId.slice(0, 8)}`);
     const cancelledRef = { current: false };
     loadRecordingsAndBlobs(cancelledRef);
     return () => {
+      audioDebugPush(`SentenceAudioControls UNMOUNT for ${sentenceId.slice(0, 8)} — calling stopPlaybackRef`);
       cancelledRef.current = true;
       stopPlaybackRef.current?.();
       stopSpeaking();
@@ -157,6 +160,7 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
   // unlockAudio, the first thing iOS sees on this element is the user's
   // blob play, which it accepts cleanly.
   const playRecording = (rec: AudioRecording) => {
+    audioDebugPush(`playRecording clicked: ${rec.name} (${rec.id.slice(0, 8)}); playingId=${playingId}; cached=${blobMap.has(rec.id)}; blobMap.size=${blobMap.size}`);
     if (playingId === rec.id) { stopAll(); return; }
     stopAll();
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -21,7 +21,12 @@ import type { Deck } from '../db/schema';
 import { localDb } from '../db/localDb';
 import { supabase } from '../lib/supabase';
 import { AUDIO_BUCKET } from '../lib/audioStorage';
-import { unlockAudio, isAudioUnlocked } from '../services/audioRecording';
+import {
+  unlockAudio,
+  isAudioUnlocked,
+  audioDebugEnabled,
+  setAudioDebugEnabled,
+} from '../services/audioRecording';
 import {
   useAudioCacheSettingsStore,
   RECORDING_CAP_SEC_MIN,
@@ -1715,6 +1720,7 @@ const ERROR_CODE_NAMES: Record<number, string> = {
 function AudioDiagnosticCard() {
   const [steps, setSteps] = useState<DiagStep[]>([]);
   const [running, setRunning] = useState(false);
+  const [debugOn, setDebugOn] = useState(audioDebugEnabled);
 
   const run = async () => {
     setRunning(true);
@@ -1920,6 +1926,29 @@ function AudioDiagnosticCard() {
       description="Walks through the audio pipeline (auth, signed URL, fetch, decode) and reports each step's result. Useful when recordings won't play on a particular device."
     >
       <div className="space-y-3">
+        <div
+          className="flex items-center justify-between p-2 rounded"
+          style={{ background: 'var(--bg-inset)' }}
+        >
+          <span className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+            Floating debug overlay (live audio events)
+          </span>
+          <button
+            onClick={() => {
+              const next = !debugOn;
+              setAudioDebugEnabled(next);
+              setDebugOn(next);
+            }}
+            className="px-2.5 py-1 rounded text-xs font-medium transition-colors"
+            style={{
+              background: debugOn ? 'var(--danger, #e53e3e)' : 'var(--accent)',
+              color: 'var(--text-inverted)',
+            }}
+          >
+            {debugOn ? 'Disable' : 'Enable'}
+          </button>
+        </div>
+
         <button
           onClick={() => {
             // Synchronously prime audio in the click gesture so the play

--- a/src/services/audioRecording.ts
+++ b/src/services/audioRecording.ts
@@ -283,12 +283,90 @@ export function isAudioUnlocked(): boolean {
   return audioUnlocked;
 }
 
+// ────────────────────────────────────────────────────────────
+// Debug log infrastructure
+// Off by default. Toggle via Settings → Audio Diagnostic. When on,
+// playBlob emits HTMLMediaElement events into a ring buffer that the
+// floating overlay (AudioDebugOverlay) renders live. Used to diagnose
+// intermittent audio failures on mobile where DevTools is hard.
+// ────────────────────────────────────────────────────────────
+
+const DEBUG_RING_SIZE = 200;
+const debugLog: string[] = [];
+const debugListeners = new Set<() => void>();
+
+function isDebugEnabled(): boolean {
+  if (typeof window === 'undefined') return false;
+  return sessionStorage.getItem('mandao_audio_debug') === '1';
+}
+
+function debugPush(line: string): void {
+  if (!isDebugEnabled()) return;
+  const stamp = new Date().toLocaleTimeString().slice(-8) + '.' + String(Date.now() % 1000).padStart(3, '0');
+  debugLog.push(`[${stamp}] ${line}`);
+  if (debugLog.length > DEBUG_RING_SIZE) debugLog.shift();
+  for (const cb of debugListeners) { try { cb(); } catch { /* noop */ } }
+}
+
+export function audioDebugEnabled(): boolean { return isDebugEnabled(); }
+export function getAudioDebugLog(): string[] { return debugLog.slice(); }
+export function clearAudioDebugLog(): void {
+  debugLog.length = 0;
+  for (const cb of debugListeners) { try { cb(); } catch { /* noop */ } }
+}
+export function subscribeAudioDebug(cb: () => void): () => void {
+  debugListeners.add(cb);
+  return () => debugListeners.delete(cb);
+}
+export function setAudioDebugEnabled(enabled: boolean): void {
+  if (typeof window === 'undefined') return;
+  if (enabled) sessionStorage.setItem('mandao_audio_debug', '1');
+  else sessionStorage.removeItem('mandao_audio_debug');
+  for (const cb of debugListeners) { try { cb(); } catch { /* noop */ } }
+}
+/** Push a custom debug line — used by callers (e.g., SentenceAudioControls)
+ *  to mark click events alongside playBlob's own event log. */
+export function audioDebugPush(line: string): void { debugPush(line); }
+
+const MEDIA_ERROR_NAMES: Record<number, string> = {
+  1: 'ABORTED',
+  2: 'NETWORK',
+  3: 'DECODE',
+  4: 'SRC_NOT_SUPPORTED',
+};
+
+/** Identify the actual file format from the first ~16 bytes. Catches
+ *  cases where the cached blob has been truncated, corrupted, or stored
+ *  with the wrong mime type. */
+function sniffAudioFormat(b: Uint8Array): string {
+  if (b.length < 4) return 'too-short';
+  if (b[0] === 0x49 && b[1] === 0x44 && b[2] === 0x33) return 'mp3 (ID3v2)';
+  if (b[0] === 0xff && (b[1] & 0xe0) === 0xe0) {
+    const layer = (b[1] >> 1) & 0x03;
+    return layer === 0 ? 'aac (ADTS)' : 'mp3 (MPEG audio)';
+  }
+  if (b.length >= 8 && b[4] === 0x66 && b[5] === 0x74 && b[6] === 0x79 && b[7] === 0x70) return 'mp4/m4a (ftyp)';
+  if (b[0] === 0x4f && b[1] === 0x67 && b[2] === 0x67 && b[3] === 0x53) return 'ogg (Vorbis/Opus/Speex)';
+  if (b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46) return 'wav (RIFF)';
+  if (b[0] === 0x66 && b[1] === 0x4c && b[2] === 0x61 && b[3] === 0x43) return 'flac';
+  if (b[0] === 0x1a && b[1] === 0x45 && b[2] === 0xdf && b[3] === 0xa3) return 'webm/matroska';
+  return 'unknown';
+}
+
 /**
  * Play an audio blob. Returns a stop() function. Revokes the object URL
  * when playback ends or is stopped.
  */
 export function playBlob(blob: Blob, onEnded?: () => void): () => void {
   const audio = getSharedAudio();
+  debugPush(`playBlob() — blob ${blob.size}B ${blob.type || '(no type)'}`);
+  if (audioDebugEnabled()) {
+    blob.slice(0, 16).arrayBuffer().then((buf) => {
+      const b = new Uint8Array(buf);
+      const hex = Array.from(b, (x) => x.toString(16).padStart(2, '0')).join(' ');
+      debugPush(`bytes[0..16]: ${hex}; format: ${sniffAudioFormat(b)}`);
+    }).catch((e) => debugPush(`byte sniff failed: ${(e as Error).message}`));
+  }
 
   // Bring the element fully back to a clean state before assigning a
   // new source. iOS Safari rejects subsequent plays with
@@ -311,10 +389,34 @@ export function playBlob(blob: Blob, onEnded?: () => void): () => void {
   pendingObjectUrl = url;
   audio.src = url;
 
+  // Hook every interesting media event when debug is on.
+  let trackedListeners: Array<{ type: string; fn: EventListener }> | null = null;
+  if (audioDebugEnabled()) {
+    trackedListeners = [];
+    const events = ['loadstart', 'loadedmetadata', 'loadeddata', 'canplay', 'play', 'playing', 'pause', 'ended', 'error', 'stalled', 'suspend', 'abort', 'emptied'];
+    for (const evt of events) {
+      const fn = () => {
+        let detail = '';
+        if (evt === 'error') {
+          const code = audio.error?.code;
+          detail = ` (MediaError ${code} ${MEDIA_ERROR_NAMES[code as 1 | 2 | 3 | 4] ?? '?'})`;
+        }
+        if (evt === 'pause') detail = ` (currentTime=${audio.currentTime.toFixed(2)}s)`;
+        debugPush(`event: ${evt}${detail}`);
+      };
+      audio.addEventListener(evt, fn);
+      trackedListeners.push({ type: evt, fn });
+    }
+  }
+
   let stopped = false;
   const cleanup = () => {
     if (stopped) return;
     stopped = true;
+    debugPush(`cleanup() — currentTime=${audio.currentTime.toFixed(2)}s readyState=${audio.readyState}`);
+    if (trackedListeners) {
+      for (const l of trackedListeners) audio.removeEventListener(l.type, l.fn);
+    }
     if (pendingObjectUrl === url) {
       URL.revokeObjectURL(url);
       pendingObjectUrl = null;
@@ -323,9 +425,21 @@ export function playBlob(blob: Blob, onEnded?: () => void): () => void {
   };
   audio.onended = cleanup;
   audio.onerror = cleanup;
-  audio.play().catch(cleanup);
+  audio.play()
+    .then(() => debugPush(`audio.play() resolved`))
+    .catch((e: unknown) => {
+      const err = e as { name?: string; message?: string };
+      const mediaErr = audio.error
+        ? `MediaError ${audio.error.code} (${MEDIA_ERROR_NAMES[audio.error.code] ?? '?'})`
+        : 'no MediaError';
+      debugPush(
+        `audio.play() rejected: ${err?.name ?? '?'} ${err?.message ?? ''}; ${mediaErr}; networkState=${audio.networkState} readyState=${audio.readyState}`,
+      );
+      cleanup();
+    });
 
   return () => {
+    debugPush(`stop() called externally`);
     try { audio.pause(); } catch { /* noop */ }
     cleanup();
   };


### PR DESCRIPTION
## Summary

The audio bug is **intermittent now, post-#142** — sometimes works, sometimes doesn't, no clear pattern. We removed the debug overlay in #140 thinking the bug was solved; it isn't, and now we need real visibility into what's happening when it fails.

This restores the same instrumentation as before, plus the byte-sniff that surfaces format-vs-claimed-MIME mismatches.

## What's restored

- **\`AudioDebugOverlay.tsx\`** (re-added): fixed-bottom floating event log, collapsible, only renders when toggle is on.
- **Debug-log infrastructure in \`audioRecording.ts\`**: 200-entry ring buffer + the \`audioDebug*\` exports. \`playBlob\` instrumented with every interesting media event (\`loadstart\`, \`loadedmetadata\`, \`canplay\`, \`play\`, \`playing\`, \`pause\`, \`ended\`, \`error\`, \`stalled\`, \`suspend\`, \`abort\`, \`emptied\`), \`play().catch\` includes \`MediaError\` code + name + \`networkState\` + \`readyState\`, and the first 16 bytes of the blob get sniffed to identify the actual format.
- **\`SentenceAudioControls\`**: \`audioDebugPush\` calls on mount/unmount and every \`playRecording\` click, with \`cached\`/\`blobMap.size\`.
- **\`AudioDiagnosticCard\`** (Settings → Data): toggle row at the top with Enable/Disable. Flips \`sessionStorage\` flag; overlay appears/disappears live.
- **\`App.tsx\`**: mounts the overlay at app root so it persists across navigation.

No URL flag this time (the \`?audioDebug=1\` friction made it unreliable on mobile previously). Toggle is sticky for the session via sessionStorage.

## How you'll use it

1. After deploy: Settings → Data → Audio Diagnostic → tap **Enable** next to "Floating debug overlay"
2. Black overlay appears at the bottom of the screen
3. Reproduce the audio bug (let it fail, then succeed, then fail again)
4. Screenshot or paste back the event log — we'll see what differs between working and broken plays

## Test plan

- [x] \`npx tsc --noEmit\` passes
- [x] \`npm test\` 93/93 pass
- [ ] Toggle on, play succeeds: see \`event: playing\` in the log
- [ ] Toggle on, play fails: see the actual MediaError code + format-sniff result
- [ ] Toggle off: overlay disappears and the log stops growing

🤖 Generated with [Claude Code](https://claude.com/claude-code)