### PR TITLE
Sync default deck through outbox

### DIFF
--- a/src/components/SyncErrorBanner.tsx
+++ b/src/components/SyncErrorBanner.tsx
@@ -11,6 +11,7 @@ const OP_LABELS: Record<SyncOpType, string> = {
   updateTags: 'tag update',
   upsertAudioRecording: 'audio upload',
   deleteStorageObjects: 'audio cleanup',
+  upsertDeck: 'deck',
 };
 
 export function SyncErrorBanner() {

--- a/src/db/localDb.ts
+++ b/src/db/localDb.ts
@@ -24,7 +24,8 @@ export type SyncOpType =
   | 'deleteAllData'
   | 'updateTags'
   | 'upsertAudioRecording'
-  | 'deleteStorageObjects';
+  | 'deleteStorageObjects'
+  | 'upsertDeck';
 
 export interface SyncOp {
   id?: number;

--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -416,20 +416,24 @@ export async function getAllDecks(): Promise<Deck[]> {
   return localDb.decks.toArray();
 }
 
-export async function ensureDefaultDeck(userId: string): Promise<string> {
+export async function ensureDefaultDeck(
+  userId: string,
+): Promise<{ deckId: string; deck: Deck; created: boolean }> {
   const deckId = 'default-' + userId;
   const existing = await localDb.decks.get(deckId);
-  if (!existing) {
-    await localDb.decks.put({
-      id: deckId,
-      name: 'Default',
-      description: 'Default deck',
-      newCardsPerDay: 20,
-      reviewsPerDay: 200,
-      createdAt: Date.now(),
-    });
+  if (existing) {
+    return { deckId, deck: existing, created: false };
   }
-  return deckId;
+  const deck: Deck = {
+    id: deckId,
+    name: 'Default',
+    description: 'Default deck',
+    newCardsPerDay: 20,
+    reviewsPerDay: 200,
+    createdAt: Date.now(),
+  };
+  await localDb.decks.put(deck);
+  return { deckId, deck, created: true };
 }
 
 // ============================================================

--- a/src/db/mappers.ts
+++ b/src/db/mappers.ts
@@ -77,6 +77,18 @@ export function deckFromRow(r: any): Deck {
   };
 }
 
+export function deckToRow(deck: Deck, userId: string) {
+  return {
+    id: deck.id,
+    user_id: userId,
+    name: deck.name,
+    description: deck.description,
+    new_cards_per_day: deck.newCardsPerDay,
+    reviews_per_day: deck.reviewsPerDay,
+    created_at: deck.createdAt,
+  };
+}
+
 export function reviewLogFromRow(r: any): ReviewLog {
   return {
     id: r.id, cardId: r.card_id, rating: r.rating,

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -337,16 +337,39 @@ export async function getAllDecks(): Promise<Deck[]> {
   return local.getAllDecks();
 }
 
+// Module-level mirror of the syncMeta flag. Avoids a Dexie read on every
+// page mount once we've enqueued the upsert at least once. Reset on
+// deleteAllUserData (and naturally on app reload, where we read once).
+let defaultDeckSyncedCache: boolean | null = null;
+
+export function resetDefaultDeckSyncedCache(): void {
+  defaultDeckSyncedCache = null;
+}
+
 export async function ensureDefaultDeck(): Promise<string> {
   // Prefer cached ID to avoid network call (works offline).
   // Falls through to getUser() only if cache is cold (rare at startup).
+  let userId: string;
   try {
-    const userId = getCachedUserIdOrThrow();
-    return local.ensureDefaultDeck(userId);
+    userId = getCachedUserIdOrThrow();
   } catch {
-    const userId = await getRemoteUserId();
-    return local.ensureDefaultDeck(userId);
+    userId = await getRemoteUserId();
   }
+  const { deckId, deck, created } = await local.ensureDefaultDeck(userId);
+
+  // Heal devices that pre-date this flag: enqueue if we just created the
+  // deck, or if we never recorded a sync. The server upsert is idempotent.
+  if (defaultDeckSyncedCache === null) {
+    const row = await localDb.syncMeta.get('defaultDeckSynced');
+    defaultDeckSyncedCache = row !== undefined;
+  }
+  if (created || !defaultDeckSyncedCache) {
+    await enqueue({ op: 'upsertDeck', payload: deck });
+    await localDb.syncMeta.put({ key: 'defaultDeckSynced', value: 1 });
+    defaultDeckSyncedCache = true;
+  }
+
+  return deckId;
 }
 
 // ============================================================
@@ -391,6 +414,10 @@ export async function deleteAllUserData(): Promise<void> {
   await localDb.syncMeta.delete('lastHydratedAt');
   await localDb.syncMeta.delete('lastUsn');
   await localDb.syncMeta.delete('schemaVersion');
+  // delete_all_user_data drops the server-side default deck, so the next
+  // ensureDefaultDeck call must re-enqueue an upsert.
+  await localDb.syncMeta.delete('defaultDeckSynced');
+  resetDefaultDeckSyncedCache();
   await enqueue({ op: 'deleteAllData', payload: {} });
   // Storage cleanup is enqueued so it survives offline / tab-close instead
   // of fire-and-forget. The push handler chunks at Supabase's 1000-key

--- a/src/db/syncEngine.ts
+++ b/src/db/syncEngine.ts
@@ -13,6 +13,7 @@
 import { supabase } from '../lib/supabase';
 import { AUDIO_BUCKET } from '../lib/audioStorage';
 import { localDb, type SyncOp } from './localDb';
+import type { Deck } from './schema';
 import type { FailedOp } from '../stores/syncStore';
 import { runAudioPrefetch } from '../services/audioPrefetch';
 import { audioBlobToBlob } from './localRepo';
@@ -56,6 +57,7 @@ import {
   reviewLogFromRow,
   audioRecordingFromRow,
   audioRecordingToRow,
+  deckToRow,
 } from './mappers';
 import { getCachedUserIdOrThrow } from './remoteRepo';
 import {
@@ -205,6 +207,9 @@ async function pushOpBatch(ops: SyncOp[]): Promise<void> {
       break;
     case 'deleteStorageObjects':
       await pushSequential(ops, pushDeleteStorageObjects);
+      break;
+    case 'upsertDeck':
+      await pushSequential(ops, pushUpsertDeck);
       break;
   }
 }
@@ -357,6 +362,15 @@ async function pushDeleteStorageObjects(op: SyncOp): Promise<void> {
     const { error } = await supabase.storage.from(AUDIO_BUCKET).remove(chunk);
     if (error) throw syncErrorFrom(error);
   }
+}
+
+async function pushUpsertDeck(op: SyncOp): Promise<void> {
+  const userId = getCachedUserIdOrThrow();
+  const { error } = await supabase.from('decks').upsert(
+    deckToRow(op.payload as Deck, userId),
+    { onConflict: 'id', ignoreDuplicates: true },
+  );
+  if (error) throw syncErrorFrom(error);
 }
 
 async function pushUpdateTags(op: SyncOp): Promise<void> {


### PR DESCRIPTION
## Summary

Fixes the `P0001: Unauthorized operation` sync failure that happens when adding a new sentence on a device whose local Default deck never reached the server.

## Root cause

`repo.ensureDefaultDeck()` only wrote to local Dexie — it never enqueued a sync op. The server-side deck was only created by `remote.ensureDefaultDeck()` inside `hydrateLocalDb()`, which runs once per device. Any code path that recreates the local deck without re-hydrating (most commonly: right after **Delete all data** wipes both sides, then a new sentence is added before the next reload) ends up with a deck the server doesn't have. `apply_ingest_bundle` validates that `deck_id` exists for the user and raises "Unauthorized operation" when it doesn't.

## Fix

- New `upsertDeck` sync op flows deck creation through the outbox like every other write.
- `pushUpsertDeck` upserts directly into `decks` with `onConflict: 'id', ignoreDuplicates: true` (idempotent — safe for re-enqueue / multi-device).
- `repo.ensureDefaultDeck` enqueues the op when (a) it just created the local deck, or (b) a `defaultDeckSynced` syncMeta flag is missing — the second case heals existing devices stuck in the old state on first call after this lands.
- A module-level mirror of the flag eliminates the Dexie read on every Dashboard / Review / Add page mount once the upsert has been enqueued.
- `deleteAllUserData` clears the flag (and its cache) so a wipe-then-recreate cycle re-syncs.
- New `deckToRow` mapper centralizes the snake_case shape; `pushUpsertDeck` uses `getCachedUserIdOrThrow()` to match the existing `pushUpsertAudioRecording` pattern.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` clean
- [x] `npm test -- --run` — 93/93 passing
- [ ] Manual: with the failed `ingestBundle` op already in the outbox, refresh the app, confirm an `upsertDeck` op is enqueued and pushes successfully, then click Retry on the sync banner — the stuck `ingestBundle` should now succeed.
- [ ] Manual: add a brand-new sentence on a fresh device, confirm no "Unauthorized operation" error.
- [ ] Manual: trigger "Delete all data" → add a sentence → confirm the deck is re-upserted before / alongside the new sentence and sync completes cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)