### PR TITLE
Add Free Review mode for ad-hoc card drilling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { hydrateLocalDb, isHydrated } from './db/hydrate';
 import { runSync, startSyncListeners, stopSyncListeners } from './db/syncEngine';
 import { DashboardPage } from './pages/DashboardPage';
 import { ReviewPage } from './pages/ReviewPage';
+import { FreeReviewPage } from './pages/FreeReviewPage';
 import { AddSentencePage } from './pages/AddSentencePage';
 import { BrowsePage } from './pages/BrowsePage';
 import { GraphPage } from './pages/GraphPage';
@@ -171,6 +172,7 @@ function App() {
           />
           <Route path="/review" element={<ReviewPage />} />
           <Route path="/review/:deckId" element={<ReviewPage />} />
+          <Route path="/free-review" element={<FreeReviewPage />} />
           <Route path="/add" element={<AddSentencePage />} />
           <Route path="/browse" element={<BrowsePage />} />
           <Route path="/graph" element={<GraphPage />} />

--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -146,13 +146,13 @@ export function ReviewCard() {
   };
 
   if (!card || !sentence) {
+    let message: string;
+    if (remaining() > 0) message = 'Loading...';
+    else if (isFreeReview) message = 'All done — nothing left in this free-review session.';
+    else message = 'No cards to review. Add some sentences first!';
     return (
       <div className="flex flex-col items-center justify-center h-64 gap-3" style={{ color: 'var(--text-tertiary)' }}>
-        {remaining() === 0
-          ? isFreeReview
-            ? 'All done — nothing left in this free-review session.'
-            : 'No cards to review. Add some sentences first!'
-          : 'Loading...'}
+        {message}
         {remaining() === 0 && undoInfo && (
           <button
             onClick={handleUndo}

--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -36,7 +36,7 @@ const SPEED_OPTIONS = [
 ] as const;
 
 export function ReviewCard() {
-  const { currentCard, isFlipped, flip, next, prev, remaining, undoInfo, clearUndo } = useReviewStore();
+  const { currentCard, isFlipped, flip, next, prev, remaining, undoInfo, clearUndo, isFreeReview, requeueCurrent } = useReviewStore();
   const [sentence, setSentence] = useState<Sentence | null>(null);
   const [tokens, setTokens] = useState<TokenWithMeaning[]>([]);
   const [editingTags, setEditingTags] = useState(false);
@@ -149,7 +149,9 @@ export function ReviewCard() {
     return (
       <div className="flex flex-col items-center justify-center h-64 gap-3" style={{ color: 'var(--text-tertiary)' }}>
         {remaining() === 0
-          ? 'No cards to review. Add some sentences first!'
+          ? isFreeReview
+            ? 'All done — nothing left in this free-review session.'
+            : 'No cards to review. Add some sentences first!'
           : 'Loading...'}
         {remaining() === 0 && undoInfo && (
           <button
@@ -279,6 +281,70 @@ export function ReviewCard() {
       setPendingRating(null);
     }
   };
+
+  const handleGotIt = () => {
+    setRateError(null);
+    next();
+  };
+  const handleAgainLater = () => {
+    setRateError(null);
+    requeueCurrent();
+  };
+
+  const actionBar = isFreeReview ? (
+    <div className="mt-6 grid grid-cols-2 gap-2">
+      <button
+        onClick={handleAgainLater}
+        className="py-3 min-h-[44px] rounded-lg font-medium transition-all active:scale-[0.95]"
+        style={{
+          background: 'color-mix(in srgb, var(--rating-again) 15%, var(--bg-surface))',
+          color: 'var(--rating-again)',
+        }}
+        title="Send this card to the back of the queue"
+      >
+        Again later
+      </button>
+      <button
+        onClick={handleGotIt}
+        className="py-3 min-h-[44px] rounded-lg font-medium transition-all active:scale-[0.95]"
+        style={{
+          background: 'color-mix(in srgb, var(--rating-good) 15%, var(--bg-surface))',
+          color: 'var(--rating-good)',
+        }}
+      >
+        Got it
+      </button>
+    </div>
+  ) : (
+    <div className="mt-6 grid grid-cols-2 sm:grid-cols-4 gap-2">
+      {([
+        { rating: 1 as const, label: 'Again', color: 'var(--rating-again)' },
+        { rating: 2 as const, label: 'Hard', color: 'var(--rating-hard)' },
+        { rating: 3 as const, label: 'Good', color: 'var(--rating-good)' },
+        { rating: 4 as const, label: 'Easy', color: 'var(--rating-easy)' },
+      ]).map((btn) => {
+        const isSelected = pendingRating === btn.rating;
+        const isDisabled = pendingRating !== null || undoing;
+        return (
+          <button
+            key={btn.rating}
+            onClick={() => handleRate(btn.rating)}
+            disabled={isDisabled}
+            className="py-3 min-h-[44px] rounded-lg font-medium transition-all active:scale-[0.95]"
+            style={{
+              background: isSelected
+                ? `color-mix(in srgb, ${btn.color} 50%, var(--bg-surface))`
+                : `color-mix(in srgb, ${btn.color} 15%, var(--bg-surface))`,
+              color: isSelected ? 'var(--text-inverted)' : btn.color,
+              opacity: isDisabled && !isSelected ? 0.4 : 1,
+            }}
+          >
+            {btn.label}
+          </button>
+        );
+      })}
+    </div>
+  );
 
   return (
     <div className="max-w-2xl mx-auto">
@@ -441,36 +507,9 @@ export function ReviewCard() {
 
               {/* Rating buttons — appear once a comparison exists; user grades themselves */}
               {comparison ? (
-                <div className="mt-6 grid grid-cols-2 sm:grid-cols-4 gap-2">
-                  {([
-                    { rating: 1 as const, label: 'Again', color: 'var(--rating-again)' },
-                    { rating: 2 as const, label: 'Hard', color: 'var(--rating-hard)' },
-                    { rating: 3 as const, label: 'Good', color: 'var(--rating-good)' },
-                    { rating: 4 as const, label: 'Easy', color: 'var(--rating-easy)' },
-                  ]).map((btn) => {
-                    const isSelected = pendingRating === btn.rating;
-                    const isDisabled = pendingRating !== null || undoing;
-                    return (
-                      <button
-                        key={btn.rating}
-                        onClick={() => handleRate(btn.rating)}
-                        disabled={isDisabled}
-                        className="py-3 min-h-[44px] rounded-lg font-medium transition-all active:scale-[0.95]"
-                        style={{
-                          background: isSelected
-                            ? `color-mix(in srgb, ${btn.color} 50%, var(--bg-surface))`
-                            : `color-mix(in srgb, ${btn.color} 15%, var(--bg-surface))`,
-                          color: isSelected ? 'var(--text-inverted)' : btn.color,
-                          opacity: isDisabled && !isSelected ? 0.4 : 1,
-                        }}
-                      >
-                        {btn.label}
-                      </button>
-                    );
-                  })}
-                </div>
+                actionBar
               ) : (
-                undoInfo && (
+                !isFreeReview && undoInfo && (
                   <button
                     onClick={handleUndo}
                     disabled={undoing || pendingRating !== null}
@@ -738,35 +777,7 @@ export function ReviewCard() {
               </p>
             )}
 
-            {/* Rating buttons */}
-            <div className="mt-6 grid grid-cols-2 sm:grid-cols-4 gap-2">
-              {([
-                { rating: 1 as const, label: 'Again', color: 'var(--rating-again)' },
-                { rating: 2 as const, label: 'Hard', color: 'var(--rating-hard)' },
-                { rating: 3 as const, label: 'Good', color: 'var(--rating-good)' },
-                { rating: 4 as const, label: 'Easy', color: 'var(--rating-easy)' },
-              ]).map((btn) => {
-                const isSelected = pendingRating === btn.rating;
-                const isDisabled = pendingRating !== null || undoing;
-                return (
-                  <button
-                    key={btn.rating}
-                    onClick={() => handleRate(btn.rating)}
-                    disabled={isDisabled}
-                    className="py-3 min-h-[44px] rounded-lg font-medium transition-all active:scale-[0.95]"
-                    style={{
-                      background: isSelected
-                        ? `color-mix(in srgb, ${btn.color} 50%, var(--bg-surface))`
-                        : `color-mix(in srgb, ${btn.color} 15%, var(--bg-surface))`,
-                      color: isSelected ? 'var(--text-inverted)' : btn.color,
-                      opacity: isDisabled && !isSelected ? 0.4 : 1,
-                    }}
-                  >
-                    {btn.label}
-                  </button>
-                );
-              })}
-            </div>
+            {actionBar}
           </>
         )}
         </>

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+
+interface Props {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+  autoFocus?: boolean;
+  className?: string;
+}
+
+export function SearchInput({ value, onChange, placeholder, autoFocus, className }: Props) {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (autoFocus) inputRef.current?.focus();
+  }, [autoFocus]);
+
+  return (
+    <div className={`relative ${className ?? ''}`}>
+      <div
+        className="absolute left-3.5 top-1/2 -translate-y-1/2 pointer-events-none"
+        style={{ color: 'var(--text-tertiary)' }}
+        aria-hidden
+      >
+        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+          <circle cx="11" cy="11" r="8" />
+          <line x1="21" y1="21" x2="16.65" y2="16.65" />
+        </svg>
+      </div>
+      <input
+        ref={inputRef}
+        type="text"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        className="w-full pl-9 pr-9 py-2 rounded-full text-sm outline-none transition-colors"
+        style={{
+          background: 'var(--bg-inset)',
+          color: 'var(--text-primary)',
+          border: '1px solid var(--border)',
+        }}
+        onFocus={(e) => { e.currentTarget.style.borderColor = 'var(--accent)'; }}
+        onBlur={(e) => { e.currentTarget.style.borderColor = 'var(--border)'; }}
+      />
+      {value && (
+        <button
+          type="button"
+          onClick={() => onChange('')}
+          aria-label="Clear search"
+          className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full flex items-center justify-center surface-hover transition-colors"
+          style={{ color: 'var(--text-tertiary)' }}
+        >
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18" />
+            <line x1="6" y1="6" x2="18" y2="18" />
+          </svg>
+        </button>
+      )}
+    </div>
+  );
+}

--- a/src/components/TagFilterRow.tsx
+++ b/src/components/TagFilterRow.tsx
@@ -5,14 +5,25 @@ interface Props {
   selected: string[];
   onChange: (tags: string[]) => void;
   className?: string;
+  allLabel?: string;
+  chipSize?: 'sm' | 'md';
 }
 
-export function TagFilterRow({ allTags, selected, onChange, className }: Props) {
+export function TagFilterRow({
+  allTags,
+  selected,
+  onChange,
+  className,
+  allLabel = 'All',
+  chipSize = 'sm',
+}: Props) {
   const [open, setOpen] = useState(false);
   if (allTags.length === 0) return null;
 
   const toggle = (tag: string) =>
     onChange(selected.includes(tag) ? selected.filter((t) => t !== tag) : [...selected, tag]);
+
+  const chipPadding = chipSize === 'md' ? 'px-2.5 py-1' : 'px-2 py-0.5';
 
   return (
     <div className={className}>
@@ -31,20 +42,20 @@ export function TagFilterRow({ allTags, selected, onChange, className }: Props) 
         <div className="flex flex-wrap items-center gap-1.5 mt-2">
           <button
             onClick={() => onChange([])}
-            className="px-2 py-0.5 text-xs rounded-full transition-colors"
+            className={`${chipPadding} text-xs rounded-full transition-colors`}
             style={
               selected.length === 0
                 ? { background: 'var(--text-primary)', color: 'var(--bg-surface)' }
                 : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
             }
           >
-            All
+            {allLabel}
           </button>
           {allTags.map((tag) => (
             <button
               key={tag}
               onClick={() => toggle(tag)}
-              className="px-2 py-0.5 text-xs rounded-full transition-colors"
+              className={`${chipPadding} text-xs rounded-full transition-colors`}
               style={
                 selected.includes(tag)
                   ? { background: 'var(--accent)', color: 'var(--text-inverted)' }

--- a/src/components/TagFilterRow.tsx
+++ b/src/components/TagFilterRow.tsx
@@ -1,0 +1,61 @@
+import { useState } from 'react';
+
+interface Props {
+  allTags: string[];
+  selected: string[];
+  onChange: (tags: string[]) => void;
+  className?: string;
+}
+
+export function TagFilterRow({ allTags, selected, onChange, className }: Props) {
+  const [open, setOpen] = useState(false);
+  if (allTags.length === 0) return null;
+
+  const toggle = (tag: string) =>
+    onChange(selected.includes(tag) ? selected.filter((t) => t !== tag) : [...selected, tag]);
+
+  return (
+    <div className={className}>
+      <button
+        onClick={() => setOpen(!open)}
+        className="text-xs px-2.5 py-1 rounded-full transition-colors"
+        style={
+          selected.length > 0
+            ? { background: 'color-mix(in srgb, var(--accent) 15%, var(--bg-surface))', color: 'var(--accent)' }
+            : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
+        }
+      >
+        Filter by tag{selected.length > 0 ? ` (${selected.length})` : ''} {open ? '▲' : '▼'}
+      </button>
+      {open && (
+        <div className="flex flex-wrap items-center gap-1.5 mt-2">
+          <button
+            onClick={() => onChange([])}
+            className="px-2 py-0.5 text-xs rounded-full transition-colors"
+            style={
+              selected.length === 0
+                ? { background: 'var(--text-primary)', color: 'var(--bg-surface)' }
+                : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
+            }
+          >
+            All
+          </button>
+          {allTags.map((tag) => (
+            <button
+              key={tag}
+              onClick={() => toggle(tag)}
+              className="px-2 py-0.5 text-xs rounded-full transition-colors"
+              style={
+                selected.includes(tag)
+                  ? { background: 'var(--accent)', color: 'var(--text-inverted)' }
+                  : { background: 'color-mix(in srgb, var(--accent) 10%, var(--bg-surface))', color: 'var(--accent)' }
+              }
+            >
+              {tag}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/lib/pinyinCompare.ts
+++ b/src/lib/pinyinCompare.ts
@@ -5,6 +5,14 @@
  * and plain letters (ni hao) all compare sensibly.
  */
 
+/**
+ * Strip diacritics, digits, whitespace; lowercase. Lets a typed substring
+ * match across either pinyin format ("hua" matches "huā" and "hua1").
+ */
+export function normalizePinyin(s: string): string {
+  return s.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[\s0-9]/g, '');
+}
+
 // ---- tone-mark ↔ tone-number mapping -----------------------------------
 
 const DIACRITIC_TO_BASE: Record<string, [string, number]> = {

--- a/src/pages/BrowsePage.tsx
+++ b/src/pages/BrowsePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useNavigate } from 'react-router';
 import * as repo from '../db/repo';
 import type { Sentence } from '../db/schema';
@@ -18,6 +18,11 @@ import type { SentenceToken, Meaning, SrsCard } from '../db/schema';
 import { getMeaningPinyin } from '../lib/meaningPinyin';
 
 type TokenWithMeaning = SentenceToken & { meaning: Meaning };
+
+/** Strip diacritics, digits, whitespace; lowercase. Lets "hua" match "huā". */
+function normalizePinyin(s: string): string {
+  return s.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[\s0-9]/g, '');
+}
 
 const SORT_DIMENSION_LABELS: Record<ReviewMode, string> = {
   'en-to-zh': 'EN→ZH',
@@ -79,6 +84,9 @@ export function BrowsePage() {
   const [cardsBySentence, setCardsBySentence] = useState<Map<string, SrsCard[]>>(new Map());
   const [sortMode, setSortMode] = useState<'newest' | 'best-known' | 'least-known'>('newest');
   const [sortDimension, setSortDimension] = useState<'overall' | ReviewMode>('overall');
+  const [search, setSearch] = useState('');
+  const [searchOpen, setSearchOpen] = useState(false);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     repo.getSentencesOrderByCreatedDesc().then(setSentences);
@@ -111,16 +119,27 @@ export function BrowsePage() {
   };
 
   const filteredSentences = useMemo(() => {
-    const base = filterTags.length > 0
+    let base = filterTags.length > 0
       ? sentences.filter((s) => filterTags.some((t) => s.tags?.includes(t)))
       : sentences;
+    const q = search.trim();
+    if (q) {
+      const qLower = q.toLowerCase();
+      const qPinyin = normalizePinyin(q);
+      base = base.filter((s) =>
+        s.chinese.includes(q) ||
+        s.english.toLowerCase().includes(qLower) ||
+        normalizePinyin(s.pinyin).includes(qPinyin) ||
+        normalizePinyin(s.pinyinSandhi).includes(qPinyin)
+      );
+    }
     if (sortMode === 'newest') return base;
     const scored = [...base];
     scored.sort((a, b) => sortMode === 'best-known'
       ? masteryOf(b.id) - masteryOf(a.id)
       : masteryOf(a.id) - masteryOf(b.id));
     return scored;
-  }, [sentences, filterTags, sortMode, sortDimension, cardsBySentence]);
+  }, [sentences, filterTags, search, sortMode, sortDimension, cardsBySentence]);
 
   const handleDelete = async (sentenceId: string) => {
     await deleteSentence(sentenceId);
@@ -168,13 +187,35 @@ export function BrowsePage() {
         </button>
         <h1 className="text-xl font-bold">Browse</h1>
         {sentences.length > 0 ? (
-          <button
-            onClick={() => setShowDeleteAll(true)}
-            className="px-3 py-1 rounded text-sm transition-colors"
-            style={{ background: 'var(--bg-inset)', color: 'var(--danger)' }}
-          >
-            Delete All
-          </button>
+          <div className="flex gap-1">
+            <button
+              onClick={() => {
+                const next = !searchOpen;
+                setSearchOpen(next);
+                if (!next) setSearch('');
+                else setTimeout(() => searchInputRef.current?.focus(), 0);
+              }}
+              aria-label="Toggle search"
+              aria-pressed={searchOpen}
+              className="px-2.5 py-1 rounded text-sm transition-colors flex items-center"
+              style={{
+                background: 'var(--bg-inset)',
+                color: searchOpen || search ? 'var(--accent)' : 'var(--text-secondary)',
+              }}
+            >
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <circle cx="11" cy="11" r="8" />
+                <line x1="21" y1="21" x2="16.65" y2="16.65" />
+              </svg>
+            </button>
+            <button
+              onClick={() => setShowDeleteAll(true)}
+              className="px-3 py-1 rounded text-sm transition-colors"
+              style={{ background: 'var(--bg-inset)', color: 'var(--danger)' }}
+            >
+              Delete All
+            </button>
+          </div>
         ) : (
           <div className="w-20" />
         )}
@@ -190,6 +231,50 @@ export function BrowsePage() {
         You'll see that 花 has two separate meaning entries. You can also click on the
         <strong> shì</strong> pinyin to see all characters that share that sound.
       </TutorialBanner>
+
+      {sentences.length > 0 && searchOpen && (
+        <div className="mb-3 relative">
+          <div
+            className="absolute left-3.5 top-1/2 -translate-y-1/2 pointer-events-none"
+            style={{ color: 'var(--text-tertiary)' }}
+            aria-hidden
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="11" cy="11" r="8" />
+              <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+          </div>
+          <input
+            ref={searchInputRef}
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search Chinese, pinyin, or English"
+            className="w-full pl-9 pr-9 py-2 rounded-full text-sm outline-none transition-colors"
+            style={{
+              background: 'var(--bg-inset)',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border)',
+            }}
+            onFocus={(e) => { e.currentTarget.style.borderColor = 'var(--accent)'; }}
+            onBlur={(e) => { e.currentTarget.style.borderColor = 'var(--border)'; }}
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch('')}
+              aria-label="Clear search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full flex items-center justify-center surface-hover transition-colors"
+              style={{ color: 'var(--text-tertiary)' }}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          )}
+        </div>
+      )}
 
       {sentences.length > 0 && (
         <div className="mb-4 space-y-2">

--- a/src/pages/BrowsePage.tsx
+++ b/src/pages/BrowsePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router';
 import * as repo from '../db/repo';
 import type { Sentence } from '../db/schema';
@@ -16,13 +16,11 @@ import { useTutorialStore } from '../stores/tutorialStore';
 import { TutorialBanner } from '../components/TutorialBanner';
 import type { SentenceToken, Meaning, SrsCard } from '../db/schema';
 import { getMeaningPinyin } from '../lib/meaningPinyin';
+import { normalizePinyin } from '../lib/pinyinCompare';
+import { TagFilterRow } from '../components/TagFilterRow';
+import { SearchInput } from '../components/SearchInput';
 
 type TokenWithMeaning = SentenceToken & { meaning: Meaning };
-
-/** Strip diacritics, digits, whitespace; lowercase. Lets "hua" match "huā". */
-function normalizePinyin(s: string): string {
-  return s.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[\s0-9]/g, '');
-}
 
 const SORT_DIMENSION_LABELS: Record<ReviewMode, string> = {
   'en-to-zh': 'EN→ZH',
@@ -77,7 +75,6 @@ export function BrowsePage() {
   const [editingTagsId, setEditingTagsId] = useState<string | null>(null);
   const [allTags, setAllTags] = useState<string[]>([]);
   const [filterTags, setFilterTags] = useState<string[]>([]);
-  const [showFilter, setShowFilter] = useState(false);
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
   const [showDeleteAll, setShowDeleteAll] = useState(false);
   const [deleteAllInput, setDeleteAllInput] = useState('');
@@ -86,7 +83,6 @@ export function BrowsePage() {
   const [sortDimension, setSortDimension] = useState<'overall' | ReviewMode>('overall');
   const [search, setSearch] = useState('');
   const [searchOpen, setSearchOpen] = useState(false);
-  const searchInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     repo.getSentencesOrderByCreatedDesc().then(setSentences);
@@ -110,12 +106,6 @@ export function BrowsePage() {
       prev.map((s) => (s.id === sentenceId ? { ...s, tags: newTags } : s))
     );
     getAllTags().then(setAllTags);
-  };
-
-  const toggleFilterTag = (tag: string) => {
-    setFilterTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
-    );
   };
 
   const filteredSentences = useMemo(() => {
@@ -193,7 +183,6 @@ export function BrowsePage() {
                 const next = !searchOpen;
                 setSearchOpen(next);
                 if (!next) setSearch('');
-                else setTimeout(() => searchInputRef.current?.focus(), 0);
               }}
               aria-label="Toggle search"
               aria-pressed={searchOpen}
@@ -233,47 +222,13 @@ export function BrowsePage() {
       </TutorialBanner>
 
       {sentences.length > 0 && searchOpen && (
-        <div className="mb-3 relative">
-          <div
-            className="absolute left-3.5 top-1/2 -translate-y-1/2 pointer-events-none"
-            style={{ color: 'var(--text-tertiary)' }}
-            aria-hidden
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="11" cy="11" r="8" />
-              <line x1="21" y1="21" x2="16.65" y2="16.65" />
-            </svg>
-          </div>
-          <input
-            ref={searchInputRef}
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search Chinese, pinyin, or English"
-            className="w-full pl-9 pr-9 py-2 rounded-full text-sm outline-none transition-colors"
-            style={{
-              background: 'var(--bg-inset)',
-              color: 'var(--text-primary)',
-              border: '1px solid var(--border)',
-            }}
-            onFocus={(e) => { e.currentTarget.style.borderColor = 'var(--accent)'; }}
-            onBlur={(e) => { e.currentTarget.style.borderColor = 'var(--border)'; }}
-          />
-          {search && (
-            <button
-              type="button"
-              onClick={() => setSearch('')}
-              aria-label="Clear search"
-              className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full flex items-center justify-center surface-hover transition-colors"
-              style={{ color: 'var(--text-tertiary)' }}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                <line x1="18" y1="6" x2="6" y2="18" />
-                <line x1="6" y1="6" x2="18" y2="18" />
-              </svg>
-            </button>
-          )}
-        </div>
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Search Chinese, pinyin, or English"
+          autoFocus
+          className="mb-3"
+        />
       )}
 
       {sentences.length > 0 && (
@@ -321,47 +276,12 @@ export function BrowsePage() {
         </div>
       )}
 
-      {allTags.length > 0 && (
-        <div className="mb-4">
-          <button
-            onClick={() => setShowFilter(!showFilter)}
-            className="text-xs px-2.5 py-1 rounded-full transition-colors"
-            style={filterTags.length > 0
-              ? { background: 'color-mix(in srgb, var(--accent) 15%, var(--bg-surface))', color: 'var(--accent)' }
-              : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
-            }
-          >
-            Filter by tag{filterTags.length > 0 ? ` (${filterTags.length})` : ''} {showFilter ? '\u25B2' : '\u25BC'}
-          </button>
-          {showFilter && (
-            <div className="flex flex-wrap items-center gap-1.5 mt-2">
-              <button
-                onClick={() => setFilterTags([])}
-                className="px-2 py-0.5 text-xs rounded-full transition-colors"
-                style={filterTags.length === 0
-                  ? { background: 'var(--text-primary)', color: 'var(--bg-surface)' }
-                  : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
-                }
-              >
-                All
-              </button>
-              {allTags.map((tag) => (
-                <button
-                  key={tag}
-                  onClick={() => toggleFilterTag(tag)}
-                  className="px-2 py-0.5 text-xs rounded-full transition-colors"
-                  style={filterTags.includes(tag)
-                    ? { background: 'var(--accent)', color: 'var(--text-inverted)' }
-                    : { background: 'color-mix(in srgb, var(--accent) 10%, var(--bg-surface))', color: 'var(--accent)' }
-                  }
-                >
-                  {tag}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-      )}
+      <TagFilterRow
+        allTags={allTags}
+        selected={filterTags}
+        onChange={setFilterTags}
+        className="mb-4"
+      />
 
       {sentences.length === 0 ? (
         <div className="text-center py-12" style={{ color: 'var(--text-tertiary)' }}>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -114,6 +114,17 @@ export function DashboardPage() {
         >
           {dueForMode > 0 ? `Study (${dueForMode} cards)` : 'No cards due'}
         </button>
+        <button
+          onClick={() => navigate('/free-review')}
+          className="mt-2 w-full py-2 rounded-lg text-xs font-medium transition-colors"
+          style={{
+            background: 'transparent',
+            color: 'var(--text-secondary)',
+            border: '1px solid var(--border-strong)',
+          }}
+        >
+          Free review (no schedule effect)
+        </button>
       </div>
 
       {/* Quick actions — ghost buttons */}

--- a/src/pages/FreeReviewPage.tsx
+++ b/src/pages/FreeReviewPage.tsx
@@ -1,0 +1,393 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router';
+import { useReviewStore } from '../stores/reviewStore';
+import { getFreeReviewQueue } from '../services/srs';
+import { getAllTags } from '../services/ingestion';
+import * as repo from '../db/repo';
+import { ReviewCard } from '../components/ReviewCard';
+import { MeaningCard } from '../components/MeaningCard';
+import type { ReviewMode, Sentence } from '../db/schema';
+import { ensureDefaultDeck } from '../db/repo';
+
+type ModeOption = ReviewMode | 'both';
+
+interface LocationState {
+  /** Sentence IDs forwarded from BrowsePage multi-select. */
+  sentenceIds?: string[];
+}
+
+function normalizePinyin(s: string): string {
+  return s.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[\s0-9]/g, '');
+}
+
+export function FreeReviewPage() {
+  const navigate = useNavigate();
+  const location = useLocation();
+  const incomingSentenceIds = (location.state as LocationState | null)?.sentenceIds ?? null;
+
+  const { setQueue, remaining, reset } = useReviewStore();
+  const [sentences, setSentences] = useState<Sentence[]>([]);
+  const [allTags, setAllTags] = useState<string[]>([]);
+  const [search, setSearch] = useState('');
+  const [filterTags, setFilterTags] = useState<string[]>([]);
+  const [showFilter, setShowFilter] = useState(false);
+  const [cart, setCart] = useState<Set<string>>(() =>
+    incomingSentenceIds ? new Set(incomingSentenceIds) : new Set()
+  );
+  const [mode, setMode] = useState<ModeOption>('both');
+  const [shuffle, setShuffle] = useState(true);
+  const [limitInput, setLimitInput] = useState('');
+  const [showOptions, setShowOptions] = useState(false);
+  const [started, setStarted] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [empty, setEmpty] = useState(false);
+  const startedRef = useRef(false);
+
+  useEffect(() => {
+    repo.getSentencesOrderByCreatedDesc().then(setSentences);
+    getAllTags().then(setAllTags);
+  }, []);
+
+  // Clear shared review store on unmount so /review later doesn't see free-review state.
+  useEffect(() => () => reset(), []);
+
+  const toggleCart = (sentenceId: string) => {
+    setCart((prev) => {
+      const next = new Set(prev);
+      if (next.has(sentenceId)) next.delete(sentenceId);
+      else next.add(sentenceId);
+      return next;
+    });
+  };
+
+  const toggleFilterTag = (tag: string) => {
+    setFilterTags((prev) =>
+      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
+    );
+  };
+
+  const filteredSentences = useMemo(() => {
+    let base = filterTags.length > 0
+      ? sentences.filter((s) => filterTags.some((t) => s.tags?.includes(t)))
+      : sentences;
+    const q = search.trim();
+    if (q) {
+      const qLower = q.toLowerCase();
+      const qPinyin = normalizePinyin(q);
+      base = base.filter((s) =>
+        s.chinese.includes(q) ||
+        s.english.toLowerCase().includes(qLower) ||
+        normalizePinyin(s.pinyin).includes(qPinyin) ||
+        normalizePinyin(s.pinyinSandhi).includes(qPinyin)
+      );
+    }
+    return base;
+  }, [sentences, filterTags, search]);
+
+  const start = async () => {
+    if (startedRef.current || cart.size === 0) return;
+    startedRef.current = true;
+    setLoading(true);
+    setEmpty(false);
+    try {
+      const deckId = await ensureDefaultDeck();
+      const parsedLimit = parseInt(limitInput, 10);
+      const queue = await getFreeReviewQueue({
+        deckId,
+        mode,
+        sentenceIds: [...cart],
+        shuffle,
+        limit: Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : null,
+      });
+      if (queue.length === 0) {
+        setEmpty(true);
+        startedRef.current = false;
+        return;
+      }
+      setQueue(queue, { freeReview: true });
+      setStarted(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!started) {
+    return (
+      <div className="px-4 pt-12 pb-40 sm:px-6 sm:pt-6 max-w-md mx-auto">
+        <div className="flex items-center justify-between mb-4">
+          <button
+            onClick={() => navigate('/')}
+            className="px-3 py-1 rounded text-sm surface-hover transition-colors"
+            style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+          >
+            &larr; Back
+          </button>
+          <h1 className="text-xl font-bold">Free review</h1>
+          <div className="w-12" />
+        </div>
+
+        <p className="text-xs mb-4 text-center" style={{ color: 'var(--text-tertiary)' }}>
+          Drill cards without affecting your schedule.
+        </p>
+
+        {/* Search */}
+        <div className="mb-2 relative">
+          <div
+            className="absolute left-3.5 top-1/2 -translate-y-1/2 pointer-events-none"
+            style={{ color: 'var(--text-tertiary)' }}
+            aria-hidden
+          >
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+              <circle cx="11" cy="11" r="8" />
+              <line x1="21" y1="21" x2="16.65" y2="16.65" />
+            </svg>
+          </div>
+          <input
+            type="text"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search Chinese, pinyin, or English"
+            className="w-full pl-9 pr-9 py-2 rounded-full text-sm outline-none transition-colors"
+            style={{
+              background: 'var(--bg-inset)',
+              color: 'var(--text-primary)',
+              border: '1px solid var(--border)',
+            }}
+            onFocus={(e) => { e.currentTarget.style.borderColor = 'var(--accent)'; }}
+            onBlur={(e) => { e.currentTarget.style.borderColor = 'var(--border)'; }}
+          />
+          {search && (
+            <button
+              type="button"
+              onClick={() => setSearch('')}
+              aria-label="Clear search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full flex items-center justify-center surface-hover transition-colors"
+              style={{ color: 'var(--text-tertiary)' }}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <line x1="18" y1="6" x2="6" y2="18" />
+                <line x1="6" y1="6" x2="18" y2="18" />
+              </svg>
+            </button>
+          )}
+        </div>
+
+        {/* Tag filter */}
+        {allTags.length > 0 && (
+          <div className="mb-3">
+            <button
+              onClick={() => setShowFilter(!showFilter)}
+              className="text-xs px-2.5 py-1 rounded-full transition-colors"
+              style={
+                filterTags.length > 0
+                  ? { background: 'color-mix(in srgb, var(--accent) 15%, var(--bg-surface))', color: 'var(--accent)' }
+                  : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
+              }
+            >
+              Filter by tag{filterTags.length > 0 ? ` (${filterTags.length})` : ''} {showFilter ? '▲' : '▼'}
+            </button>
+            {showFilter && (
+              <div className="flex flex-wrap gap-1.5 mt-2">
+                <button
+                  onClick={() => setFilterTags([])}
+                  className="px-2 py-0.5 text-xs rounded-full transition-colors"
+                  style={
+                    filterTags.length === 0
+                      ? { background: 'var(--text-primary)', color: 'var(--bg-surface)' }
+                      : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
+                  }
+                >
+                  All
+                </button>
+                {allTags.map((tag) => (
+                  <button
+                    key={tag}
+                    onClick={() => toggleFilterTag(tag)}
+                    className="px-2 py-0.5 text-xs rounded-full transition-colors"
+                    style={
+                      filterTags.includes(tag)
+                        ? { background: 'var(--accent)', color: 'var(--text-inverted)' }
+                        : { background: 'color-mix(in srgb, var(--accent) 10%, var(--bg-surface))', color: 'var(--accent)' }
+                    }
+                  >
+                    {tag}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* Sentence list */}
+        <div className="space-y-1.5">
+          {filteredSentences.length === 0 ? (
+            <p className="text-center py-6 text-sm" style={{ color: 'var(--text-tertiary)' }}>
+              No sentences match.
+            </p>
+          ) : (
+            filteredSentences.map((s) => {
+              const isInCart = cart.has(s.id);
+              return (
+                <button
+                  key={s.id}
+                  onClick={() => toggleCart(s.id)}
+                  className="w-full text-left px-3 py-2 rounded-lg transition-colors flex items-center gap-3"
+                  style={{
+                    background: isInCart ? 'color-mix(in srgb, var(--accent) 10%, var(--bg-surface))' : 'var(--bg-surface)',
+                    border: `1px solid ${isInCart ? 'color-mix(in srgb, var(--accent) 40%, transparent)' : 'var(--border)'}`,
+                  }}
+                >
+                  <div
+                    className="shrink-0 w-5 h-5 rounded-full flex items-center justify-center"
+                    style={{
+                      background: isInCart ? 'var(--accent)' : 'transparent',
+                      border: `2px solid ${isInCart ? 'var(--accent)' : 'var(--border-strong)'}`,
+                      color: 'var(--text-inverted)',
+                    }}
+                  >
+                    {isInCart && (
+                      <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
+                        <polyline points="20 6 9 17 4 12" />
+                      </svg>
+                    )}
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <div className="text-base truncate">{s.chinese}</div>
+                    <div className="text-xs truncate" style={{ color: 'var(--text-secondary)' }}>
+                      {s.english}
+                    </div>
+                  </div>
+                </button>
+              );
+            })
+          )}
+        </div>
+
+        {/* Sticky bottom: options + start */}
+        <div
+          className="fixed inset-x-0 bottom-0 z-40 px-4 pb-4 pt-3"
+          style={{
+            background: 'color-mix(in srgb, var(--bg-surface) 92%, transparent)',
+            borderTop: '1px solid var(--border)',
+            backdropFilter: 'blur(8px)',
+          }}
+        >
+          <div className="max-w-md mx-auto">
+            {showOptions && (
+              <div className="mb-3 space-y-3">
+                <div>
+                  <p className="text-xs mb-1" style={{ color: 'var(--text-tertiary)' }}>Mode</p>
+                  <div className="grid grid-cols-3 gap-1">
+                    {([
+                      { key: 'both' as ModeOption, label: 'All' },
+                      { key: 'en-to-zh' as ModeOption, label: 'EN→ZH' },
+                      { key: 'zh-to-en' as ModeOption, label: 'ZH→EN' },
+                      { key: 'py-to-en-zh' as ModeOption, label: 'PY→' },
+                      { key: 'listen-type' as ModeOption, label: 'Listen' },
+                      { key: 'speak' as ModeOption, label: 'Speak' },
+                    ]).map((opt) => {
+                      const selected = mode === opt.key;
+                      return (
+                        <button
+                          key={opt.key}
+                          onClick={() => setMode(opt.key)}
+                          className="px-2 py-1 rounded text-xs font-medium transition-colors"
+                          style={
+                            selected
+                              ? { background: 'var(--accent)', color: 'var(--text-inverted)' }
+                              : { background: 'var(--bg-inset)', color: 'var(--text-tertiary)' }
+                          }
+                        >
+                          {opt.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+                <div className="flex items-center justify-between gap-3">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs" style={{ color: 'var(--text-tertiary)' }}>Shuffle</span>
+                    <button
+                      onClick={() => setShuffle(!shuffle)}
+                      className="px-2.5 py-0.5 rounded-full text-xs font-medium transition-colors"
+                      style={
+                        shuffle
+                          ? { background: 'var(--accent)', color: 'var(--text-inverted)' }
+                          : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
+                      }
+                    >
+                      {shuffle ? 'On' : 'Off'}
+                    </button>
+                  </div>
+                  <div className="flex items-center gap-2 flex-1">
+                    <span className="text-xs" style={{ color: 'var(--text-tertiary)' }}>Cap</span>
+                    <input
+                      type="number"
+                      inputMode="numeric"
+                      min={1}
+                      value={limitInput}
+                      onChange={(e) => setLimitInput(e.target.value)}
+                      placeholder="None"
+                      className="flex-1 px-2 py-1 rounded text-xs"
+                      style={{ background: 'var(--bg-inset)', color: 'var(--text-primary)', border: '1px solid var(--border)' }}
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="flex items-center justify-between mb-2">
+              <button
+                onClick={() => setShowOptions(!showOptions)}
+                className="text-xs transition-colors"
+                style={{ color: 'var(--text-tertiary)' }}
+              >
+                Options {showOptions ? '▲' : '▼'}
+              </button>
+              <span className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
+                {cart.size} selected
+              </span>
+            </div>
+
+            {empty && (
+              <p className="mb-2 text-xs text-center" style={{ color: 'var(--danger)' }}>
+                No cards match for this mode.
+              </p>
+            )}
+
+            <button
+              onClick={start}
+              disabled={loading || cart.size === 0}
+              className="w-full py-3 rounded-lg font-medium transition-all active:scale-[0.98] disabled:opacity-40"
+              style={{ background: 'var(--accent)', color: 'var(--text-inverted)' }}
+            >
+              {loading ? 'Loading…' : `Start free review${cart.size > 0 ? ` (${cart.size})` : ''}`}
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 pt-12 pb-4 sm:p-6">
+      <div className="flex items-center justify-between mb-6 max-w-2xl mx-auto">
+        <button
+          onClick={() => {
+            reset();
+            navigate('/');
+          }}
+          className="px-3 py-1 rounded text-sm transition-colors"
+          style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+        >
+          &larr; Back
+        </button>
+        <h1 className="text-xl font-bold">Free review</h1>
+        <div className="text-sm" style={{ color: 'var(--text-tertiary)' }}>{remaining()} left</div>
+      </div>
+
+      <ReviewCard />
+      <MeaningCard />
+    </div>
+  );
+}

--- a/src/pages/FreeReviewPage.tsx
+++ b/src/pages/FreeReviewPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { useReviewStore } from '../stores/reviewStore';
 import { getFreeReviewQueue } from '../services/srs';
@@ -7,17 +7,15 @@ import * as repo from '../db/repo';
 import { ReviewCard } from '../components/ReviewCard';
 import { MeaningCard } from '../components/MeaningCard';
 import type { ReviewMode, Sentence } from '../db/schema';
-import { ensureDefaultDeck } from '../db/repo';
+import { normalizePinyin } from '../lib/pinyinCompare';
+import { TagFilterRow } from '../components/TagFilterRow';
+import { SearchInput } from '../components/SearchInput';
 
 type ModeOption = ReviewMode | 'both';
 
 interface LocationState {
   /** Sentence IDs forwarded from BrowsePage multi-select. */
   sentenceIds?: string[];
-}
-
-function normalizePinyin(s: string): string {
-  return s.normalize('NFD').replace(/[̀-ͯ]/g, '').toLowerCase().replace(/[\s0-9]/g, '');
 }
 
 export function FreeReviewPage() {
@@ -30,7 +28,6 @@ export function FreeReviewPage() {
   const [allTags, setAllTags] = useState<string[]>([]);
   const [search, setSearch] = useState('');
   const [filterTags, setFilterTags] = useState<string[]>([]);
-  const [showFilter, setShowFilter] = useState(false);
   const [cart, setCart] = useState<Set<string>>(() =>
     incomingSentenceIds ? new Set(incomingSentenceIds) : new Set()
   );
@@ -41,7 +38,6 @@ export function FreeReviewPage() {
   const [started, setStarted] = useState(false);
   const [loading, setLoading] = useState(false);
   const [empty, setEmpty] = useState(false);
-  const startedRef = useRef(false);
 
   useEffect(() => {
     repo.getSentencesOrderByCreatedDesc().then(setSentences);
@@ -52,18 +48,13 @@ export function FreeReviewPage() {
   useEffect(() => () => reset(), []);
 
   const toggleCart = (sentenceId: string) => {
+    setEmpty(false);
     setCart((prev) => {
       const next = new Set(prev);
       if (next.has(sentenceId)) next.delete(sentenceId);
       else next.add(sentenceId);
       return next;
     });
-  };
-
-  const toggleFilterTag = (tag: string) => {
-    setFilterTags((prev) =>
-      prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
-    );
   };
 
   const filteredSentences = useMemo(() => {
@@ -85,23 +76,21 @@ export function FreeReviewPage() {
   }, [sentences, filterTags, search]);
 
   const start = async () => {
-    if (startedRef.current || cart.size === 0) return;
-    startedRef.current = true;
+    if (loading || cart.size === 0) return;
     setLoading(true);
     setEmpty(false);
     try {
-      const deckId = await ensureDefaultDeck();
+      const deckId = await repo.ensureDefaultDeck();
       const parsedLimit = parseInt(limitInput, 10);
       const queue = await getFreeReviewQueue({
         deckId,
         mode,
         sentenceIds: [...cart],
         shuffle,
-        limit: Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : null,
+        limit: parsedLimit > 0 ? parsedLimit : null,
       });
       if (queue.length === 0) {
         setEmpty(true);
-        startedRef.current = false;
         return;
       }
       setQueue(queue, { freeReview: true });
@@ -130,93 +119,19 @@ export function FreeReviewPage() {
           Drill cards without affecting your schedule.
         </p>
 
-        {/* Search */}
-        <div className="mb-2 relative">
-          <div
-            className="absolute left-3.5 top-1/2 -translate-y-1/2 pointer-events-none"
-            style={{ color: 'var(--text-tertiary)' }}
-            aria-hidden
-          >
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-              <circle cx="11" cy="11" r="8" />
-              <line x1="21" y1="21" x2="16.65" y2="16.65" />
-            </svg>
-          </div>
-          <input
-            type="text"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-            placeholder="Search Chinese, pinyin, or English"
-            className="w-full pl-9 pr-9 py-2 rounded-full text-sm outline-none transition-colors"
-            style={{
-              background: 'var(--bg-inset)',
-              color: 'var(--text-primary)',
-              border: '1px solid var(--border)',
-            }}
-            onFocus={(e) => { e.currentTarget.style.borderColor = 'var(--accent)'; }}
-            onBlur={(e) => { e.currentTarget.style.borderColor = 'var(--border)'; }}
-          />
-          {search && (
-            <button
-              type="button"
-              onClick={() => setSearch('')}
-              aria-label="Clear search"
-              className="absolute right-2 top-1/2 -translate-y-1/2 w-6 h-6 rounded-full flex items-center justify-center surface-hover transition-colors"
-              style={{ color: 'var(--text-tertiary)' }}
-            >
-              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
-                <line x1="18" y1="6" x2="6" y2="18" />
-                <line x1="6" y1="6" x2="18" y2="18" />
-              </svg>
-            </button>
-          )}
-        </div>
+        <SearchInput
+          value={search}
+          onChange={setSearch}
+          placeholder="Search Chinese, pinyin, or English"
+          className="mb-2"
+        />
 
-        {/* Tag filter */}
-        {allTags.length > 0 && (
-          <div className="mb-3">
-            <button
-              onClick={() => setShowFilter(!showFilter)}
-              className="text-xs px-2.5 py-1 rounded-full transition-colors"
-              style={
-                filterTags.length > 0
-                  ? { background: 'color-mix(in srgb, var(--accent) 15%, var(--bg-surface))', color: 'var(--accent)' }
-                  : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
-              }
-            >
-              Filter by tag{filterTags.length > 0 ? ` (${filterTags.length})` : ''} {showFilter ? '▲' : '▼'}
-            </button>
-            {showFilter && (
-              <div className="flex flex-wrap gap-1.5 mt-2">
-                <button
-                  onClick={() => setFilterTags([])}
-                  className="px-2 py-0.5 text-xs rounded-full transition-colors"
-                  style={
-                    filterTags.length === 0
-                      ? { background: 'var(--text-primary)', color: 'var(--bg-surface)' }
-                      : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
-                  }
-                >
-                  All
-                </button>
-                {allTags.map((tag) => (
-                  <button
-                    key={tag}
-                    onClick={() => toggleFilterTag(tag)}
-                    className="px-2 py-0.5 text-xs rounded-full transition-colors"
-                    style={
-                      filterTags.includes(tag)
-                        ? { background: 'var(--accent)', color: 'var(--text-inverted)' }
-                        : { background: 'color-mix(in srgb, var(--accent) 10%, var(--bg-surface))', color: 'var(--accent)' }
-                    }
-                  >
-                    {tag}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        )}
+        <TagFilterRow
+          allTags={allTags}
+          selected={filterTags}
+          onChange={setFilterTags}
+          className="mb-3"
+        />
 
         {/* Sentence list */}
         <div className="space-y-1.5">

--- a/src/pages/FreeReviewPage.tsx
+++ b/src/pages/FreeReviewPage.tsx
@@ -47,7 +47,8 @@ export function FreeReviewPage() {
   // Clear shared review store on unmount so /review later doesn't see free-review state.
   useEffect(() => () => reset(), []);
 
-  // Clear the "no cards match for this mode" message when the user switches modes.
+  // `empty` reflects the last start() attempt against the previous mode;
+  // a mode change invalidates it, otherwise the stale banner persists.
   useEffect(() => {
     setEmpty(false);
   }, [mode]);

--- a/src/pages/FreeReviewPage.tsx
+++ b/src/pages/FreeReviewPage.tsx
@@ -47,6 +47,11 @@ export function FreeReviewPage() {
   // Clear shared review store on unmount so /review later doesn't see free-review state.
   useEffect(() => () => reset(), []);
 
+  // Clear the "no cards match for this mode" message when the user switches modes.
+  useEffect(() => {
+    setEmpty(false);
+  }, [mode]);
+
   const toggleCart = (sentenceId: string) => {
     setEmpty(false);
     setCart((prev) => {
@@ -74,6 +79,20 @@ export function FreeReviewPage() {
     }
     return base;
   }, [sentences, filterTags, search]);
+
+  const allFilteredInCart =
+    filteredSentences.length > 0 && filteredSentences.every((s) => cart.has(s.id));
+
+  const toggleAllFiltered = () => {
+    if (filteredSentences.length === 0) return;
+    setEmpty(false);
+    setCart((prev) => {
+      const next = new Set(prev);
+      if (allFilteredInCart) filteredSentences.forEach((s) => next.delete(s.id));
+      else filteredSentences.forEach((s) => next.add(s.id));
+      return next;
+    });
+  };
 
   const start = async () => {
     if (loading || cart.size === 0) return;
@@ -132,6 +151,25 @@ export function FreeReviewPage() {
           onChange={setFilterTags}
           className="mb-3"
         />
+
+        {filteredSentences.length > 0 && (
+          <div className="flex items-center justify-between mb-2">
+            <span className="text-xs" style={{ color: 'var(--text-tertiary)' }}>
+              {filteredSentences.length} match{filteredSentences.length === 1 ? '' : 'es'}
+            </span>
+            <button
+              onClick={toggleAllFiltered}
+              className="text-xs px-2.5 py-1 rounded-full transition-colors"
+              style={
+                allFilteredInCart
+                  ? { background: 'color-mix(in srgb, var(--accent) 15%, var(--bg-surface))', color: 'var(--accent)' }
+                  : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
+              }
+            >
+              {allFilteredInCart ? 'Deselect all' : 'Select all'}
+            </button>
+          </div>
+        )}
 
         {/* Sentence list */}
         <div className="space-y-1.5">

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -5,6 +5,7 @@ import { getReviewQueue } from '../services/srs';
 import { getAllTags } from '../services/ingestion';
 import { ReviewCard } from '../components/ReviewCard';
 import { MeaningCard } from '../components/MeaningCard';
+import { TagFilterRow } from '../components/TagFilterRow';
 import type { ReviewMode } from '../db/schema';
 import { ensureDefaultDeck } from '../db/repo';
 
@@ -28,7 +29,6 @@ export function ReviewPage() {
   const [started, setStarted] = useState(false);
   const [allTags, setAllTags] = useState<string[]>([]);
   const [filterTags, setFilterTags] = useState<string[]>([]);
-  const [showFilter, setShowFilter] = useState(false);
   const [loading, setLoading] = useState(false);
   const [loadingMode, setLoadingMode] = useState<ModeOption | null>(null);
   const autoStarted = useRef(false);
@@ -90,49 +90,14 @@ export function ReviewPage() {
         </div>
 
         <div className="space-y-3">
-          {allTags.length > 0 && (
-            <div className="mb-4">
-              <button
-                onClick={() => setShowFilter(!showFilter)}
-                className="text-xs px-2.5 py-1 rounded-full transition-colors"
-                style={filterTags.length > 0
-                  ? { background: 'color-mix(in srgb, var(--accent) 15%, var(--bg-surface))', color: 'var(--accent)' }
-                  : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
-                }
-              >
-                Filter by tag{filterTags.length > 0 ? ` (${filterTags.length})` : ''} {showFilter ? '\u25B2' : '\u25BC'}
-              </button>
-              {showFilter && (
-                <div className="flex flex-wrap gap-1.5 mt-2">
-                  <button
-                    onClick={() => setFilterTags([])}
-                    className="px-2.5 py-1 text-xs rounded-full transition-colors"
-                    style={filterTags.length === 0
-                      ? { background: 'var(--text-primary)', color: 'var(--bg-surface)' }
-                      : { background: 'var(--bg-inset)', color: 'var(--text-secondary)' }
-                    }
-                  >
-                    All sentences
-                  </button>
-                  {allTags.map((tag) => (
-                    <button
-                      key={tag}
-                      onClick={() => setFilterTags((prev) =>
-                        prev.includes(tag) ? prev.filter((t) => t !== tag) : [...prev, tag]
-                      )}
-                      className="px-2.5 py-1 text-xs rounded-full transition-colors"
-                      style={filterTags.includes(tag)
-                        ? { background: 'var(--accent)', color: 'var(--text-inverted)' }
-                        : { background: 'color-mix(in srgb, var(--accent) 10%, var(--bg-surface))', color: 'var(--accent)' }
-                      }
-                    >
-                      {tag}
-                    </button>
-                  ))}
-                </div>
-              )}
-            </div>
-          )}
+          <TagFilterRow
+            allTags={allTags}
+            selected={filterTags}
+            onChange={setFilterTags}
+            allLabel="All sentences"
+            chipSize="md"
+            className="mb-4"
+          />
 
           <p className="text-sm text-center" style={{ color: 'var(--text-secondary)' }}>
             Choose review mode:

--- a/src/services/srs.test.ts
+++ b/src/services/srs.test.ts
@@ -6,32 +6,13 @@ import {
   getFreeReviewQueue,
 } from './srs';
 import type { SrsCard, ReviewMode } from '../db/schema';
+import { card } from '../test/factories';
 
 vi.mock('../db/repo', () => ({
   getSrsCardsByDeckAndStates: vi.fn(),
 }));
 
 import * as repo from '../db/repo';
-
-function card(overrides: Partial<SrsCard>): SrsCard {
-  return {
-    id: 'c',
-    sentenceId: 's',
-    deckId: 'd',
-    reviewMode: 'en-to-zh' as ReviewMode,
-    due: 0,
-    stability: 0,
-    difficulty: 0,
-    elapsedDays: 0,
-    scheduledDays: 0,
-    reps: 0,
-    lapses: 0,
-    state: 0,
-    lastReview: null,
-    createdAt: 0,
-    ...overrides,
-  };
-}
 
 describe('sentenceMasteryFromCards', () => {
   it('returns 0 when a sentence has no cards', () => {

--- a/src/services/srs.test.ts
+++ b/src/services/srs.test.ts
@@ -1,6 +1,17 @@
-import { describe, it, expect } from 'vitest';
-import { sentenceMasteryFromCards, sentenceMasteryForMode, groupCardsBySentence } from './srs';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  sentenceMasteryFromCards,
+  sentenceMasteryForMode,
+  groupCardsBySentence,
+  getFreeReviewQueue,
+} from './srs';
 import type { SrsCard, ReviewMode } from '../db/schema';
+
+vi.mock('../db/repo', () => ({
+  getSrsCardsByDeckAndStates: vi.fn(),
+}));
+
+import * as repo from '../db/repo';
 
 function card(overrides: Partial<SrsCard>): SrsCard {
   return {
@@ -79,5 +90,125 @@ describe('groupCardsBySentence', () => {
     const grouped = groupCardsBySentence(cards);
     expect(grouped.get('s1')?.map((c) => c.id)).toEqual(['a', 'c']);
     expect(grouped.get('s2')?.map((c) => c.id)).toEqual(['b']);
+  });
+});
+
+describe('getFreeReviewQueue', () => {
+  const mockedRepo = vi.mocked(repo);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns [] when sentenceIds is empty', async () => {
+    const result = await getFreeReviewQueue({
+      deckId: 'd1',
+      mode: 'both',
+      sentenceIds: [],
+    });
+    expect(result).toEqual([]);
+    expect(mockedRepo.getSrsCardsByDeckAndStates).not.toHaveBeenCalled();
+  });
+
+  it('ignores due dates — includes cards due far in the future', async () => {
+    const farFuture = Date.now() + 1000 * 60 * 60 * 24 * 365; // 1 year
+    const cards = [
+      card({ id: 'c1', sentenceId: 's1', due: farFuture, state: 2 }),
+      card({ id: 'c2', sentenceId: 's2', due: farFuture, state: 2 }),
+    ];
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue(cards);
+
+    const result = await getFreeReviewQueue({
+      deckId: 'd1',
+      mode: 'both',
+      sentenceIds: ['s1', 's2'],
+      shuffle: false,
+    });
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.id).sort()).toEqual(['c1', 'c2']);
+  });
+
+  it('filters to sentenceIds', async () => {
+    const cards = [
+      card({ id: 'c1', sentenceId: 's1' }),
+      card({ id: 'c2', sentenceId: 's2' }),
+      card({ id: 'c3', sentenceId: 's3' }),
+      card({ id: 'c4', sentenceId: 's4' }),
+      card({ id: 'c5', sentenceId: 's5' }),
+    ];
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue(cards);
+
+    const result = await getFreeReviewQueue({
+      deckId: 'd1',
+      mode: 'both',
+      sentenceIds: ['s2', 's4'],
+      shuffle: false,
+    });
+    expect(result.map((c) => c.id).sort()).toEqual(['c2', 'c4']);
+  });
+
+  it("filters by mode when not 'both'", async () => {
+    const cards: SrsCard[] = [
+      card({ id: 'c1', sentenceId: 's1', reviewMode: 'en-to-zh' }),
+      card({ id: 'c2', sentenceId: 's1', reviewMode: 'zh-to-en' }),
+      card({ id: 'c3', sentenceId: 's2', reviewMode: 'en-to-zh' }),
+      card({ id: 'c4', sentenceId: 's2', reviewMode: 'listen-type' }),
+    ];
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue(cards);
+
+    const result = await getFreeReviewQueue({
+      deckId: 'd1',
+      mode: 'en-to-zh',
+      sentenceIds: ['s1', 's2'],
+      shuffle: false,
+    });
+    expect(result.map((c) => c.id).sort()).toEqual(['c1', 'c3']);
+    expect(result.every((c) => c.reviewMode === 'en-to-zh')).toBe(true);
+  });
+
+  it("includes all modes when mode is 'both'", async () => {
+    const allModes: ReviewMode[] = [
+      'en-to-zh',
+      'zh-to-en',
+      'py-to-en-zh',
+      'listen-type',
+      'speak',
+    ];
+    const cards: SrsCard[] = allModes.map((m, i) =>
+      card({ id: `c${i}`, sentenceId: 's1', reviewMode: m }),
+    );
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue(cards);
+
+    const result = await getFreeReviewQueue({
+      deckId: 'd1',
+      mode: 'both',
+      sentenceIds: ['s1'],
+      shuffle: false,
+    });
+    const presentModes = new Set(result.map((c) => c.reviewMode));
+    for (const m of allModes) {
+      expect(presentModes.has(m)).toBe(true);
+    }
+  });
+
+  it('respects limit', async () => {
+    const cards = [
+      card({ id: 'c1', sentenceId: 's1' }),
+      card({ id: 'c2', sentenceId: 's2' }),
+      card({ id: 'c3', sentenceId: 's3' }),
+      card({ id: 'c4', sentenceId: 's4' }),
+      card({ id: 'c5', sentenceId: 's5' }),
+    ];
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue(cards);
+
+    const result = await getFreeReviewQueue({
+      deckId: 'd1',
+      mode: 'both',
+      sentenceIds: ['s1', 's2', 's3', 's4', 's5'],
+      shuffle: false,
+      limit: 3,
+    });
+    expect(result.length).toBeLessThanOrEqual(3);
+    expect(result).toHaveLength(3);
   });
 });

--- a/src/services/srs.ts
+++ b/src/services/srs.ts
@@ -195,6 +195,52 @@ export async function getReviewQueue(
   return [...duelearning, ...dueReview, ...dueNew];
 }
 
+export interface FreeReviewQueueArgs {
+  deckId: string;
+  mode: ReviewMode | 'both';
+  /** Restrict to these sentence IDs (e.g. selected on BrowsePage). */
+  sentenceIds?: string[] | null;
+  /** Restrict to sentences carrying any of these tags. Ignored if sentenceIds is set. */
+  tagFilter?: string[] | null;
+  shuffle?: boolean;
+  /** Optional cap on queue length. */
+  limit?: number | null;
+}
+
+/**
+ * Build a queue for free review. Unlike {@link getReviewQueue} this ignores
+ * due dates and daily limits — the user is opting in to drill specific cards.
+ * Cards returned here are NEVER passed to FSRS scheduling; the caller must
+ * skip {@link reviewCard} writes.
+ */
+export async function getFreeReviewQueue(args: FreeReviewQueueArgs): Promise<SrsCard[]> {
+  const { deckId, mode, sentenceIds, tagFilter, shuffle = true, limit } = args;
+
+  let restrictSentenceIds: Set<string> | null = null;
+  if (sentenceIds && sentenceIds.length > 0) {
+    restrictSentenceIds = new Set(sentenceIds);
+  } else if (tagFilter && tagFilter.length > 0) {
+    const tagged = await repo.getSentencesByTags(tagFilter);
+    restrictSentenceIds = new Set(tagged.map((s) => s.id));
+  }
+
+  const all = await repo.getSrsCardsByDeckAndStates(deckId, [0, 1, 2, 3]);
+  let filtered = all.filter((c) => mode === 'both' || c.reviewMode === mode);
+  if (restrictSentenceIds) {
+    filtered = filtered.filter((c) => restrictSentenceIds!.has(c.sentenceId));
+  }
+
+  if (shuffle) {
+    for (let i = filtered.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [filtered[i], filtered[j]] = [filtered[j], filtered[i]];
+    }
+  }
+
+  if (limit && limit > 0) filtered = filtered.slice(0, limit);
+  return filtered;
+}
+
 /** Get counts for dashboard display */
 export async function getDueCounts(
   deckId: string

--- a/src/services/srs.ts
+++ b/src/services/srs.ts
@@ -198,12 +198,8 @@ export async function getReviewQueue(
 export interface FreeReviewQueueArgs {
   deckId: string;
   mode: ReviewMode | 'both';
-  /** Restrict to these sentence IDs (e.g. selected on BrowsePage). */
-  sentenceIds?: string[] | null;
-  /** Restrict to sentences carrying any of these tags. Ignored if sentenceIds is set. */
-  tagFilter?: string[] | null;
+  sentenceIds: string[];
   shuffle?: boolean;
-  /** Optional cap on queue length. */
   limit?: number | null;
 }
 
@@ -214,21 +210,14 @@ export interface FreeReviewQueueArgs {
  * skip {@link reviewCard} writes.
  */
 export async function getFreeReviewQueue(args: FreeReviewQueueArgs): Promise<SrsCard[]> {
-  const { deckId, mode, sentenceIds, tagFilter, shuffle = true, limit } = args;
+  const { deckId, mode, sentenceIds, shuffle = true, limit } = args;
+  if (sentenceIds.length === 0) return [];
 
-  let restrictSentenceIds: Set<string> | null = null;
-  if (sentenceIds && sentenceIds.length > 0) {
-    restrictSentenceIds = new Set(sentenceIds);
-  } else if (tagFilter && tagFilter.length > 0) {
-    const tagged = await repo.getSentencesByTags(tagFilter);
-    restrictSentenceIds = new Set(tagged.map((s) => s.id));
-  }
-
+  const restrict = new Set(sentenceIds);
   const all = await repo.getSrsCardsByDeckAndStates(deckId, [0, 1, 2, 3]);
-  let filtered = all.filter((c) => mode === 'both' || c.reviewMode === mode);
-  if (restrictSentenceIds) {
-    filtered = filtered.filter((c) => restrictSentenceIds!.has(c.sentenceId));
-  }
+  let filtered = all.filter(
+    (c) => (mode === 'both' || c.reviewMode === mode) && restrict.has(c.sentenceId)
+  );
 
   if (shuffle) {
     for (let i = filtered.length - 1; i > 0; i--) {

--- a/src/stores/reviewStore.test.ts
+++ b/src/stores/reviewStore.test.ts
@@ -1,26 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { useReviewStore } from './reviewStore';
-import type { SrsCard, ReviewMode } from '../db/schema';
-
-function card(overrides: Partial<SrsCard>): SrsCard {
-  return {
-    id: 'c',
-    sentenceId: 's',
-    deckId: 'd',
-    reviewMode: 'en-to-zh' as ReviewMode,
-    due: 0,
-    stability: 0,
-    difficulty: 0,
-    elapsedDays: 0,
-    scheduledDays: 0,
-    reps: 0,
-    lapses: 0,
-    state: 0,
-    lastReview: null,
-    createdAt: 0,
-    ...overrides,
-  };
-}
+import { card } from '../test/factories';
 
 describe('useReviewStore — requeueCurrent', () => {
   beforeEach(() => {

--- a/src/stores/reviewStore.test.ts
+++ b/src/stores/reviewStore.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useReviewStore } from './reviewStore';
+import type { SrsCard, ReviewMode } from '../db/schema';
+
+function card(overrides: Partial<SrsCard>): SrsCard {
+  return {
+    id: 'c',
+    sentenceId: 's',
+    deckId: 'd',
+    reviewMode: 'en-to-zh' as ReviewMode,
+    due: 0,
+    stability: 0,
+    difficulty: 0,
+    elapsedDays: 0,
+    scheduledDays: 0,
+    reps: 0,
+    lapses: 0,
+    state: 0,
+    lastReview: null,
+    createdAt: 0,
+    ...overrides,
+  };
+}
+
+describe('useReviewStore — requeueCurrent', () => {
+  beforeEach(() => {
+    useReviewStore.getState().reset();
+  });
+
+  it('moves current card to the end of the queue, leaves index pointing at next card', () => {
+    const cards = [
+      card({ id: 'a' }),
+      card({ id: 'b' }),
+      card({ id: 'c' }),
+    ];
+    const store = useReviewStore.getState();
+    store.setQueue(cards, { freeReview: true });
+
+    store.requeueCurrent();
+
+    const { queue, currentIndex } = useReviewStore.getState();
+    expect(queue[currentIndex].id).toBe('b');
+    expect(queue[queue.length - 1].id).toBe('a');
+    expect(queue).toHaveLength(3);
+  });
+
+  it('single-card queue ends the session instead of looping', () => {
+    const cards = [card({ id: 'only' })];
+    const store = useReviewStore.getState();
+    store.setQueue(cards, { freeReview: true });
+
+    store.requeueCurrent();
+
+    const state = useReviewStore.getState();
+    expect(state.currentCard()).toBeNull();
+    expect(state.remaining()).toBe(0);
+  });
+
+  it('clears isFlipped and undoInfo', () => {
+    const cards = [card({ id: 'a' }), card({ id: 'b' }), card({ id: 'c' })];
+    const store = useReviewStore.getState();
+    store.setQueue(cards, { freeReview: true });
+
+    // Flip first
+    store.flip();
+    expect(useReviewStore.getState().isFlipped).toBe(true);
+
+    store.requeueCurrent();
+
+    const after = useReviewStore.getState();
+    expect(after.isFlipped).toBe(false);
+    expect(after.undoInfo).toBeNull();
+  });
+});

--- a/src/stores/reviewStore.ts
+++ b/src/stores/reviewStore.ts
@@ -11,7 +11,7 @@ interface ReviewState {
   isFlipped: boolean;
   isLoading: boolean;
   undoInfo: UndoInfo | null;
-  /** When true, ratings/actions must NOT write to FSRS. Set by FreeReviewPage. */
+  /** When true, ratings/actions must NOT write to FSRS. */
   isFreeReview: boolean;
 
   setQueue: (cards: SrsCard[], opts?: { freeReview?: boolean }) => void;

--- a/src/stores/reviewStore.ts
+++ b/src/stores/reviewStore.ts
@@ -69,6 +69,12 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   requeueCurrent: () => {
     const { queue, currentIndex } = get();
     if (currentIndex >= queue.length) return;
+    // Only one unconsumed card left: requeueing would put it right back at currentIndex
+    // and trap the user. Treat "Again later" as "next" and end the session instead.
+    if (queue.length - currentIndex <= 1) {
+      set({ currentIndex: queue.length, isFlipped: false, undoInfo: null });
+      return;
+    }
     const card = queue[currentIndex];
     const next = [...queue.slice(0, currentIndex), ...queue.slice(currentIndex + 1), card];
     // currentIndex stays — what's now at this slot is the next card.

--- a/src/stores/reviewStore.ts
+++ b/src/stores/reviewStore.ts
@@ -11,11 +11,15 @@ interface ReviewState {
   isFlipped: boolean;
   isLoading: boolean;
   undoInfo: UndoInfo | null;
+  /** When true, ratings/actions must NOT write to FSRS. Set by FreeReviewPage. */
+  isFreeReview: boolean;
 
-  setQueue: (cards: SrsCard[]) => void;
+  setQueue: (cards: SrsCard[], opts?: { freeReview?: boolean }) => void;
   flip: () => void;
   next: (undo?: UndoInfo) => void;
   prev: () => void;
+  /** Free-review only: send the current card to the back of the queue and advance. */
+  requeueCurrent: () => void;
   currentCard: () => SrsCard | null;
   remaining: () => number;
   clearUndo: () => void;
@@ -28,9 +32,17 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   isFlipped: false,
   isLoading: false,
   undoInfo: null,
+  isFreeReview: false,
 
-  setQueue: (cards) =>
-    set({ queue: cards, currentIndex: 0, isFlipped: false, isLoading: false, undoInfo: null }),
+  setQueue: (cards, opts) =>
+    set({
+      queue: cards,
+      currentIndex: 0,
+      isFlipped: false,
+      isLoading: false,
+      undoInfo: null,
+      isFreeReview: opts?.freeReview ?? false,
+    }),
 
   flip: () => set({ isFlipped: true }),
 
@@ -54,6 +66,15 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
     }
   },
 
+  requeueCurrent: () => {
+    const { queue, currentIndex } = get();
+    if (currentIndex >= queue.length) return;
+    const card = queue[currentIndex];
+    const next = [...queue.slice(0, currentIndex), ...queue.slice(currentIndex + 1), card];
+    // currentIndex stays — what's now at this slot is the next card.
+    set({ queue: next, isFlipped: false, undoInfo: null });
+  },
+
   currentCard: () => {
     const { queue, currentIndex } = get();
     return currentIndex < queue.length ? queue[currentIndex] : null;
@@ -67,5 +88,12 @@ export const useReviewStore = create<ReviewState>((set, get) => ({
   clearUndo: () => set({ undoInfo: null }),
 
   reset: () =>
-    set({ queue: [], currentIndex: 0, isFlipped: false, isLoading: false, undoInfo: null }),
+    set({
+      queue: [],
+      currentIndex: 0,
+      isFlipped: false,
+      isLoading: false,
+      undoInfo: null,
+      isFreeReview: false,
+    }),
 }));

--- a/src/test/factories.ts
+++ b/src/test/factories.ts
@@ -1,0 +1,21 @@
+import type { SrsCard, ReviewMode } from '../db/schema';
+
+export function card(overrides: Partial<SrsCard> = {}): SrsCard {
+  return {
+    id: 'c',
+    sentenceId: 's',
+    deckId: 'd',
+    reviewMode: 'en-to-zh' as ReviewMode,
+    due: 0,
+    stability: 0,
+    difficulty: 0,
+    elapsedDays: 0,
+    scheduledDays: 0,
+    reps: 0,
+    lapses: 0,
+    state: 0,
+    lastReview: null,
+    createdAt: 0,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- New `/free-review` route — a session-builder page where you iteratively filter (search + tag) and select sentences, with a persistent cart that survives filter changes (so you can stack picks across multiple searches before starting).
- `ReviewCard` shows **Got it** / **Again later** instead of FSRS rating buttons when `isFreeReview` is set; "Again later" sends the current card to the back of the queue. Nothing is ever written to FSRS in this mode.
- `BrowsePage` gets a toggleable search bar (icon button in header reveals it) — substring match across Chinese, pinyin, English; tone-insensitive so `hua` matches `huā`.
- `DashboardPage` gets a small "Free review (no schedule effect)" button under Study.

## Why no FSRS writes
FSRS treats the interval between reviews as part of the learning signal, so cramming a card 10× in 5 minutes and rating each "Good" actively distorts stability. Free Review is positioned as the no-consequence drill mode; the complementary "Study ahead" flow (bonus review of soon-due cards that *does* update FSRS) is tracked in #163.

## Test plan
- [ ] Dashboard → "Free review" → land with empty cart → search/filter → tap rows to add → start session → cards play back without "Again/Hard/Good/Easy" buttons.
- [ ] Build a session from multiple filters: search A → pick 2 → clear → search B → pick 3 → start with 5.
- [ ] "Again later" pushes the current card to the end of the queue (count stays the same; same card reappears later).
- [ ] Verify FSRS state is unchanged for any card reviewed in free mode (check `lastReview` / `due` / `stability` in DevTools or by re-entering normal review and seeing the same due list).
- [ ] Browse search icon in header — tap to reveal input; tap again to hide and clear; icon turns accent when there's an active query.
- [ ] Browse search composes with tag filter and sort.
- [ ] Empty selection / no matching cards / mode with zero cards in the cart all surface a sensible empty state instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)