### PR TITLE
Custom Study: study ahead + per-day cap bumps

### DIFF
--- a/src/components/CustomStudyButton.tsx
+++ b/src/components/CustomStudyButton.tsx
@@ -1,0 +1,79 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router';
+import { CustomStudyPanel, type CustomStudyAction } from './CustomStudyPanel';
+import { addNewLimitBumpToday, addReviewLimitBumpToday } from '../lib/dailyLimits';
+import type { DueBreakdown } from '../services/srs';
+import type { ReviewMode } from '../db/schema';
+
+type ModeOption = ReviewMode | 'all';
+
+interface Props {
+  deckId: string;
+  mode: ModeOption;
+  breakdown: DueBreakdown;
+  /** Called after a bump is applied so the parent can refetch counts / restart. */
+  onAfterBump?: () => void;
+  /** Called when the user picks Review ahead with the chosen card count. */
+  onStudyAhead: (count: number) => void;
+}
+
+export function CustomStudyButton({ deckId, mode, breakdown, onAfterBump, onStudyAhead }: Props) {
+  const navigate = useNavigate();
+  const [open, setOpen] = useState(false);
+
+  const handleConfirm = (action: CustomStudyAction) => {
+    setOpen(false);
+    switch (action.kind) {
+      case 'bumpNew':
+        addNewLimitBumpToday(deckId, action.count);
+        onAfterBump?.();
+        break;
+      case 'bumpReview':
+        addReviewLimitBumpToday(deckId, action.count);
+        onAfterBump?.();
+        break;
+      case 'studyAhead':
+        onStudyAhead(action.count);
+        break;
+      case 'freeReview':
+        navigate('/free-review');
+        break;
+    }
+  };
+
+  return (
+    <>
+      <button
+        onClick={() => setOpen(true)}
+        className="mt-2 w-full py-2 rounded-lg text-xs font-medium transition-colors"
+        style={{
+          background: 'transparent',
+          color: 'var(--text-secondary)',
+          border: '1px solid var(--border-strong)',
+        }}
+      >
+        Custom study…
+      </button>
+      {open && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          style={{ background: 'rgba(0,0,0,0.5)' }}
+          onClick={() => setOpen(false)}
+        >
+          <div
+            className="rounded-2xl shadow-xl max-w-md w-full surface p-5"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h2 className="text-base font-semibold mb-4">Custom study</h2>
+            <CustomStudyPanel
+              breakdown={breakdown}
+              mode={mode}
+              onCancel={() => setOpen(false)}
+              onConfirm={handleConfirm}
+            />
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/CustomStudyPanel.tsx
+++ b/src/components/CustomStudyPanel.tsx
@@ -1,0 +1,172 @@
+import { useState } from 'react';
+import { EMPTY_MODE_STATE, type DueBreakdown, type ModeStateCounts } from '../services/srs';
+import type { ReviewMode } from '../db/schema';
+import { InfoTooltip } from './InfoTooltip';
+
+type ModeOption = ReviewMode | 'all';
+
+type ActionKind = 'bumpNew' | 'bumpReview' | 'studyAhead' | 'freeReview';
+
+export type CustomStudyAction =
+  | { kind: 'bumpNew'; count: number }
+  | { kind: 'bumpReview'; count: number }
+  | { kind: 'studyAhead'; count: number }
+  | { kind: 'freeReview' };
+
+interface Props {
+  breakdown: DueBreakdown;
+  mode: ModeOption;
+  onCancel: () => void;
+  onConfirm: (action: CustomStudyAction) => void;
+}
+
+interface ActionMeta {
+  label: string;
+  help: string;
+  /** Null for freeReview — the "no count" branch uses a different layout. */
+  count: null | {
+    pick: (s: ModeStateCounts) => number;
+    availableLabel: string;
+    inputLabel: string;
+  };
+}
+
+const ACTIONS: Record<ActionKind, ActionMeta> = {
+  bumpNew: {
+    label: "Increase today's new card limit",
+    help: "Adds more unseen cards to today's queue beyond the daily new-card cap. These cards generate future reviews, so it does increase tomorrow's load.",
+    count: {
+      pick: (s) => s.newBacklog,
+      availableLabel: 'Available new cards',
+      inputLabel: "Increase today's new card limit by",
+    },
+  },
+  bumpReview: {
+    label: "Increase today's review card limit",
+    help: "Lets you go past today's review cap on cards already due today. Doesn't change future scheduling — you're just catching up.",
+    count: {
+      pick: (s) => s.reviewBacklog,
+      availableLabel: 'Cards held back by review limit',
+      inputLabel: "Increase today's review card limit by",
+    },
+  },
+  studyAhead: {
+    label: 'Review ahead',
+    help: "Pulls in cards that aren't due yet, sorted by soonest due. Ratings still update FSRS as normal early reviews. Doesn't add future load — often slightly reduces it.",
+    count: {
+      pick: (s) => s.futureCount,
+      availableLabel: 'Future cards available',
+      inputLabel: 'Pull in next',
+    },
+  },
+  freeReview: {
+    label: 'Free review (no schedule effect)',
+    help: 'Drill any sentences on demand without affecting FSRS scheduling. Useful for cramming or warm-ups; ratings are NOT recorded.',
+    count: null,
+  },
+};
+
+const ACTION_ORDER: ActionKind[] = ['bumpNew', 'bumpReview', 'studyAhead', 'freeReview'];
+
+export function CustomStudyPanel({ breakdown, mode, onCancel, onConfirm }: Props) {
+  const states = breakdown.byModeAndState[mode] ?? EMPTY_MODE_STATE;
+
+  const [selected, setSelected] = useState<ActionKind>('bumpNew');
+  const [count, setCount] = useState<number>(20);
+
+  const meta = ACTIONS[selected];
+  const available = meta.count ? meta.count.pick(states) : 0;
+
+  const inputDisabled = !meta.count || available === 0;
+  const okDisabled = meta.count
+    ? available === 0 || !Number.isFinite(count) || count < 1
+    : false;
+
+  const handleConfirm = () => {
+    if (selected === 'freeReview') {
+      onConfirm({ kind: 'freeReview' });
+      return;
+    }
+    if (okDisabled) return;
+    const clamped = Math.max(1, Math.min(count, Math.max(available, 1)));
+    onConfirm({ kind: selected, count: clamped });
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-1">
+        {ACTION_ORDER.map((kind) => (
+          <label
+            key={kind}
+            className="flex items-center gap-3 px-2 py-1.5 rounded transition-colors"
+            style={{ background: selected === kind ? 'var(--bg-inset)' : 'transparent' }}
+          >
+            <input
+              type="radio"
+              name="custom-study-action"
+              checked={selected === kind}
+              onChange={() => setSelected(kind)}
+              className="accent-[var(--accent)]"
+            />
+            <span className="text-sm flex-1">{ACTIONS[kind].label}</span>
+            <InfoTooltip help={ACTIONS[kind].help} />
+          </label>
+        ))}
+      </div>
+
+      {meta.count ? (
+        <div
+          className="p-3 rounded-lg space-y-2"
+          style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+        >
+          <div className="text-xs" style={{ color: 'var(--text-secondary)' }}>
+            {meta.count.availableLabel}: <span style={{ color: 'var(--text-primary)' }}>{available}</span>
+          </div>
+          <label className="flex items-center gap-2 text-sm flex-wrap">
+            <span style={{ color: 'var(--text-secondary)' }}>{meta.count.inputLabel}</span>
+            <input
+              type="number"
+              min={1}
+              max={Math.max(available, 1)}
+              value={count}
+              onChange={(e) => setCount(parseInt(e.target.value, 10) || 0)}
+              disabled={inputDisabled}
+              className="w-20 px-2 py-1 rounded text-sm tabular-nums"
+              style={{
+                background: 'var(--bg-base)',
+                border: '1px solid var(--border-strong)',
+                color: 'var(--text-primary)',
+              }}
+            />
+            <span style={{ color: 'var(--text-secondary)' }}>cards</span>
+          </label>
+        </div>
+      ) : (
+        <div
+          className="p-3 rounded-lg text-xs"
+          style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)', color: 'var(--text-secondary)' }}
+        >
+          Drill any sentences without affecting FSRS scheduling. Lets you filter by tag and shuffle.
+        </div>
+      )}
+
+      <div className="flex justify-end gap-2 pt-1">
+        <button
+          onClick={onCancel}
+          className="px-4 py-1.5 rounded-md text-sm font-medium transition-colors"
+          style={{ background: 'var(--bg-inset)', color: 'var(--text-secondary)' }}
+        >
+          Cancel
+        </button>
+        <button
+          onClick={handleConfirm}
+          disabled={okDisabled}
+          className="px-4 py-1.5 rounded-md text-sm font-medium transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+          style={{ background: 'var(--accent)', color: '#fff' }}
+        >
+          OK
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/InfoTooltip.tsx
+++ b/src/components/InfoTooltip.tsx
@@ -1,0 +1,47 @@
+interface Props {
+  help: string;
+}
+
+/**
+ * Small info icon with a CSS-driven hover popover. Used over the native
+ * `title=` pattern when the help text is multi-sentence and the long
+ * native-tooltip delay feels sluggish. Touch devices won't see the popover
+ * (no hover); they fall through to the icon's silent presence.
+ */
+export function InfoTooltip({ help }: Props) {
+  return (
+    <span
+      className="relative inline-flex group"
+      // The icon sits inside a parent <label>, where any click would toggle
+      // the associated radio. Block the label-default and bubbling.
+      onClick={(e) => { e.preventDefault(); e.stopPropagation(); }}
+    >
+      <svg
+        width="14"
+        height="14"
+        viewBox="0 0 16 16"
+        aria-hidden="true"
+        style={{ color: 'var(--text-tertiary)', cursor: 'default' }}
+      >
+        <circle cx="8" cy="8" r="7" fill="none" stroke="currentColor" strokeWidth="1.2" />
+        <circle cx="8" cy="4.5" r="0.9" fill="currentColor" />
+        <rect x="7.25" y="6.5" width="1.5" height="5.5" rx="0.5" fill="currentColor" />
+      </svg>
+      <span
+        role="tooltip"
+        className="absolute z-10 hidden group-hover:block w-60 p-2 rounded-md text-xs leading-snug"
+        style={{
+          right: 0,
+          top: '100%',
+          marginTop: '6px',
+          background: 'var(--bg-elevated, var(--bg-surface))',
+          color: 'var(--text-primary)',
+          border: '1px solid var(--border-strong)',
+          boxShadow: '0 4px 12px rgba(0,0,0,0.25)',
+        }}
+      >
+        {help}
+      </span>
+    </span>
+  );
+}

--- a/src/lib/dailyLimits.ts
+++ b/src/lib/dailyLimits.ts
@@ -1,0 +1,53 @@
+/**
+ * Per-day, per-deck overrides for newCardsPerDay / reviewsPerDay.
+ *
+ * Anki calls these "Custom Study" actions: temporarily raise today's caps
+ * so cards held back by the daily limit become eligible. Bumps reset at
+ * local midnight via date-scoped storage keys — no migration, no cleanup.
+ *
+ * Stored in localStorage rather than Dexie because:
+ *   - they're operational, per-device, and shouldn't sync.
+ *   - they auto-expire by date, so old keys becoming stale is harmless.
+ */
+
+function todayKey(): string {
+  const d = new Date();
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+}
+
+function storageKey(kind: 'new' | 'review', deckId: string): string {
+  return `mandao:bump:${kind}:${deckId}:${todayKey()}`;
+}
+
+function read(kind: 'new' | 'review', deckId: string): number {
+  try {
+    const v = localStorage.getItem(storageKey(kind, deckId));
+    return v ? Math.max(0, parseInt(v, 10) || 0) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function write(kind: 'new' | 'review', deckId: string, value: number): void {
+  try {
+    localStorage.setItem(storageKey(kind, deckId), String(Math.max(0, value)));
+  } catch {
+    // localStorage unavailable; bumps remain session-effective via callers' refetch.
+  }
+}
+
+export function getNewLimitBumpToday(deckId: string): number {
+  return read('new', deckId);
+}
+
+export function getReviewLimitBumpToday(deckId: string): number {
+  return read('review', deckId);
+}
+
+export function addNewLimitBumpToday(deckId: string, amount: number): void {
+  write('new', deckId, read('new', deckId) + amount);
+}
+
+export function addReviewLimitBumpToday(deckId: string, amount: number): void {
+  write('review', deckId, read('review', deckId) + amount);
+}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -22,19 +22,24 @@ const MODE_LABEL: Record<ModeOption, string> = {
 
 interface CustomStudyRowProps<T extends string | number> {
   label: string;
+  count: number;
   options: { label: string; value: T }[];
   onPick: (value: T) => void;
 }
 
-function CustomStudyRow<T extends string | number>({ label, options, onPick }: CustomStudyRowProps<T>) {
+function CustomStudyRow<T extends string | number>({ label, count, options, onPick }: CustomStudyRowProps<T>) {
+  const disabled = count === 0;
   return (
-    <div className="flex items-center gap-2">
-      <span className="text-xs flex-1" style={{ color: 'var(--text-secondary)' }}>{label}</span>
+    <div className="flex items-center gap-2" style={{ opacity: disabled ? 0.4 : 1 }}>
+      <span className="text-xs flex-1 min-w-0" style={{ color: 'var(--text-secondary)' }}>
+        {label} <span style={{ color: 'var(--text-tertiary)' }}>({count})</span>
+      </span>
       {options.map((opt) => (
         <button
           key={opt.label}
           onClick={() => onPick(opt.value)}
-          className="px-3 py-1 rounded-md text-xs font-medium transition-colors"
+          disabled={disabled}
+          className="px-3 py-1 rounded-md text-xs font-medium transition-colors disabled:cursor-not-allowed"
           style={{ background: 'transparent', color: 'var(--accent)', border: '1px solid var(--accent)' }}
         >
           {opt.label}
@@ -163,45 +168,43 @@ export function DashboardPage() {
             <div className="w-full py-2.5 rounded-lg text-sm font-medium text-center" style={{ background: 'var(--bg-inset)', color: 'var(--text-tertiary)' }}>
               No cards due
             </div>
-            {(states.newBacklog > 0 || states.reviewBacklog > 0 || states.futureCount > 0) && (
-              <div className="space-y-2 pt-1">
-                <div className="text-xs font-semibold" style={{ color: 'var(--text-tertiary)' }}>
-                  Custom Study
-                </div>
-                {states.newBacklog > 0 && (
-                  <CustomStudyRow
-                    label="New cards today"
-                    options={[
-                      { label: '+10', value: 10 },
-                      { label: '+20', value: 20 },
-                    ]}
-                    onPick={bumpNew}
-                  />
-                )}
-                {states.reviewBacklog > 0 && (
-                  <CustomStudyRow
-                    label="Review backlog"
-                    options={[
-                      { label: '+10', value: 10 },
-                      { label: '+20', value: 20 },
-                      { label: 'All', value: states.reviewBacklog },
-                    ]}
-                    onPick={bumpReview}
-                  />
-                )}
-                {states.futureCount > 0 && (
-                  <CustomStudyRow
-                    label="Study ahead"
-                    options={[
-                      { label: '+10', value: '10' },
-                      { label: '+20', value: '20' },
-                      { label: 'All', value: 'all' },
-                    ]}
-                    onPick={goStudyAhead}
-                  />
-                )}
+            <div
+              className="space-y-2 p-3 rounded-lg"
+              style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
+            >
+              <div className="text-xs font-semibold mb-1" style={{ color: 'var(--text-secondary)' }}>
+                Custom Study
               </div>
-            )}
+              <CustomStudyRow
+                label="New cards today"
+                count={states.newBacklog}
+                options={[
+                  { label: '+10', value: 10 },
+                  { label: '+20', value: 20 },
+                ]}
+                onPick={bumpNew}
+              />
+              <CustomStudyRow
+                label="Review backlog"
+                count={states.reviewBacklog}
+                options={[
+                  { label: '+10', value: 10 },
+                  { label: '+20', value: 20 },
+                  { label: 'All', value: Math.max(1, states.reviewBacklog) },
+                ]}
+                onPick={bumpReview}
+              />
+              <CustomStudyRow
+                label="Study ahead"
+                count={states.futureCount}
+                options={[
+                  { label: '+10', value: '10' },
+                  { label: '+20', value: '20' },
+                  { label: 'All', value: 'all' },
+                ]}
+                onPick={goStudyAhead}
+              />
+            </div>
           </div>
         )}
       </div>

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router';
-import { getDueBreakdown, type DueBreakdown } from '../services/srs';
+import { getDueBreakdown, EMPTY_MODE_STATE, type DueBreakdown } from '../services/srs';
 import * as repo from '../db/repo';
 import { TutorialBanner } from '../components/TutorialBanner';
+import { CustomStudyButton } from '../components/CustomStudyButton';
 import { useTutorialStore } from '../stores/tutorialStore';
 import { useAuthStore } from '../stores/authStore';
-import { addNewLimitBumpToday, addReviewLimitBumpToday } from '../lib/dailyLimits';
 import type { ReviewMode } from '../db/schema';
 
 type ModeOption = ReviewMode | 'all';
@@ -20,35 +20,6 @@ const MODE_LABEL: Record<ModeOption, string> = {
   'speak': 'Speak',
 };
 
-interface CustomStudyRowProps<T extends string | number> {
-  label: string;
-  count: number;
-  options: { label: string; value: T }[];
-  onPick: (value: T) => void;
-}
-
-function CustomStudyRow<T extends string | number>({ label, count, options, onPick }: CustomStudyRowProps<T>) {
-  const disabled = count === 0;
-  return (
-    <div className="flex items-center gap-2" style={{ opacity: disabled ? 0.4 : 1 }}>
-      <span className="text-xs flex-1 min-w-0" style={{ color: 'var(--text-secondary)' }}>
-        {label} <span style={{ color: 'var(--text-tertiary)' }}>({count})</span>
-      </span>
-      {options.map((opt) => (
-        <button
-          key={opt.label}
-          onClick={() => onPick(opt.value)}
-          disabled={disabled}
-          className="px-3 py-1 rounded-md text-xs font-medium transition-colors disabled:cursor-not-allowed"
-          style={{ background: 'transparent', color: 'var(--accent)', border: '1px solid var(--accent)' }}
-        >
-          {opt.label}
-        </button>
-      ))}
-    </div>
-  );
-}
-
 export function DashboardPage() {
   const navigate = useNavigate();
   const user = useAuthStore((s) => s.user);
@@ -62,37 +33,35 @@ export function DashboardPage() {
   const tutorialStep = useTutorialStore((s) => s.step);
   const advanceTutorial = useTutorialStore((s) => s.advance);
 
+  // Static-ish counts only refetch on user change. A Custom Study bump
+  // doesn't change sentence/meaning totals, so we don't need to re-run them
+  // when reloadFlag bumps.
   useEffect(() => {
     if (!user) return;
-    async function load() {
+    (async () => {
       const id = await repo.ensureDefaultDeck();
       setDeckId(id);
-      setBreakdown(await getDueBreakdown(id));
       setTotalSentences(await repo.getSentencesCount());
       setTotalMeanings(await repo.getMeaningsCount());
-    }
-    load();
-  }, [user, reloadFlag]);
+    })();
+  }, [user]);
 
-  const states = breakdown?.byModeAndState[mode] ?? {
-    newCount: 0, learningCount: 0, reviewCount: 0,
-    newBacklog: 0, reviewBacklog: 0, futureCount: 0,
-  };
+  // Breakdown refetches on bump too, since a bump shifts due/backlog counts.
+  useEffect(() => {
+    if (!deckId) return;
+    let cancelled = false;
+    getDueBreakdown(deckId).then((b) => {
+      if (!cancelled) setBreakdown(b);
+    });
+    return () => { cancelled = true; };
+  }, [deckId, reloadFlag]);
+
+  const states = breakdown?.byModeAndState[mode] ?? EMPTY_MODE_STATE;
   const dueForMode = states.newCount + states.learningCount + states.reviewCount;
   const reviewParam = mode === 'all' ? 'both' : mode;
 
-  const bumpNew = (n: number) => {
-    if (!deckId) return;
-    addNewLimitBumpToday(deckId, n);
-    setReloadFlag((f) => f + 1);
-  };
-  const bumpReview = (n: number) => {
-    if (!deckId) return;
-    addReviewLimitBumpToday(deckId, n);
-    setReloadFlag((f) => f + 1);
-  };
-  const goStudyAhead = (ahead: string) => {
-    navigate(`/review?mode=${reviewParam}&ahead=${ahead}`);
+  const goStudyAhead = (count: number) => {
+    navigate(`/review?mode=${reviewParam}&ahead=${count}`);
   };
   const totalAll = breakdown
     ? breakdown.byMode['en-to-zh'] + breakdown.byMode['zh-to-en'] + breakdown.byMode['py-to-en-zh'] + (breakdown.byMode['listen-type'] ?? 0) + (breakdown.byMode['speak'] ?? 0)
@@ -164,60 +133,19 @@ export function DashboardPage() {
             Study ({dueForMode} cards)
           </button>
         ) : (
-          <div className="space-y-3">
-            <div className="w-full py-2.5 rounded-lg text-sm font-medium text-center" style={{ background: 'var(--bg-inset)', color: 'var(--text-tertiary)' }}>
-              No cards due
-            </div>
-            <div
-              className="space-y-2 p-3 rounded-lg"
-              style={{ background: 'var(--bg-surface)', border: '1px solid var(--border)' }}
-            >
-              <div className="text-xs font-semibold mb-1" style={{ color: 'var(--text-secondary)' }}>
-                Custom Study
-              </div>
-              <CustomStudyRow
-                label="New cards today"
-                count={states.newBacklog}
-                options={[
-                  { label: '+10', value: 10 },
-                  { label: '+20', value: 20 },
-                ]}
-                onPick={bumpNew}
-              />
-              <CustomStudyRow
-                label="Review backlog"
-                count={states.reviewBacklog}
-                options={[
-                  { label: '+10', value: 10 },
-                  { label: '+20', value: 20 },
-                  { label: 'All', value: Math.max(1, states.reviewBacklog) },
-                ]}
-                onPick={bumpReview}
-              />
-              <CustomStudyRow
-                label="Study ahead"
-                count={states.futureCount}
-                options={[
-                  { label: '+10', value: '10' },
-                  { label: '+20', value: '20' },
-                  { label: 'All', value: 'all' },
-                ]}
-                onPick={goStudyAhead}
-              />
-            </div>
+          <div className="w-full py-2.5 rounded-lg text-sm font-medium text-center" style={{ background: 'var(--bg-inset)', color: 'var(--text-tertiary)' }}>
+            No cards due
           </div>
         )}
-        <button
-          onClick={() => navigate('/free-review')}
-          className="mt-2 w-full py-2 rounded-lg text-xs font-medium transition-colors"
-          style={{
-            background: 'transparent',
-            color: 'var(--text-secondary)',
-            border: '1px solid var(--border-strong)',
-          }}
-        >
-          Free review (no schedule effect)
-        </button>
+        {breakdown && deckId && (
+          <CustomStudyButton
+            deckId={deckId}
+            mode={mode}
+            breakdown={breakdown}
+            onAfterBump={() => setReloadFlag((f) => f + 1)}
+            onStudyAhead={goStudyAhead}
+          />
+        )}
       </div>
 
       {/* Quick actions — ghost buttons */}

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -5,6 +5,7 @@ import * as repo from '../db/repo';
 import { TutorialBanner } from '../components/TutorialBanner';
 import { useTutorialStore } from '../stores/tutorialStore';
 import { useAuthStore } from '../stores/authStore';
+import { addNewLimitBumpToday, addReviewLimitBumpToday } from '../lib/dailyLimits';
 import type { ReviewMode } from '../db/schema';
 
 type ModeOption = ReviewMode | 'all';
@@ -19,6 +20,30 @@ const MODE_LABEL: Record<ModeOption, string> = {
   'speak': 'Speak',
 };
 
+interface CustomStudyRowProps<T extends string | number> {
+  label: string;
+  options: { label: string; value: T }[];
+  onPick: (value: T) => void;
+}
+
+function CustomStudyRow<T extends string | number>({ label, options, onPick }: CustomStudyRowProps<T>) {
+  return (
+    <div className="flex items-center gap-2">
+      <span className="text-xs flex-1" style={{ color: 'var(--text-secondary)' }}>{label}</span>
+      {options.map((opt) => (
+        <button
+          key={opt.label}
+          onClick={() => onPick(opt.value)}
+          className="px-3 py-1 rounded-md text-xs font-medium transition-colors"
+          style={{ background: 'transparent', color: 'var(--accent)', border: '1px solid var(--accent)' }}
+        >
+          {opt.label}
+        </button>
+      ))}
+    </div>
+  );
+}
+
 export function DashboardPage() {
   const navigate = useNavigate();
   const user = useAuthStore((s) => s.user);
@@ -26,6 +51,8 @@ export function DashboardPage() {
   const [mode, setMode] = useState<ModeOption>('all');
   const [totalSentences, setTotalSentences] = useState(0);
   const [totalMeanings, setTotalMeanings] = useState(0);
+  const [deckId, setDeckId] = useState<string | null>(null);
+  const [reloadFlag, setReloadFlag] = useState(0);
 
   const tutorialStep = useTutorialStore((s) => s.step);
   const advanceTutorial = useTutorialStore((s) => s.advance);
@@ -33,21 +60,38 @@ export function DashboardPage() {
   useEffect(() => {
     if (!user) return;
     async function load() {
-      const deckId = await repo.ensureDefaultDeck();
-      setBreakdown(await getDueBreakdown(deckId));
+      const id = await repo.ensureDefaultDeck();
+      setDeckId(id);
+      setBreakdown(await getDueBreakdown(id));
       setTotalSentences(await repo.getSentencesCount());
       setTotalMeanings(await repo.getMeaningsCount());
     }
     load();
-  }, [user]);
+  }, [user, reloadFlag]);
 
-  const states = breakdown?.byModeAndState[mode] ?? { newCount: 0, learningCount: 0, reviewCount: 0 };
+  const states = breakdown?.byModeAndState[mode] ?? {
+    newCount: 0, learningCount: 0, reviewCount: 0,
+    newBacklog: 0, reviewBacklog: 0, futureCount: 0,
+  };
   const dueForMode = states.newCount + states.learningCount + states.reviewCount;
+  const reviewParam = mode === 'all' ? 'both' : mode;
+
+  const bumpNew = (n: number) => {
+    if (!deckId) return;
+    addNewLimitBumpToday(deckId, n);
+    setReloadFlag((f) => f + 1);
+  };
+  const bumpReview = (n: number) => {
+    if (!deckId) return;
+    addReviewLimitBumpToday(deckId, n);
+    setReloadFlag((f) => f + 1);
+  };
+  const goStudyAhead = (ahead: string) => {
+    navigate(`/review?mode=${reviewParam}&ahead=${ahead}`);
+  };
   const totalAll = breakdown
     ? breakdown.byMode['en-to-zh'] + breakdown.byMode['zh-to-en'] + breakdown.byMode['py-to-en-zh'] + (breakdown.byMode['listen-type'] ?? 0) + (breakdown.byMode['speak'] ?? 0)
     : 0;
-
-  const reviewParam = mode === 'all' ? 'both' : mode;
 
   return (
     <div className="max-w-xl mx-auto px-4 sm:px-6 py-8 sm:py-10">
@@ -106,14 +150,60 @@ export function DashboardPage() {
             </button>
           ))}
         </div>
-        <button
-          onClick={() => navigate(`/review?mode=${reviewParam}`)}
-          disabled={dueForMode === 0}
-          className="w-full py-2.5 rounded-lg text-sm font-medium transition-colors disabled:opacity-30"
-          style={{ background: 'var(--accent)', color: '#fff' }}
-        >
-          {dueForMode > 0 ? `Study (${dueForMode} cards)` : 'No cards due'}
-        </button>
+        {dueForMode > 0 ? (
+          <button
+            onClick={() => navigate(`/review?mode=${reviewParam}`)}
+            className="w-full py-2.5 rounded-lg text-sm font-medium transition-colors"
+            style={{ background: 'var(--accent)', color: '#fff' }}
+          >
+            Study ({dueForMode} cards)
+          </button>
+        ) : (
+          <div className="space-y-3">
+            <div className="w-full py-2.5 rounded-lg text-sm font-medium text-center" style={{ background: 'var(--bg-inset)', color: 'var(--text-tertiary)' }}>
+              No cards due
+            </div>
+            {(states.newBacklog > 0 || states.reviewBacklog > 0 || states.futureCount > 0) && (
+              <div className="space-y-2 pt-1">
+                <div className="text-xs font-semibold" style={{ color: 'var(--text-tertiary)' }}>
+                  Custom Study
+                </div>
+                {states.newBacklog > 0 && (
+                  <CustomStudyRow
+                    label="New cards today"
+                    options={[
+                      { label: '+10', value: 10 },
+                      { label: '+20', value: 20 },
+                    ]}
+                    onPick={bumpNew}
+                  />
+                )}
+                {states.reviewBacklog > 0 && (
+                  <CustomStudyRow
+                    label="Review backlog"
+                    options={[
+                      { label: '+10', value: 10 },
+                      { label: '+20', value: 20 },
+                      { label: 'All', value: states.reviewBacklog },
+                    ]}
+                    onPick={bumpReview}
+                  />
+                )}
+                {states.futureCount > 0 && (
+                  <CustomStudyRow
+                    label="Study ahead"
+                    options={[
+                      { label: '+10', value: '10' },
+                      { label: '+20', value: '20' },
+                      { label: 'All', value: 'all' },
+                    ]}
+                    onPick={goStudyAhead}
+                  />
+                )}
+              </div>
+            )}
+          </div>
+        )}
       </div>
 
       {/* Quick actions — ghost buttons */}

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router';
 import { useReviewStore } from '../stores/reviewStore';
-import { getReviewQueue } from '../services/srs';
+import { getReviewQueue, getStudyAheadQueue } from '../services/srs';
 import { getAllTags } from '../services/ingestion';
 import { ReviewCard } from '../components/ReviewCard';
 import { MeaningCard } from '../components/MeaningCard';
@@ -37,16 +37,15 @@ export function ReviewPage() {
     getAllTags().then(setAllTags);
   }, []);
 
-  const startReview = async (selectedMode: ModeOption) => {
+  const startReview = async (selectedMode: ModeOption, studyAhead?: number | 'all') => {
     setLoading(true);
     setLoadingMode(selectedMode);
     try {
       const effectiveDeckId = deckId ?? (await ensureDefaultDeck());
-      const queue = await getReviewQueue(
-        effectiveDeckId,
-        selectedMode,
-        filterTags.length > 0 ? filterTags : null
-      );
+      const tags = filterTags.length > 0 ? filterTags : null;
+      const queue = studyAhead !== undefined
+        ? await getStudyAheadQueue(effectiveDeckId, selectedMode, tags, studyAhead === 'all' ? undefined : studyAhead)
+        : await getReviewQueue(effectiveDeckId, selectedMode, tags);
       setQueue(queue);
       setStarted(true);
     } finally {
@@ -58,10 +57,15 @@ export function ReviewPage() {
   // Auto-start if mode passed via query param from dashboard
   useEffect(() => {
     const modeParam = searchParams.get('mode') as ModeOption | null;
+    const aheadParam = searchParams.get('ahead');
     if (modeParam && !autoStarted.current) {
       autoStarted.current = true;
       setMode(modeParam);
-      startReview(modeParam);
+      const studyAhead: number | 'all' | undefined =
+        aheadParam === null ? undefined :
+        aheadParam === 'all' ? 'all' :
+        Math.max(0, parseInt(aheadParam, 10) || 0);
+      startReview(modeParam, studyAhead);
     }
   }, []);
 

--- a/src/pages/ReviewPage.tsx
+++ b/src/pages/ReviewPage.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState, useRef } from 'react';
 import { useParams, useNavigate, useSearchParams } from 'react-router';
 import { useReviewStore } from '../stores/reviewStore';
-import { getReviewQueue, getStudyAheadQueue } from '../services/srs';
+import { getReviewQueue, getStudyAheadQueue, getDueBreakdown, type DueBreakdown } from '../services/srs';
 import { getAllTags } from '../services/ingestion';
 import { ReviewCard } from '../components/ReviewCard';
 import { MeaningCard } from '../components/MeaningCard';
 import { TagFilterRow } from '../components/TagFilterRow';
+import { CustomStudyButton } from '../components/CustomStudyButton';
 import type { ReviewMode } from '../db/schema';
 import { ensureDefaultDeck } from '../db/repo';
 
@@ -24,14 +25,19 @@ export function ReviewPage() {
   const { deckId } = useParams();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
-  const { setQueue, remaining, reset } = useReviewStore();
+  const { setQueue, reset } = useReviewStore();
+  const remainingCount = useReviewStore((s) => s.queue.length - s.currentIndex);
   const [mode, setMode] = useState<ModeOption>('en-to-zh');
   const [started, setStarted] = useState(false);
   const [allTags, setAllTags] = useState<string[]>([]);
   const [filterTags, setFilterTags] = useState<string[]>([]);
   const [loading, setLoading] = useState(false);
   const [loadingMode, setLoadingMode] = useState<ModeOption | null>(null);
+  const [activeDeckId, setActiveDeckId] = useState<string | null>(null);
+  const [breakdown, setBreakdown] = useState<DueBreakdown | null>(null);
   const autoStarted = useRef(false);
+
+  const isSessionDone = started && remainingCount === 0;
 
   useEffect(() => {
     getAllTags().then(setAllTags);
@@ -42,6 +48,7 @@ export function ReviewPage() {
     setLoadingMode(selectedMode);
     try {
       const effectiveDeckId = deckId ?? (await ensureDefaultDeck());
+      setActiveDeckId(effectiveDeckId);
       const tags = filterTags.length > 0 ? filterTags : null;
       const queue = studyAhead !== undefined
         ? await getStudyAheadQueue(effectiveDeckId, selectedMode, tags, studyAhead === 'all' ? undefined : studyAhead)
@@ -52,6 +59,25 @@ export function ReviewPage() {
       setLoading(false);
       setLoadingMode(null);
     }
+  };
+
+  // Refetch the breakdown whenever the session ends so the Custom Study panel
+  // shows accurate backlogs / future counts (after a bump, those numbers shift).
+  useEffect(() => {
+    if (!isSessionDone || !activeDeckId) return;
+    let cancelled = false;
+    getDueBreakdown(activeDeckId).then((b) => {
+      if (!cancelled) setBreakdown(b);
+    });
+    return () => { cancelled = true; };
+  }, [isSessionDone, activeDeckId]);
+
+  const handleStudyAhead = (count: number) => {
+    startReview(mode, Math.max(1, count));
+  };
+
+  const handleAfterBump = () => {
+    startReview(mode);
   };
 
   // Auto-start if mode passed via query param from dashboard
@@ -156,11 +182,22 @@ export function ReviewPage() {
           &larr; Back
         </button>
         <h1 className="text-xl font-bold">Review</h1>
-        <div className="text-sm" style={{ color: 'var(--text-tertiary)' }}>{remaining()} left</div>
+        <div className="text-sm" style={{ color: 'var(--text-tertiary)' }}>{remainingCount} left</div>
       </div>
 
       <ReviewCard />
       <MeaningCard />
+      {isSessionDone && breakdown && activeDeckId && (
+        <div className="max-w-md mx-auto mt-2">
+          <CustomStudyButton
+            deckId={activeDeckId}
+            mode={mode === 'both' ? 'all' : mode}
+            breakdown={breakdown}
+            onAfterBump={handleAfterBump}
+            onStudyAhead={handleStudyAhead}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/services/srs.ts
+++ b/src/services/srs.ts
@@ -352,6 +352,11 @@ export interface ModeStateCounts {
   futureCount: number;
 }
 
+export const EMPTY_MODE_STATE: ModeStateCounts = {
+  newCount: 0, learningCount: 0, reviewCount: 0,
+  newBacklog: 0, reviewBacklog: 0, futureCount: 0,
+};
+
 export interface DueBreakdown {
   byMode: ModeCounts;
   byModeAndState: Record<ReviewMode | 'all', ModeStateCounts>;
@@ -369,10 +374,7 @@ export async function getDueBreakdown(deckId: string): Promise<DueBreakdown> {
   const now = Date.now();
   const deck = await repo.getDeck(deckId);
   if (!deck) {
-    const empty: ModeStateCounts = {
-      newCount: 0, learningCount: 0, reviewCount: 0,
-      newBacklog: 0, reviewBacklog: 0, futureCount: 0,
-    };
+    const empty = EMPTY_MODE_STATE;
     const byModeAndState = {
       'all': empty, 'en-to-zh': empty, 'zh-to-en': empty,
       'py-to-en-zh': empty, 'listen-type': empty, 'speak': empty,

--- a/src/services/srs.ts
+++ b/src/services/srs.ts
@@ -14,6 +14,7 @@ import type { SrsCard, ReviewLog, ReviewMode } from '../db/schema';
 import { v4 as uuid } from 'uuid';
 import { getDeviceId } from '../db/syncEngine';
 import { useFSRSSettingsStore, toFSRSParams } from '../stores/fsrsSettingsStore';
+import { getNewLimitBumpToday, getReviewLimitBumpToday } from '../lib/dailyLimits';
 
 function getScheduler() {
   const settings = useFSRSSettingsStore.getState();
@@ -140,6 +141,22 @@ export async function undoReview(undo: UndoInfo): Promise<void> {
   await repo.deletePendingSyncOp(undo.syncOpId);
 }
 
+/**
+ * How many new cards the user can still see today, deck-wide. The cap is
+ * shared across review modes — matches Anki's "new cards/day" semantic.
+ * Adds any "Increase today's new card limit" bump the user has applied.
+ */
+async function newCardsRemainingToday(deckId: string, newCardsPerDay: number): Promise<number> {
+  const todayStart = new Date();
+  todayStart.setHours(0, 0, 0, 0);
+  const todayLogs = await repo.getReviewLogsSince(todayStart.getTime());
+  const todayNewCardIds = new Set(todayLogs.map((r) => r.cardId));
+  const todayCards = await repo.getSrsCardsByIds([...todayNewCardIds]);
+  const newReviewedToday = todayCards.filter((c) => c.reps === 1).length;
+  const cap = newCardsPerDay + getNewLimitBumpToday(deckId);
+  return Math.max(0, cap - newReviewedToday);
+}
+
 /** Get review queue for a deck, optionally filtered by review mode and/or tags */
 export async function getReviewQueue(
   deckId: string,
@@ -165,34 +182,64 @@ export async function getReviewQueue(
 
   // Fetch all cards for this deck in relevant states
   // Learning (1) + Relearning (3) + Review (2) + New (0)
-  const [learningRelearning, reviewCards, newCards] = await Promise.all([
+  const [learningRelearning, reviewCards, newCards, newRemaining] = await Promise.all([
     repo.getSrsCardsByDeckAndStates(deckId, [1, 3]),
     repo.getSrsCardsByDeckAndState(deckId, 2),
     repo.getSrsCardsByDeckAndState(deckId, 0),
+    newCardsRemainingToday(deckId, deck.newCardsPerDay),
   ]);
 
-  // Learning cards (state=1 or 3, due now)
+  const reviewLimit = deck.reviewsPerDay + getReviewLimitBumpToday(deckId);
+
   const duelearning = learningRelearning.filter((c) => c.due <= now && ok(c));
 
-  // Review cards (state=2, due now, up to daily limit)
   const dueReview = reviewCards
     .filter((c) => c.due <= now && ok(c))
-    .slice(0, deck.reviewsPerDay);
+    .slice(0, reviewLimit);
 
-  // New cards (state=0) up to daily limit
-  const todayStart = new Date();
-  todayStart.setHours(0, 0, 0, 0);
-  const todayLogs = await repo.getReviewLogsSince(todayStart.getTime());
-
-  const todayNewCardIds = new Set(todayLogs.map((r) => r.cardId));
-  const todayCards = await repo.getSrsCardsByIds([...todayNewCardIds]);
-  const newReviewedToday = todayCards.filter((c) => c.reps === 1).length;
-
-  const remaining = Math.max(0, deck.newCardsPerDay - newReviewedToday);
-  const dueNew = newCards.filter((c) => ok(c)).slice(0, remaining);
+  const dueNew = newCards.filter((c) => ok(c)).slice(0, newRemaining);
 
   // Priority: learning/relearning > review > new
   return [...duelearning, ...dueReview, ...dueNew];
+}
+
+/**
+ * Bonus queue of cards that aren't due yet but are coming up soonest. The
+ * regular queue is empty (or close to it) and the user wants to keep going.
+ *
+ * Ratings still write to FSRS as normal early reviews — elapsed-time is
+ * meaningful, so this isn't cram-mode. New cards (state 0) are excluded;
+ * they aren't "ahead", they're always available and have their own daily cap.
+ */
+export async function getStudyAheadQueue(
+  deckId: string,
+  modeFilter?: ReviewMode | 'both',
+  tagFilter?: string[] | null,
+  limit?: number,
+): Promise<SrsCard[]> {
+  const now = Date.now();
+
+  let tagSentenceIds: Set<string> | null = null;
+  if (tagFilter && tagFilter.length > 0) {
+    const tagged = await repo.getSentencesByTags(tagFilter);
+    tagSentenceIds = new Set(tagged.map((s) => s.id));
+  }
+
+  const modeOk = (c: SrsCard) =>
+    !modeFilter || modeFilter === 'both' || c.reviewMode === modeFilter;
+  const tagOk = (c: SrsCard) =>
+    !tagSentenceIds || tagSentenceIds.has(c.sentenceId);
+
+  const [learningRelearning, reviewCards] = await Promise.all([
+    repo.getSrsCardsByDeckAndStates(deckId, [1, 3]),
+    repo.getSrsCardsByDeckAndState(deckId, 2),
+  ]);
+
+  const future = [...learningRelearning, ...reviewCards]
+    .filter((c) => c.due > now && modeOk(c) && tagOk(c))
+    .sort((a, b) => a.due - b.due);
+
+  return typeof limit === 'number' ? future.slice(0, limit) : future;
 }
 
 /** Get counts for dashboard display */
@@ -252,25 +299,67 @@ export function groupCardsBySentence(cards: SrsCard[]): Map<string, SrsCard[]> {
 
 export type ModeCounts = Record<ReviewMode, number>;
 
-export interface DueBreakdown {
-  byMode: ModeCounts;
-  /** Per-state counts keyed by mode ('all' includes every mode) */
-  byModeAndState: Record<ReviewMode | 'all', { newCount: number; learningCount: number; reviewCount: number }>;
+/**
+ * Per-mode counts. The first three are what the user can review *right now*
+ * (cap-applied, matches getReviewQueue). The "*Backlog" / futureCount fields
+ * are what *could* be reviewed via Custom Study actions — used by the
+ * Dashboard to decide which Custom Study rows to show when due === 0.
+ */
+export interface ModeStateCounts {
+  newCount: number;
+  learningCount: number;
+  reviewCount: number;
+  /** Unseen new cards held back by the daily new-card cap. */
+  newBacklog: number;
+  /** Already-due review cards held back by the daily review cap. */
+  reviewBacklog: number;
+  /** Cards scheduled in the future (study-ahead candidates). */
+  futureCount: number;
 }
 
-/** Get due card counts broken down by review mode and card state */
+export interface DueBreakdown {
+  byMode: ModeCounts;
+  byModeAndState: Record<ReviewMode | 'all', ModeStateCounts>;
+}
+
+/**
+ * Due card counts broken down by review mode and card state. Counts are
+ * cap-aware: they reflect what `getReviewQueue` would actually return for
+ * each mode, so "X due (today)" matches what clicking Study delivers.
+ *
+ * Also surfaces "what could be unlocked": newBacklog/reviewBacklog (cards
+ * the daily caps are holding back) and futureCount (study-ahead candidates).
+ */
 export async function getDueBreakdown(deckId: string): Promise<DueBreakdown> {
   const now = Date.now();
+  const deck = await repo.getDeck(deckId);
+  if (!deck) {
+    const empty: ModeStateCounts = {
+      newCount: 0, learningCount: 0, reviewCount: 0,
+      newBacklog: 0, reviewBacklog: 0, futureCount: 0,
+    };
+    const byModeAndState = {
+      'all': empty, 'en-to-zh': empty, 'zh-to-en': empty,
+      'py-to-en-zh': empty, 'listen-type': empty, 'speak': empty,
+    };
+    return {
+      byMode: { 'en-to-zh': 0, 'zh-to-en': 0, 'py-to-en-zh': 0, 'listen-type': 0, 'speak': 0 },
+      byModeAndState,
+    };
+  }
 
-  const [newCards, learningCards, reviewCards] = await Promise.all([
+  const [newCards, learningCards, reviewCards, newRemaining] = await Promise.all([
     repo.getSrsCardsByDeckAndState(deckId, 0),
     repo.getSrsCardsByDeckAndStates(deckId, [1, 3]),
     repo.getSrsCardsByDeckAndState(deckId, 2),
+    newCardsRemainingToday(deckId, deck.newCardsPerDay),
   ]);
 
-  const dueNew = newCards;
+  const reviewLimit = deck.reviewsPerDay + getReviewLimitBumpToday(deckId);
+
   const dueLearning = learningCards.filter((c) => c.due <= now);
   const dueReview = reviewCards.filter((c) => c.due <= now);
+  const futureCards = [...learningCards, ...reviewCards].filter((c) => c.due > now);
 
   const modes: (ReviewMode | 'all')[] = ['all', 'en-to-zh', 'zh-to-en', 'py-to-en-zh', 'listen-type', 'speak'];
   const byMode: ModeCounts = { 'en-to-zh': 0, 'zh-to-en': 0, 'py-to-en-zh': 0, 'listen-type': 0, 'speak': 0 };
@@ -278,10 +367,21 @@ export async function getDueBreakdown(deckId: string): Promise<DueBreakdown> {
 
   for (const m of modes) {
     const modeOk = (c: SrsCard) => m === 'all' || c.reviewMode === m;
-    const nc = dueNew.filter(modeOk).length;
+    const modeNewTotal = newCards.filter(modeOk).length;
+    const modeDueReviewTotal = dueReview.filter(modeOk).length;
+
+    const nc = Math.min(modeNewTotal, newRemaining);
     const lc = dueLearning.filter(modeOk).length;
-    const rc = dueReview.filter(modeOk).length;
-    byModeAndState[m] = { newCount: nc, learningCount: lc, reviewCount: rc };
+    const rc = Math.min(modeDueReviewTotal, reviewLimit);
+
+    byModeAndState[m] = {
+      newCount: nc,
+      learningCount: lc,
+      reviewCount: rc,
+      newBacklog: Math.max(0, modeNewTotal - newRemaining),
+      reviewBacklog: Math.max(0, modeDueReviewTotal - reviewLimit),
+      futureCount: futureCards.filter(modeOk).length,
+    };
     if (m !== 'all') byMode[m] = nc + lc + rc;
   }
 


### PR DESCRIPTION
Closes #163.

## Summary
Adds an Anki-style Custom Study panel to the Dashboard for when the regular queue is empty. Up to three rows appear depending on what's available:

- **New cards today (+10 / +20)** — bumps `newCardsPerDay` for today only, surfacing unseen new cards held back by the daily cap.
- **Review backlog (+10 / +20 / All)** — bumps `reviewsPerDay` for today only, surfacing already-due review cards held back by the daily cap.
- **Study ahead (+10 / +20 / All)** — pulls future-due cards forward via a new \`getStudyAheadQueue\`. Ratings write to FSRS as normal early reviews; the elapsed-time signal is still meaningful.

Bumps are stored in localStorage with date-scoped keys (\`mandao:bump:<kind>:<deckId>:<yyyy-mm-dd>\`), so they auto-expire at local midnight without a Dexie migration. Bumps are deck-wide, matching Anki's semantics.

## Bonus fix
\`getDueBreakdown\` (Dashboard count) now applies the same daily caps as \`getReviewQueue\`, so "X due (today)" matches what clicking Study delivers. Previously the Dashboard could show "3 due" while Study returned an empty queue when the cap was reached — now they're consistent.

## Test plan
- [ ] Drain the daily review queue. Dashboard shows "No cards due".
- [ ] If unseen new cards exist beyond \`newCardsPerDay\`, the **New cards today** row appears. Click +10 → Dashboard refetches → \`Study (N cards)\` button appears with up to 10 newly-eligible cards.
- [ ] If already-due review cards exist beyond \`reviewsPerDay\`, the **Review backlog** row appears. Click +10 → same flow.
- [ ] If future-due cards exist, the **Study ahead** row appears. Click +10 → routes to \`/review?ahead=10\` and starts a session of 10 soonest-due-future cards. Rate them with the regular FSRS buttons; verify cards' \`due\` and \`stability\` updated in IndexedDB.
- [ ] Reload the page after bumping — bump persists for the rest of the day.
- [ ] Wait for local midnight (or change date) — bumps reset.
- [ ] Caps survive across review modes correctly (bumps are deck-wide).

🤖 Generated with [Claude Code](https://claude.com/claude-code)