### PR TITLE
Pivot graph rotation around the touch midpoint

### DIFF
--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -273,13 +273,15 @@ export function GraphPage() {
   const containerRef = useRef<HTMLDivElement>(null);
   const fgRef = useRef<ForceGraphMethods | undefined>(undefined);
 
-  // Two-finger rotate gesture (mobile). When the user puts two fingers
-  // on the canvas and rotates them in opposite directions, we rotate the
-  // entire graph wrapper by the angular delta between the touches. Pure
-  // pan (both fingers translating together) leaves the angle untouched
-  // and so contributes no rotation — exactly the desired behavior.
-  const [rotationDeg, setRotationDeg] = useState(0);
+  // Two-finger rotate gesture (mobile). Each gesture pivots around the
+  // screen-space midpoint between the two touches at the moment they
+  // landed — that's the natural "rotate around your thumbs" feel. We
+  // accumulate via a DOMMatrix so successive gestures at different
+  // pivots compose correctly (each new rotation is applied in screen
+  // space, on top of whatever transform is already there).
   const lastAngleRef = useRef<number | null>(null);
+  const pivotRef = useRef<{ x: number; y: number } | null>(null);
+  const matrixRef = useRef<DOMMatrix>(new DOMMatrix());
   const rotateWrapperRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -338,15 +340,29 @@ export function GraphPage() {
     const angleBetween = (t0: Touch, t1: Touch) =>
       (Math.atan2(t1.clientY - t0.clientY, t1.clientX - t0.clientX) * 180) / Math.PI;
 
+    // The wrapper is `absolute inset-0` inside chained absolute/fixed
+    // inset-0 parents, and we use transform-origin: 0 0 — so the
+    // element's local (0,0) coincides with viewport (0,0), and clientX/Y
+    // can be used directly as the pivot in matrix space.
     const onTouchStart = (e: TouchEvent) => {
       if (e.touches.length === 2) {
-        lastAngleRef.current = angleBetween(e.touches[0], e.touches[1]);
+        const t0 = e.touches[0], t1 = e.touches[1];
+        lastAngleRef.current = angleBetween(t0, t1);
+        pivotRef.current = {
+          x: (t0.clientX + t1.clientX) / 2,
+          y: (t0.clientY + t1.clientY) / 2,
+        };
       } else {
         lastAngleRef.current = null;
+        pivotRef.current = null;
       }
     };
     const onTouchMove = (e: TouchEvent) => {
-      if (e.touches.length !== 2 || lastAngleRef.current == null) return;
+      if (
+        e.touches.length !== 2 ||
+        lastAngleRef.current == null ||
+        pivotRef.current == null
+      ) return;
       e.preventDefault();
       const curr = angleBetween(e.touches[0], e.touches[1]);
       let delta = curr - lastAngleRef.current;
@@ -354,10 +370,24 @@ export function GraphPage() {
       if (delta > 180) delta -= 360;
       else if (delta < -180) delta += 360;
       lastAngleRef.current = curr;
-      setRotationDeg((r) => r + delta);
+
+      const { x: px, y: py } = pivotRef.current;
+      // Compose: M' = T(p) · R(delta) · T(-p) · M.  This applies the new
+      // rotation around the screen-space pivot p, on top of the
+      // accumulated transform M, so prior rotations stay intact while
+      // the new one pivots where the user's fingers actually are.
+      const step = new DOMMatrix()
+        .translate(px, py)
+        .rotate(delta)
+        .translate(-px, -py);
+      matrixRef.current = step.multiply(matrixRef.current);
+      el.style.transform = matrixRef.current.toString();
     };
     const onTouchEnd = (e: TouchEvent) => {
-      if (e.touches.length < 2) lastAngleRef.current = null;
+      if (e.touches.length < 2) {
+        lastAngleRef.current = null;
+        pivotRef.current = null;
+      }
     };
 
     // Capture phase — react-force-graph's d3-zoom listens on the inner
@@ -687,8 +717,10 @@ export function GraphPage() {
             ref={rotateWrapperRef}
             className="absolute inset-0"
             style={{
-              transform: `rotate(${rotationDeg}deg)`,
-              transformOrigin: '50% 50%',
+              // transform-origin: 0 0 lets us use viewport coordinates
+              // directly as DOMMatrix pivots — the touch handler updates
+              // `style.transform` imperatively per move.
+              transformOrigin: '0 0',
               touchAction: 'none',
             }}
           >


### PR DESCRIPTION
## Summary
- Two-finger rotate previously used `transform-origin: 50% 50%`, so the graph rotated about the screen center regardless of where the user's fingers actually were.
- Capture the screen-space midpoint of the two touches at the moment they land, and compose each per-frame angular delta as `M' = T(p) · R(δ) · T(-p) · M` on a `DOMMatrix`.
- Set `transform-origin: 0 0` so viewport `clientX/Y` maps straight to matrix pivots without rect math (the wrapper is `absolute inset-0` inside chained `inset-0` parents, so element-local (0,0) coincides with viewport (0,0)).
- Imperative `el.style.transform = matrix.toString()` per touchmove — no React state, no re-renders during the gesture.

## Test plan
- [ ] Place fingers off-center on `/graph`, rotate — graph pivots around the midpoint of the fingers, not the screen center.
- [ ] Lift, place fingers in a different spot, rotate again — accumulated transform stays intact and the new rotation pivots at the new midpoint.
- [ ] Single-finger pan/zoom still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)