### PR TITLE
Show build SHA in Settings footer

### DIFF
--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="vite/client" />
+
+declare const __BUILD_SHA__: string;

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -94,6 +94,15 @@ export function SettingsPage() {
       {section === 'ai' && <AISection />}
       {section === 'anki' && <AnkiSection />}
       {section === 'data' && <DataSection />}
+
+      {/* Build stamp — lets us confirm at a glance which commit the
+          running app / installed PWA is actually on. */}
+      <div
+        className="mt-8 text-center text-xs"
+        style={{ color: 'var(--text-tertiary)' }}
+      >
+        build {__BUILD_SHA__}
+      </div>
     </div>
   );
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,9 +1,27 @@
 import { defineConfig } from 'vite'
+import { execSync } from 'node:child_process'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { VitePWA } from 'vite-plugin-pwa'
 
+// Build identifier surfaced in the UI so we can confirm at a glance
+// which commit the running PWA / browser tab is on. Vercel sets
+// VERCEL_GIT_COMMIT_SHA on prod builds; locally we fall back to git.
+const BUILD_SHA = (() => {
+  if (process.env.VERCEL_GIT_COMMIT_SHA) {
+    return process.env.VERCEL_GIT_COMMIT_SHA.slice(0, 7)
+  }
+  try {
+    return execSync('git rev-parse --short HEAD').toString().trim()
+  } catch {
+    return 'dev'
+  }
+})()
+
 export default defineConfig({
+  define: {
+    __BUILD_SHA__: JSON.stringify(BUILD_SHA),
+  },
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION
## Summary
- Inline the git SHA at build time via Vite's `define` (`__BUILD_SHA__`) and render it as faded `build <sha>` text at the bottom of `/settings`.
- Vercel prod builds use `VERCEL_GIT_COMMIT_SHA`; local dev/builds fall back to `git rev-parse --short HEAD`, then to `dev`.
- Lets us tell at a glance whether an installed PWA is on the latest deploy without needing a visual canary baked into UI behavior.

## Test plan
- [ ] After deploy, open `/settings` on the installed PWA — footer reads `build <SHA>` matching `main`.
- [ ] After a subsequent merge, resume the PWA and re-open `/settings` — SHA matches the new commit (this is the actual auto-update test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)