### PR TITLE
PWA auto-update on resume + two-finger rotate on Graph

### DIFF
--- a/src/lib/pwaUpdate.ts
+++ b/src/lib/pwaUpdate.ts
@@ -1,0 +1,47 @@
+/**
+ * PWA auto-update bootstrap.
+ *
+ * Default vite-plugin-pwa registration only runs the SW update check on a
+ * real page load. Installed PWAs typically resume from background, so a
+ * fresh deploy on Vercel never gets picked up until the user fully quits
+ * the app. This module forces the check on visibility/focus and on a
+ * periodic poll, then auto-reloads the page once the new SW takes
+ * control — yielding "open the app, brief flicker, new version" UX with
+ * no prompt.
+ */
+import { registerSW } from 'virtual:pwa-register';
+
+const POLL_INTERVAL_MS = 60 * 60 * 1000;
+
+export function initPwaAutoUpdate(): void {
+  if (typeof navigator === 'undefined' || !('serviceWorker' in navigator)) return;
+
+  // controllerchange fires when the new SW takes over the page (skipWaiting
+  // + clientsClaim, both default with registerType:'autoUpdate'). Reload
+  // once so the running JS matches the now-active SW's precache.
+  let reloading = false;
+  navigator.serviceWorker.addEventListener('controllerchange', () => {
+    if (reloading) return;
+    reloading = true;
+    window.location.reload();
+  });
+
+  registerSW({
+    immediate: true,
+    onRegisteredSW(_swUrl, registration) {
+      if (!registration) return;
+
+      const checkForUpdate = () => {
+        registration.update().catch(() => {
+          // Offline or transient network error — silently retry on next trigger.
+        });
+      };
+
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') checkForUpdate();
+      });
+      window.addEventListener('focus', checkForUpdate);
+      window.setInterval(checkForUpdate, POLL_INTERVAL_MS);
+    },
+  });
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,9 @@ import App from './App.tsx'
 import { runAuditInConsole, runRepairInConsole } from './lib/auditPinyin'
 import { runCleanOrphanedAudioInConsole } from './lib/cleanOrphanedAudio'
 import { runCleanOrphanedMeaningsInConsole } from './lib/cleanOrphanedMeanings'
+import { initPwaAutoUpdate } from './lib/pwaUpdate'
+
+initPwaAutoUpdate()
 
 const w = window as unknown as {
   __auditPinyin?: () => Promise<unknown>

--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -273,6 +273,15 @@ export function GraphPage() {
   const containerRef = useRef<HTMLDivElement>(null);
   const fgRef = useRef<ForceGraphMethods | undefined>(undefined);
 
+  // Two-finger rotate gesture (mobile). When the user puts two fingers
+  // on the canvas and rotates them in opposite directions, we rotate the
+  // entire graph wrapper by the angular delta between the touches. Pure
+  // pan (both fingers translating together) leaves the angle untouched
+  // and so contributes no rotation — exactly the desired behavior.
+  const [rotationDeg, setRotationDeg] = useState(0);
+  const lastAngleRef = useRef<number | null>(null);
+  const rotateWrapperRef = useRef<HTMLDivElement>(null);
+
   useEffect(() => {
     buildGraphData().then((data) => {
       setGraphData(data);
@@ -316,6 +325,51 @@ export function GraphPage() {
     const observer = new MutationObserver(() => setColors(getThemeColors()));
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class', 'data-theme'] });
     return () => observer.disconnect();
+  }, []);
+
+  // Attach native touch listeners with passive:false so we can block
+  // the page-level pinch-zoom while the user is rotating the graph.
+  // React's synthetic event system installs touchmove as passive,
+  // which makes preventDefault a no-op there.
+  useEffect(() => {
+    const el = rotateWrapperRef.current;
+    if (!el) return;
+
+    const angleBetween = (t0: Touch, t1: Touch) =>
+      (Math.atan2(t1.clientY - t0.clientY, t1.clientX - t0.clientX) * 180) / Math.PI;
+
+    const onTouchStart = (e: TouchEvent) => {
+      if (e.touches.length === 2) {
+        lastAngleRef.current = angleBetween(e.touches[0], e.touches[1]);
+      } else {
+        lastAngleRef.current = null;
+      }
+    };
+    const onTouchMove = (e: TouchEvent) => {
+      if (e.touches.length !== 2 || lastAngleRef.current == null) return;
+      e.preventDefault();
+      const curr = angleBetween(e.touches[0], e.touches[1]);
+      let delta = curr - lastAngleRef.current;
+      // Normalize wrap-around (e.g. -179 → 179 should read as +2°, not -358°).
+      if (delta > 180) delta -= 360;
+      else if (delta < -180) delta += 360;
+      lastAngleRef.current = curr;
+      setRotationDeg((r) => r + delta);
+    };
+    const onTouchEnd = (e: TouchEvent) => {
+      if (e.touches.length < 2) lastAngleRef.current = null;
+    };
+
+    el.addEventListener('touchstart', onTouchStart, { passive: true });
+    el.addEventListener('touchmove', onTouchMove, { passive: false });
+    el.addEventListener('touchend', onTouchEnd, { passive: true });
+    el.addEventListener('touchcancel', onTouchEnd, { passive: true });
+    return () => {
+      el.removeEventListener('touchstart', onTouchStart);
+      el.removeEventListener('touchmove', onTouchMove);
+      el.removeEventListener('touchend', onTouchEnd);
+      el.removeEventListener('touchcancel', onTouchEnd);
+    };
   }, []);
 
   useEffect(() => {
@@ -622,6 +676,15 @@ export function GraphPage() {
             No data yet. Add some sentences first.
           </div>
         ) : (
+          <div
+            ref={rotateWrapperRef}
+            className="absolute inset-0"
+            style={{
+              transform: `rotate(${rotationDeg}deg)`,
+              transformOrigin: '50% 50%',
+              touchAction: 'none',
+            }}
+          >
           <ForceGraph2D
             ref={fgRef as any}
             width={dimensions.width}
@@ -651,6 +714,7 @@ export function GraphPage() {
               fgRef.current?.zoomToFit(500, 80);
             }}
           />
+          </div>
         )}
       </div>
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "vite-plugin-pwa/client"],
     "skipLibCheck": true,
 
     /* Bundler mode */

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,6 +9,9 @@ export default defineConfig({
     tailwindcss(),
     VitePWA({
       registerType: 'autoUpdate',
+      // We register the SW ourselves in src/lib/pwaUpdate.ts so we can
+      // re-check on visibilitychange and auto-reload on controllerchange.
+      injectRegister: false,
       // Serve the manifest + service worker in `vite dev` so install
       // prompt + offline behavior can be exercised locally without
       // running a production build.


### PR DESCRIPTION
## Summary
- Take over SW registration in `src/lib/pwaUpdate.ts` so `registration.update()` runs on `visibilitychange`, `focus`, and an hourly poll — covers the resume-from-background case where installed PWAs miss new Vercel deploys.
- Auto-reload once on `controllerchange` so the running JS matches the now-active SW's precache.
- Adds a two-finger rotate gesture to `GraphPage` (canvas wrapper rotates by the angular delta between two touches) as a visual canary for confirming the new build was picked up on mobile.

## Test plan
- [ ] Deploy, open installed PWA on iOS, deploy again, background then resume the PWA — verify the page reloads to the new build within a couple seconds without a full quit.
- [ ] On mobile, open `/graph`, place two fingers on the canvas and rotate them in opposite directions — graph rotates with the gesture.
- [ ] Single-finger pan/zoom on graph still works.
- [ ] `npm test` and `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)