### PR TITLE
Skip already-imported notes in .apkg picker

### DIFF
--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -252,6 +252,12 @@ export async function getSentencesByIds(ids: string[]): Promise<Sentence[]> {
   return localDb.sentences.where('id').anyOf(unique).toArray();
 }
 
+export async function getSentencesByChineseList(chineseTexts: string[]): Promise<Sentence[]> {
+  if (chineseTexts.length === 0) return [];
+  const unique = [...new Set(chineseTexts)];
+  return localDb.sentences.where('chinese').anyOf(unique).toArray();
+}
+
 export async function insertSentence(sentence: Sentence): Promise<void> {
   await localDb.sentences.put(sentence);
 }

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -143,6 +143,10 @@ export async function getSentencesByIds(ids: string[]): Promise<Sentence[]> {
   return local.getSentencesByIds(ids);
 }
 
+export async function getSentencesByChineseList(chineseTexts: string[]): Promise<Sentence[]> {
+  return local.getSentencesByChineseList(chineseTexts);
+}
+
 export async function insertSentence(sentence: Sentence): Promise<void> {
   await local.insertSentence(sentence);
   // Enqueued as part of ingestBundle by the ingestion service.

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -662,6 +662,7 @@ function AnkiSection() {
   const [audioField, setAudioField] = useState<number | null>(null);
   const [audioName, setAudioName] = useState('anki');
   const [selectedNotes, setSelectedNotes] = useState<Set<number>>(new Set());
+  const [existingNoteIds, setExistingNoteIds] = useState<Set<number>>(new Set());
   const lastClickedIdx = useRef<number | null>(null);
   const dragSelectMode = useRef<boolean | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -673,6 +674,45 @@ function AnkiSection() {
     window.addEventListener('mouseup', handler);
     return () => window.removeEventListener('mouseup', handler);
   }, []);
+
+  // Find which notes already exist in the app so we can disable their rows.
+  // Recomputes when the user picks a different Chinese field.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      if (!apkgInfo) {
+        if (!cancelled) setExistingNoteIds(new Set());
+        return;
+      }
+      const keys = apkgInfo.notes
+        .map((n) => (n.fields[chineseField] ?? '').trim())
+        .filter((k) => k.length > 0);
+      const unique = Array.from(new Set(keys));
+      const matched = new Set<string>();
+      if (unique.length > 0) {
+        const rows = await localDb.sentences.where('chinese').anyOf(unique).toArray();
+        for (const r of rows) matched.add(r.chinese);
+      }
+      if (cancelled) return;
+      const existing = new Set<number>();
+      for (const note of apkgInfo.notes) {
+        const c = (note.fields[chineseField] ?? '').trim();
+        if (c && matched.has(c)) existing.add(note.id);
+      }
+      setExistingNoteIds(existing);
+      // Drop any existing-note IDs from the current selection.
+      setSelectedNotes((prev) => {
+        if (prev.size === 0) return prev;
+        let changed = false;
+        const next = new Set(prev);
+        for (const id of existing) {
+          if (next.delete(id)) changed = true;
+        }
+        return changed ? next : prev;
+      });
+    })();
+    return () => { cancelled = true; };
+  }, [apkgInfo, chineseField]);
 
   const handleAnkiExport = async (format: 'text' | 'apkg') => {
     setAnkiExporting(true);
@@ -888,11 +928,16 @@ function AnkiSection() {
             {/* Select all / none */}
             <div className="flex items-center justify-between">
               <span className="text-sm" style={{ color: 'var(--text-secondary)' }}>
-                {selectedNotes.size} of {apkgInfo.notes.length} selected
+                {selectedNotes.size} of {apkgInfo.notes.length - existingNoteIds.size} selected
+                {existingNoteIds.size > 0 && (
+                  <span style={{ color: 'var(--text-tertiary)' }}>
+                    {' · '}{existingNoteIds.size} already imported
+                  </span>
+                )}
               </span>
               <div className="flex gap-2">
                 <button
-                  onClick={() => setSelectedNotes(new Set(apkgInfo.notes.map(n => n.id)))}
+                  onClick={() => setSelectedNotes(new Set(apkgInfo.notes.filter(n => !existingNoteIds.has(n.id)).map(n => n.id)))}
                   className="text-xs px-2 py-1 rounded transition-colors"
                   style={{ color: 'var(--accent)' }}
                 >
@@ -933,25 +978,28 @@ function AnkiSection() {
               {apkgInfo.notes.map((note, idx) => {
                 const display = note.fields[displayField] ?? '';
                 const isSelected = selectedNotes.has(note.id);
+                const isExisting = existingNoteIds.has(note.id);
 
                 return (
                   <div
                     key={note.id}
-                    className="flex items-center gap-3 px-3 py-2.5 cursor-pointer"
+                    className={`flex items-center gap-3 px-3 py-2.5 ${isExisting ? 'cursor-not-allowed' : 'cursor-pointer'}`}
                     style={{
-                      background: isSelected ? 'color-mix(in srgb, var(--accent) 8%, var(--bg-surface))' : 'transparent',
+                      background: !isExisting && isSelected ? 'color-mix(in srgb, var(--accent) 8%, var(--bg-surface))' : 'transparent',
                       borderBottom: '1px solid var(--border)',
+                      opacity: isExisting ? 0.45 : 1,
                     }}
-                    onMouseDown={(e) => {
+                    onMouseDown={isExisting ? undefined : (e) => {
                       e.preventDefault();
                       if (e.shiftKey && lastClickedIdx.current !== null) {
-                        // Shift-click: select range
+                        // Shift-click: select range, skipping already-imported notes
                         const from = Math.min(lastClickedIdx.current, idx);
                         const to = Math.max(lastClickedIdx.current, idx);
                         setSelectedNotes(prev => {
                           const next = new Set(prev);
                           for (let j = from; j <= to; j++) {
-                            next.add(apkgInfo.notes[j].id);
+                            const nid = apkgInfo.notes[j].id;
+                            if (!existingNoteIds.has(nid)) next.add(nid);
                           }
                           return next;
                         });
@@ -968,7 +1016,7 @@ function AnkiSection() {
                       }
                       lastClickedIdx.current = idx;
                     }}
-                    onMouseEnter={() => {
+                    onMouseEnter={isExisting ? undefined : () => {
                       if (dragSelectMode.current === null) return;
                       setSelectedNotes(prev => {
                         const next = new Set(prev);
@@ -981,19 +1029,24 @@ function AnkiSection() {
                     <div
                       className="shrink-0 w-4 h-4 rounded border flex items-center justify-center"
                       style={{
-                        borderColor: isSelected ? 'var(--accent)' : 'var(--border)',
-                        background: isSelected ? 'var(--accent)' : 'transparent',
+                        borderColor: !isExisting && isSelected ? 'var(--accent)' : 'var(--border)',
+                        background: !isExisting && isSelected ? 'var(--accent)' : 'transparent',
                       }}
                     >
-                      {isSelected && (
+                      {!isExisting && isSelected && (
                         <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                           <polyline points="2 6 5 9 10 3" />
                         </svg>
                       )}
                     </div>
-                    <span className="text-sm" style={{ color: 'var(--text-primary)' }}>
+                    <span className="text-sm flex-1 min-w-0 truncate" style={{ color: 'var(--text-primary)' }}>
                       {display || <span style={{ color: 'var(--text-tertiary)' }}>(empty)</span>}
                     </span>
+                    {isExisting && (
+                      <span className="text-xs shrink-0" style={{ color: 'var(--text-tertiary)' }}>
+                        Already imported
+                      </span>
+                    )}
                   </div>
                 );
               })}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -675,8 +675,9 @@ function AnkiSection() {
     return () => window.removeEventListener('mouseup', handler);
   }, []);
 
-  // Find which notes already exist in the app so we can disable their rows.
-  // Recomputes when the user picks a different Chinese field.
+  // Pre-check which Anki notes are already in the app so the picker can
+  // disable them. Mirrors the runtime dedup at ankiApkg.ts (exact `chinese`
+  // match) so what's dimmed here matches what import would skip.
   useEffect(() => {
     let cancelled = false;
     (async () => {
@@ -684,23 +685,18 @@ function AnkiSection() {
         if (!cancelled) setExistingNoteIds(new Set());
         return;
       }
-      const keys = apkgInfo.notes
-        .map((n) => (n.fields[chineseField] ?? '').trim())
-        .filter((k) => k.length > 0);
-      const unique = Array.from(new Set(keys));
-      const matched = new Set<string>();
-      if (unique.length > 0) {
-        const rows = await localDb.sentences.where('chinese').anyOf(unique).toArray();
-        for (const r of rows) matched.add(r.chinese);
-      }
+      const chineseOf = (n: typeof apkgInfo.notes[number]) =>
+        (n.fields[chineseField] ?? '').trim();
+      const keys = apkgInfo.notes.map(chineseOf).filter((k) => k.length > 0);
+      const rows = await repo.getSentencesByChineseList(keys);
       if (cancelled) return;
+      const matched = new Set(rows.map((r) => r.chinese));
       const existing = new Set<number>();
       for (const note of apkgInfo.notes) {
-        const c = (note.fields[chineseField] ?? '').trim();
+        const c = chineseOf(note);
         if (c && matched.has(c)) existing.add(note.id);
       }
       setExistingNoteIds(existing);
-      // Drop any existing-note IDs from the current selection.
       setSelectedNotes((prev) => {
         if (prev.size === 0) return prev;
         let changed = false;
@@ -937,7 +933,13 @@ function AnkiSection() {
               </span>
               <div className="flex gap-2">
                 <button
-                  onClick={() => setSelectedNotes(new Set(apkgInfo.notes.filter(n => !existingNoteIds.has(n.id)).map(n => n.id)))}
+                  onClick={() => setSelectedNotes(
+                    new Set(
+                      apkgInfo.notes
+                        .filter((n) => !existingNoteIds.has(n.id))
+                        .map((n) => n.id),
+                    ),
+                  )}
                   className="text-xs px-2 py-1 rounded transition-colors"
                   style={{ color: 'var(--accent)' }}
                 >
@@ -979,20 +981,20 @@ function AnkiSection() {
                 const display = note.fields[displayField] ?? '';
                 const isSelected = selectedNotes.has(note.id);
                 const isExisting = existingNoteIds.has(note.id);
+                const showSelected = isSelected && !isExisting;
 
                 return (
                   <div
                     key={note.id}
                     className={`flex items-center gap-3 px-3 py-2.5 ${isExisting ? 'cursor-not-allowed' : 'cursor-pointer'}`}
                     style={{
-                      background: !isExisting && isSelected ? 'color-mix(in srgb, var(--accent) 8%, var(--bg-surface))' : 'transparent',
+                      background: showSelected ? 'color-mix(in srgb, var(--accent) 8%, var(--bg-surface))' : 'transparent',
                       borderBottom: '1px solid var(--border)',
                       opacity: isExisting ? 0.45 : 1,
                     }}
                     onMouseDown={isExisting ? undefined : (e) => {
                       e.preventDefault();
                       if (e.shiftKey && lastClickedIdx.current !== null) {
-                        // Shift-click: select range, skipping already-imported notes
                         const from = Math.min(lastClickedIdx.current, idx);
                         const to = Math.max(lastClickedIdx.current, idx);
                         setSelectedNotes(prev => {
@@ -1029,11 +1031,11 @@ function AnkiSection() {
                     <div
                       className="shrink-0 w-4 h-4 rounded border flex items-center justify-center"
                       style={{
-                        borderColor: !isExisting && isSelected ? 'var(--accent)' : 'var(--border)',
-                        background: !isExisting && isSelected ? 'var(--accent)' : 'transparent',
+                        borderColor: showSelected ? 'var(--accent)' : 'var(--border)',
+                        background: showSelected ? 'var(--accent)' : 'transparent',
                       }}
                     >
-                      {!isExisting && isSelected && (
+                      {showSelected && (
                         <svg width="10" height="10" viewBox="0 0 12 12" fill="none" stroke="white" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
                           <polyline points="2 6 5 9 10 3" />
                         </svg>


### PR DESCRIPTION
## Summary
- The Anki .apkg import picker showed every note as selectable; duplicates were only silently counted as skipped during import.
- Pre-check each note's Chinese against the existing sentence DB and surface that to the user *before* they click Import.
- Already-imported rows are grayed out (0.45 opacity), non-interactive (click / shift-range / drag-paint all skip them), and labeled "Already imported".
- The selection counter now reads `N of <importable> selected · X already imported`, and Select All only adds importable rows.
- Recomputes when the user picks a different "Import field (Chinese)".

## Test plan
- [ ] Open Settings → Anki → choose a .apkg containing some notes already imported into the app
- [ ] Verify those rows render dimmed with "Already imported" on the right
- [ ] Verify Select All / Select None / shift-click range / drag paint never touch dimmed rows
- [ ] Change the "Import field (Chinese)" dropdown and verify the dimmed set updates
- [ ] Click Import; the import progress should report 0 duplicates (since duplicates are now unselectable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)