### PR TITLE
Remove two-finger rotate gesture from GraphPage

### DIFF
--- a/src/pages/GraphPage.tsx
+++ b/src/pages/GraphPage.tsx
@@ -273,17 +273,6 @@ export function GraphPage() {
   const containerRef = useRef<HTMLDivElement>(null);
   const fgRef = useRef<ForceGraphMethods | undefined>(undefined);
 
-  // Two-finger rotate gesture (mobile). Each gesture pivots around the
-  // screen-space midpoint between the two touches at the moment they
-  // landed — that's the natural "rotate around your thumbs" feel. We
-  // accumulate via a DOMMatrix so successive gestures at different
-  // pivots compose correctly (each new rotation is applied in screen
-  // space, on top of whatever transform is already there).
-  const lastAngleRef = useRef<number | null>(null);
-  const pivotRef = useRef<{ x: number; y: number } | null>(null);
-  const matrixRef = useRef<DOMMatrix>(new DOMMatrix());
-  const rotateWrapperRef = useRef<HTMLDivElement>(null);
-
   useEffect(() => {
     buildGraphData().then((data) => {
       setGraphData(data);
@@ -328,86 +317,6 @@ export function GraphPage() {
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class', 'data-theme'] });
     return () => observer.disconnect();
   }, []);
-
-  // Attach native touch listeners with passive:false so we can block
-  // the page-level pinch-zoom while the user is rotating the graph.
-  // React's synthetic event system installs touchmove as passive,
-  // which makes preventDefault a no-op there.
-  useEffect(() => {
-    const el = rotateWrapperRef.current;
-    if (!el) return;
-
-    const angleBetween = (t0: Touch, t1: Touch) =>
-      (Math.atan2(t1.clientY - t0.clientY, t1.clientX - t0.clientX) * 180) / Math.PI;
-
-    // The wrapper is `absolute inset-0` inside chained absolute/fixed
-    // inset-0 parents, and we use transform-origin: 0 0 — so the
-    // element's local (0,0) coincides with viewport (0,0), and clientX/Y
-    // can be used directly as the pivot in matrix space.
-    const onTouchStart = (e: TouchEvent) => {
-      if (e.touches.length === 2) {
-        const t0 = e.touches[0], t1 = e.touches[1];
-        lastAngleRef.current = angleBetween(t0, t1);
-        pivotRef.current = {
-          x: (t0.clientX + t1.clientX) / 2,
-          y: (t0.clientY + t1.clientY) / 2,
-        };
-      } else {
-        lastAngleRef.current = null;
-        pivotRef.current = null;
-      }
-    };
-    const onTouchMove = (e: TouchEvent) => {
-      if (
-        e.touches.length !== 2 ||
-        lastAngleRef.current == null ||
-        pivotRef.current == null
-      ) return;
-      e.preventDefault();
-      const curr = angleBetween(e.touches[0], e.touches[1]);
-      let delta = curr - lastAngleRef.current;
-      // Normalize wrap-around (e.g. -179 → 179 should read as +2°, not -358°).
-      if (delta > 180) delta -= 360;
-      else if (delta < -180) delta += 360;
-      lastAngleRef.current = curr;
-
-      const { x: px, y: py } = pivotRef.current;
-      // Compose: M' = T(p) · R(delta) · T(-p) · M.  This applies the new
-      // rotation around the screen-space pivot p, on top of the
-      // accumulated transform M, so prior rotations stay intact while
-      // the new one pivots where the user's fingers actually are.
-      const step = new DOMMatrix()
-        .translate(px, py)
-        .rotate(delta)
-        .translate(-px, -py);
-      matrixRef.current = step.multiply(matrixRef.current);
-      el.style.transform = matrixRef.current.toString();
-    };
-    const onTouchEnd = (e: TouchEvent) => {
-      if (e.touches.length < 2) {
-        lastAngleRef.current = null;
-        pivotRef.current = null;
-      }
-    };
-
-    // Capture phase — react-force-graph's d3-zoom listens on the inner
-    // canvas; capturing on our wrapper means we see the events before
-    // its handlers, regardless of any propagation stopping.
-    el.addEventListener('touchstart', onTouchStart, { capture: true, passive: true });
-    el.addEventListener('touchmove', onTouchMove, { capture: true, passive: false });
-    el.addEventListener('touchend', onTouchEnd, { capture: true, passive: true });
-    el.addEventListener('touchcancel', onTouchEnd, { capture: true, passive: true });
-    return () => {
-      el.removeEventListener('touchstart', onTouchStart, { capture: true });
-      el.removeEventListener('touchmove', onTouchMove, { capture: true });
-      el.removeEventListener('touchend', onTouchEnd, { capture: true });
-      el.removeEventListener('touchcancel', onTouchEnd, { capture: true });
-    };
-    // The wrapper div is only mounted once `loading` flips false (it
-    // sits inside the same conditional as the canvas). Re-run when that
-    // happens so we actually attach to the live element rather than the
-    // null ref captured during the loading phase.
-  }, [loading]);
 
   useEffect(() => {
     function updateSize() {
@@ -713,17 +622,6 @@ export function GraphPage() {
             No data yet. Add some sentences first.
           </div>
         ) : (
-          <div
-            ref={rotateWrapperRef}
-            className="absolute inset-0"
-            style={{
-              // transform-origin: 0 0 lets us use viewport coordinates
-              // directly as DOMMatrix pivots — the touch handler updates
-              // `style.transform` imperatively per move.
-              transformOrigin: '0 0',
-              touchAction: 'none',
-            }}
-          >
           <ForceGraph2D
             ref={fgRef as any}
             width={dimensions.width}
@@ -753,7 +651,6 @@ export function GraphPage() {
               fgRef.current?.zoomToFit(500, 80);
             }}
           />
-          </div>
         )}
       </div>
 


### PR DESCRIPTION
## Summary
- Pulls out the entire two-finger rotate gesture introduced in #147 / #148 / #150 — it didn't feel right in practice.
- Removes the rotating wrapper div, the touch listeners, the DOMMatrix state, and the related refs. Canvas falls back to react-force-graph's built-in pan/zoom.

## Test plan
- [ ] `/graph` opens normally; one-finger pan and pinch-zoom work.
- [ ] No leftover refs or unused state in `GraphPage.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)