### PR TITLE
Add 'due (today)' count next to new/learning/review on Dashboard

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -66,6 +66,7 @@
   --state-learning: #cb7b37;
   --state-review: #448361;
   --state-relearning: #9065b0;
+  --state-due: #b8517a;
 }
 
 .dark {
@@ -123,6 +124,7 @@
   --state-learning: #e6a35c;
   --state-review: #6bc490;
   --state-relearning: #b98cd1;
+  --state-due: #e88aac;
 }
 
 /* ============================================================

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -84,10 +84,11 @@ export function DashboardPage() {
       {/* Default Deck */}
       <div className="mb-10">
         <div className="flex items-baseline justify-between mb-2">
-          <div className="flex gap-3 text-xs" style={{ color: 'var(--text-secondary)' }}>
+          <div className="flex gap-3 text-xs flex-wrap" style={{ color: 'var(--text-secondary)' }}>
             <span style={{ color: 'var(--state-new)' }}>{states.newCount} new</span>
             <span style={{ color: 'var(--state-learning)' }}>{states.learningCount} learning</span>
             <span style={{ color: 'var(--state-review)' }}>{states.reviewCount} review</span>
+            <span style={{ color: 'var(--state-due)' }}>{dueForMode} due (today)</span>
           </div>
         </div>
         <div className="flex gap-1 mb-3 flex-wrap">


### PR DESCRIPTION
## Summary
- Adds a fourth state-coloured counter (`X due (today)`) to the breakdown row on the Dashboard, next to `new` / `learning` / `review`. Updates live as the user taps All, EN→ZH, ZH→EN, PY→, Listen, Speak.
- New CSS variable `--state-due` in both light (`#b8517a`) and dark (`#e88aac`) themes — rose tone so it's distinct from the existing four state colors (blue/orange/green/purple).
- Also doubles as a small visible canary for the next auto-update test: once this lands on Vercel, mobile Chrome and the PWA should both show it after the next resume, with no manual cache clearing.

## Test plan
- [ ] Dashboard renders the new "X due (today)" pill in rose color.
- [ ] Tapping each mode tab updates the four counters consistently.
- [ ] After Vercel deploys, mobile Chrome shows the new pill on resume without any cache clearing — confirming auto-update works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)