### PR TITLE
Skip tutorial for returning users on fresh browsers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import { ThemeToggle } from './components/ThemeToggle';
 import { SyncIndicator } from './components/SyncIndicator';
 import { SyncErrorBanner } from './components/SyncErrorBanner';
 import { InstallBanner } from './components/InstallBanner';
-import { useTutorialStore } from './stores/tutorialStore';
+import { useTutorialStore, initTutorialFromUserData } from './stores/tutorialStore';
 import { useAuthStore } from './stores/authStore';
 import './stores/themeStore';
 
@@ -56,6 +56,7 @@ function App() {
           setHydrating(false);
         }
         await loadCedict();
+        await initTutorialFromUserData();
         if (!cancelled) setReady(true);
       } catch (e: any) {
         if (cancelled) return;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,7 @@ import { ThemeToggle } from './components/ThemeToggle';
 import { SyncIndicator } from './components/SyncIndicator';
 import { SyncErrorBanner } from './components/SyncErrorBanner';
 import { InstallBanner } from './components/InstallBanner';
-import { useTutorialStore, initTutorialFromUserData } from './stores/tutorialStore';
+import { useTutorialStore, skipTutorialIfReturningUser } from './stores/tutorialStore';
 import { useAuthStore } from './stores/authStore';
 import './stores/themeStore';
 
@@ -55,8 +55,7 @@ function App() {
           if (cancelled) return;
           setHydrating(false);
         }
-        await loadCedict();
-        await initTutorialFromUserData();
+        await Promise.all([loadCedict(), skipTutorialIfReturningUser()]);
         if (!cancelled) setReady(true);
       } catch (e: any) {
         if (cancelled) return;

--- a/src/data/tutorialSentences.ts
+++ b/src/data/tutorialSentences.ts
@@ -1,11 +1,13 @@
 import type { SentenceInput } from '../services/ingestion';
 
+export const TUTORIAL_SOURCE = 'tutorial';
+
 /** The first sentence is the one users walk through adding manually. */
 export const TUTORIAL_SENTENCES: SentenceInput[] = [
   {
     chinese: '她花了很多钱买花。',
     english: 'She spent a lot of money buying flowers.',
-    source: 'tutorial',
+    source: TUTORIAL_SOURCE,
     tokens: [
       { surfaceForm: '她', pinyinNumeric: 'ta1', english: 'she', partOfSpeech: 'pronoun' },
       { surfaceForm: '花', pinyinNumeric: 'hua1', english: 'to spend', partOfSpeech: 'verb' },
@@ -20,7 +22,7 @@ export const TUTORIAL_SENTENCES: SentenceInput[] = [
   {
     chinese: '你好！你是哪国人？',
     english: 'Hello! What country are you from?',
-    source: 'tutorial',
+    source: TUTORIAL_SOURCE,
     tokens: [
       { surfaceForm: '你', pinyinNumeric: 'ni3', english: 'you', partOfSpeech: 'pronoun' },
       { surfaceForm: '好', pinyinNumeric: 'hao3', english: 'good', partOfSpeech: 'adj' },
@@ -34,7 +36,7 @@ export const TUTORIAL_SENTENCES: SentenceInput[] = [
   {
     chinese: '这件事不是他做的。',
     english: 'This matter was not something he did.',
-    source: 'tutorial',
+    source: TUTORIAL_SOURCE,
     tokens: [
       { surfaceForm: '这', pinyinNumeric: 'zhe4', english: 'this', partOfSpeech: 'pronoun' },
       { surfaceForm: '件', pinyinNumeric: 'jian4', english: 'measure word for matters', partOfSpeech: 'measure' },

--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -246,6 +246,13 @@ export async function getSentencesCount(): Promise<number> {
   return localDb.sentences.count();
 }
 
+export async function hasNonTutorialSentence(): Promise<boolean> {
+  const row = await localDb.sentences
+    .filter((s) => s.source !== 'tutorial')
+    .first();
+  return row !== undefined;
+}
+
 export async function getSentencesByIds(ids: string[]): Promise<Sentence[]> {
   if (ids.length === 0) return [];
   const unique = [...new Set(ids)];

--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -246,10 +246,8 @@ export async function getSentencesCount(): Promise<number> {
   return localDb.sentences.count();
 }
 
-export async function hasNonTutorialSentence(): Promise<boolean> {
-  const row = await localDb.sentences
-    .filter((s) => s.source !== 'tutorial')
-    .first();
+export async function hasSentenceNotFromSource(source: string): Promise<boolean> {
+  const row = await localDb.sentences.where('source').notEqual(source).first();
   return row !== undefined;
 }
 

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -139,6 +139,10 @@ export async function getSentencesCount(): Promise<number> {
   return local.getSentencesCount();
 }
 
+export async function hasNonTutorialSentence(): Promise<boolean> {
+  return local.hasNonTutorialSentence();
+}
+
 export async function getSentencesByIds(ids: string[]): Promise<Sentence[]> {
   return local.getSentencesByIds(ids);
 }

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -139,8 +139,8 @@ export async function getSentencesCount(): Promise<number> {
   return local.getSentencesCount();
 }
 
-export async function hasNonTutorialSentence(): Promise<boolean> {
-  return local.hasNonTutorialSentence();
+export async function hasSentenceNotFromSource(source: string): Promise<boolean> {
+  return local.hasSentenceNotFromSource(source);
 }
 
 export async function getSentencesByIds(ids: string[]): Promise<Sentence[]> {

--- a/src/services/ingestion.ts
+++ b/src/services/ingestion.ts
@@ -21,6 +21,7 @@ import type {
   MeaningFlag,
 } from '../db/schema';
 import { applyToneSandhi, numericStringToDiacritic } from './toneSandhi';
+import { TUTORIAL_SOURCE } from '../data/tutorialSentences';
 
 /**
  * Accumulator for tracking newly created entities during ingestion,
@@ -499,7 +500,7 @@ export { updateSentenceTags } from '../db/repo';
 /** Delete all tutorial sentences and their associated tokens and SRS cards */
 export async function deleteTutorialSentences(): Promise<void> {
   // Sentence deletion cascades to tokens, SRS cards, and review logs.
-  await repo.deleteSentencesBySource('tutorial');
+  await repo.deleteSentencesBySource(TUTORIAL_SOURCE);
 }
 
 /** Get all meanings that share the same pinyin (for pinyin card) */

--- a/src/stores/tutorialStore.ts
+++ b/src/stores/tutorialStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand';
 import { deleteTutorialSentences } from '../services/ingestion';
+import { hasNonTutorialSentence } from '../db/repo';
 
 /**
  * Tutorial steps:
@@ -45,3 +46,16 @@ export const useTutorialStore = create<TutorialState>((set) => ({
     set({ step: MAX_STEP as TutorialStep });
   },
 }));
+
+/**
+ * Skip the tutorial on devices where the user already has data, so a
+ * returning user signing in on a fresh browser doesn't get re-onboarded.
+ * No-op if any explicit progress is already persisted on this device —
+ * we don't want to advance a user mid-tutorial.
+ */
+export async function initTutorialFromUserData(): Promise<void> {
+  if (localStorage.getItem(STORAGE_KEY) !== null) return;
+  if (!(await hasNonTutorialSentence())) return;
+  localStorage.setItem(STORAGE_KEY, String(MAX_STEP));
+  useTutorialStore.setState({ step: MAX_STEP as TutorialStep });
+}

--- a/src/stores/tutorialStore.ts
+++ b/src/stores/tutorialStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand';
 import { deleteTutorialSentences } from '../services/ingestion';
-import { hasNonTutorialSentence } from '../db/repo';
+import { hasSentenceNotFromSource } from '../db/repo';
+import { TUTORIAL_SOURCE } from '../data/tutorialSentences';
 
 /**
  * Tutorial steps:
@@ -53,9 +54,9 @@ export const useTutorialStore = create<TutorialState>((set) => ({
  * No-op if any explicit progress is already persisted on this device —
  * we don't want to advance a user mid-tutorial.
  */
-export async function initTutorialFromUserData(): Promise<void> {
+export async function skipTutorialIfReturningUser(): Promise<void> {
   if (localStorage.getItem(STORAGE_KEY) !== null) return;
-  if (!(await hasNonTutorialSentence())) return;
+  if (!(await hasSentenceNotFromSource(TUTORIAL_SOURCE))) return;
   localStorage.setItem(STORAGE_KEY, String(MAX_STEP));
   useTutorialStore.setState({ step: MAX_STEP as TutorialStep });
 }


### PR DESCRIPTION
## Summary

Closes #159.

Tutorial progress was only persisted in `localStorage` (`mandao_tutorial_step`), so a user who'd completed the tutorial on browser A and then signed in on browser B (or a fresh incognito window) saw the intro modal and was redirected to `/add?tutorial=1` again.

After hydration completes, this PR checks whether the user has any non-tutorial sentence in Dexie. If they do — and no explicit step is recorded for this device — we persist `MAX_STEP` so the tutorial doesn't replay. Devices that already have progress in localStorage are left alone, so this can never advance a user mid-tutorial.

## Changes

- `src/db/localRepo.ts`: New `hasNonTutorialSentence()` Dexie helper. `.filter().first()` short-circuits at the first match.
- `src/db/repo.ts`: Re-export through the repo facade.
- `src/stores/tutorialStore.ts`: New `initTutorialFromUserData()`. Guards against advancing a mid-tutorial user by exiting early when localStorage already has a step.
- `src/App.tsx`: Call `initTutorialFromUserData()` from the hydration effect, after `loadCedict` and before `setReady(true)`. Runs every login (not just first hydration), so a user who clears `localStorage` but keeps Dexie also recovers correctly.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.app.json` clean
- [x] `npm test -- --run` — 93/93 passing
- [ ] Manual: complete tutorial on browser A → sign in on browser B (or incognito) with same account → confirm dashboard renders without intro modal and `/` does not redirect to `/add?tutorial=1`.
- [ ] Manual: sign up as a brand-new user on a fresh browser → confirm intro modal still shows and tutorial proceeds normally.
- [ ] Manual: start tutorial on browser A (advance to step 2 or 3, but don't complete) → open browser B with same account → confirm browser B shows tutorial from step 0 (acceptable: A hasn't yet added a non-tutorial sentence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)