### PR TITLE
Auto-play audio on card reveal (#170)

### DIFF
--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -11,7 +11,8 @@ import { ClickableEnglish } from './ClickableEnglish';
 import { reviewCard, undoReview, type Grade } from '../services/srs';
 import { comparePinyin, type SyllableResult } from '../lib/pinyinCompare';
 import { numericStringToDiacritic } from '../services/toneSandhi';
-import { speakChinese, stopSpeaking } from '../services/audio';
+import { stopSpeaking } from '../services/audio';
+import { useAudioPlaybackSettingsStore } from '../stores/audioPlaybackSettingsStore';
 import {
   isSpeechRecognitionSupported,
   stopRecognition,
@@ -46,9 +47,10 @@ export function ReviewCard() {
   const [pinyinInput, setPinyinInput] = useState('');
   const [pinyinResults, setPinyinResults] = useState<SyllableResult[] | null>(null);
   const pinyinInputRef = useRef<HTMLInputElement>(null);
-  const autoPlayed = useRef<string | null>(null);
   const [speedIndex, setSpeedIndex] = useState(2);
   const speechRate = SPEED_OPTIONS[speedIndex].value;
+  const masterAutoPlay = useAudioPlaybackSettingsStore((s) => s.masterEnabled);
+  const perModeAutoPlay = useAudioPlaybackSettingsStore((s) => s.perMode);
 
   // Speak-mode state
   const [isListening, setIsListening] = useState(false);
@@ -122,10 +124,6 @@ export function ReviewCard() {
   useEffect(() => {
     if (!isListenType || !sentence || !card) return;
     if (sentence.id !== card.sentenceId) return;
-    if (autoPlayed.current !== card.id) {
-      autoPlayed.current = card.id;
-      speakChinese(sentence.chinese, speechRate).catch(() => {});
-    }
     if (pinyinInputRef.current) {
       pinyinInputRef.current.focus();
     }
@@ -135,6 +133,18 @@ export function ReviewCard() {
   // Synchronous lock so OS key-repeat (holding 1-4 or Cmd+Z) can't fire
   // a second action before React commits the pending/undoing state flip.
   const actionLockRef = useRef(false);
+
+  // Auto-play key passed to SentenceAudioControls. Listen-type/speak fire on
+  // mount (audio is the prompt); other modes fire after flip. Speak skips
+  // while recording so playback doesn't bleed into the user's mic.
+  const autoPlayKey = (() => {
+    if (!card || !sentence) return null;
+    if (!masterAutoPlay) return null;
+    if (!perModeAutoPlay[card.reviewMode]) return null;
+    if (card.reviewMode === 'speak' && isListening) return null;
+    if (card.reviewMode === 'listen-type' || card.reviewMode === 'speak') return card.id;
+    return isFlipped ? card.id : null;
+  })();
 
   const handleUndo = async () => {
     if (actionLockRef.current || !undoInfo || undoing || pendingRating !== null) return;
@@ -519,7 +529,11 @@ export function ReviewCard() {
 
               {/* Audio controls row */}
               <div className="flex gap-2 justify-center flex-wrap mt-4">
-                <SentenceAudioControls sentenceId={sentence.id} text={sentence.chinese} />
+                <SentenceAudioControls
+                  sentenceId={sentence.id}
+                  text={sentence.chinese}
+                  autoPlayKey={autoPlayKey}
+                />
                 {recordingBlob && (
                   <button
                     onClick={handlePlayRecording}
@@ -583,6 +597,8 @@ export function ReviewCard() {
                   text={sentence.chinese}
                   rate={speechRate}
                   className="text-2xl"
+                  autoPlayKey={autoPlayKey}
+                  autoPlayFallbackToTts
                 />
                 <button
                   onClick={() => setSpeedIndex((i) => (i + 1) % SPEED_OPTIONS.length)}
@@ -762,7 +778,11 @@ export function ReviewCard() {
               )}
 
               <div className="text-center">
-                <SentenceAudioControls sentenceId={sentence.id} text={sentence.chinese} />
+                <SentenceAudioControls
+                  sentenceId={sentence.id}
+                  text={sentence.chinese}
+                  autoPlayKey={autoPlayKey}
+                />
               </div>
 
               {/* Tags */}

--- a/src/components/SentenceAudioControls.tsx
+++ b/src/components/SentenceAudioControls.tsx
@@ -57,6 +57,14 @@ interface Props {
   text: string;
   rate?: number;
   className?: string;
+  /**
+   * When this string changes to a non-null value, attempt auto-play once for
+   * that key. The component plays the first available recording; if none
+   * exists and `autoPlayFallbackToTts` is set, it falls back to default TTS.
+   */
+  autoPlayKey?: string | null;
+  /** If no recording exists, fall back to playing default Google TTS. */
+  autoPlayFallbackToTts?: boolean;
 }
 
 /**
@@ -64,15 +72,26 @@ interface Props {
  * one button per saved recording (same icon + label underneath), and a
  * trailing + button that starts a new recording inline.
  */
-export function SentenceAudioControls({ sentenceId, text, rate, className = '' }: Props) {
+export function SentenceAudioControls({
+  sentenceId,
+  text,
+  rate,
+  className = '',
+  autoPlayKey = null,
+  autoPlayFallbackToTts = false,
+}: Props) {
   const [recordings, setRecordings] = useState<AudioRecording[]>([]);
   // Recording id → resolved Blob. Eagerly populated alongside recordings so
   // play clicks can read the blob synchronously and call audio.play() inside
   // the user-gesture context — required by iOS Safari, where any await
   // between the click and play() rejects unmuted audio playback.
   const [blobMap, setBlobMap] = useState<Map<string, Blob>>(new Map());
+  const [recordingsLoaded, setRecordingsLoaded] = useState(false);
   const [playingId, setPlayingId] = useState<string | null>(null); // 'default' or recording.id
   const stopPlaybackRef = useRef<(() => void) | null>(null);
+  // Tracks which auto-play keys have already been handled, so a single key
+  // never fires twice (e.g. when recordings reload mid-effect).
+  const handledAutoPlayKeyRef = useRef<string | null>(null);
 
   // Inline recording state
   const [recordHandle, setRecordHandle] = useState<RecordingHandle | null>(null);
@@ -96,7 +115,12 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
         if (blob) map.set(r.id, blob);
       }),
     );
-    if (!cancelledRef.current) setBlobMap(map);
+    if (cancelledRef.current) return;
+    setBlobMap(map);
+    // Set after blobs land so the auto-play effect uses the eager-loaded
+    // blob path (synchronous play() inside the user-gesture context) rather
+    // than the async fallback.
+    setRecordingsLoaded(true);
   };
 
   const refresh = async () => {
@@ -105,6 +129,7 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
 
   useEffect(() => {
     const cancelledRef = { current: false };
+    setRecordingsLoaded(false);
     loadRecordingsAndBlobs(cancelledRef);
     return () => {
       cancelledRef.current = true;
@@ -193,6 +218,24 @@ export function SentenceAudioControls({ sentenceId, text, rate, className = '' }
       }
     })();
   };
+
+  // Each autoPlayKey fires at most once. We bail if playback has already
+  // started (cancel-on-manual-play) or recordings haven't finished loading.
+  useEffect(() => {
+    if (!autoPlayKey) return;
+    if (!recordingsLoaded) return;
+    if (handledAutoPlayKeyRef.current === autoPlayKey) return;
+    handledAutoPlayKeyRef.current = autoPlayKey;
+    if (playingId !== null) return;
+
+    if (recordings.length > 0) {
+      // recordings are sorted asc by createdAt; the last is the newest.
+      playRecording(recordings[recordings.length - 1]);
+      return;
+    }
+    if (autoPlayFallbackToTts) void playDefault();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [autoPlayKey, recordingsLoaded, recordings]);
 
   const defaultName = () => `Recording ${recordings.length + 1}`;
 

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -24,6 +24,8 @@ import {
   RECORDING_CAP_SEC_MAX,
   type AudioCacheCapMB,
 } from '../stores/audioCacheSettingsStore';
+import { useAudioPlaybackSettingsStore } from '../stores/audioPlaybackSettingsStore';
+import type { ReviewMode } from '../db/schema';
 import { getAudioCacheUsage } from '../db/localRepo';
 import {
   runAudioPrefetch,
@@ -1333,6 +1335,8 @@ function DataSection() {
         </div>
       </SectionCard>
 
+      <AudioPlaybackCard />
+
       {/* Offline audio cache */}
       <AudioCacheCard />
 
@@ -1375,6 +1379,60 @@ function DataSection() {
         )}
       </SectionCard>
     </div>
+  );
+}
+
+// ────────────────────────────────────────────────────────────
+// Auto-play during review
+// ────────────────────────────────────────────────────────────
+
+const PLAYBACK_MODES: { mode: ReviewMode; label: string }[] = [
+  { mode: 'listen-type', label: 'Listen mode' },
+  { mode: 'zh-to-en', label: 'ZH → EN' },
+  { mode: 'en-to-zh', label: 'EN → ZH' },
+  { mode: 'py-to-en-zh', label: 'Pinyin' },
+  { mode: 'speak', label: 'Speak' },
+];
+
+function AudioPlaybackCard() {
+  const masterEnabled = useAudioPlaybackSettingsStore((s) => s.masterEnabled);
+  const perMode = useAudioPlaybackSettingsStore((s) => s.perMode);
+  const setMasterEnabled = useAudioPlaybackSettingsStore((s) => s.setMasterEnabled);
+  const setModeEnabled = useAudioPlaybackSettingsStore((s) => s.setModeEnabled);
+
+  return (
+    <SectionCard
+      title="Auto-play during review"
+      description="When a card is revealed, automatically play the most-recent recording for that sentence (or the default voice for Listen mode if no recording exists)."
+    >
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-medium">Auto-play audio during review</span>
+          <Toggle checked={masterEnabled} onChange={setMasterEnabled} />
+        </div>
+
+        <div
+          className="space-y-2 pt-2"
+          style={{
+            opacity: masterEnabled ? 1 : 0.4,
+            pointerEvents: masterEnabled ? 'auto' : 'none',
+            borderTop: '1px solid var(--border)',
+          }}
+        >
+          {PLAYBACK_MODES.map(({ mode, label }) => (
+            <div key={mode} className="flex items-center justify-between">
+              <span className="text-sm" style={{ color: 'var(--text-secondary)' }}>
+                {label}
+              </span>
+              <Toggle
+                checked={perMode[mode]}
+                onChange={(v) => setModeEnabled(mode, v)}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </SectionCard>
   );
 }
 

--- a/src/stores/audioPlaybackSettingsStore.ts
+++ b/src/stores/audioPlaybackSettingsStore.ts
@@ -1,0 +1,71 @@
+import { create } from 'zustand';
+import type { ReviewMode } from '../db/schema';
+
+const STORAGE_KEY = 'mandao_audio_playback_settings';
+
+export interface AudioPlaybackSettings {
+  /** Master toggle. When off, no auto-play happens regardless of per-mode flags. */
+  masterEnabled: boolean;
+  /** Per-mode toggles. Listen-type fires when the card is shown; the rest fire after flip. */
+  perMode: Record<ReviewMode, boolean>;
+}
+
+const DEFAULTS: AudioPlaybackSettings = {
+  masterEnabled: true,
+  perMode: {
+    'listen-type': true,
+    'zh-to-en': true,
+    'en-to-zh': true,
+    'py-to-en-zh': false,
+    'speak': false,
+  },
+};
+
+const VALID_MODES: ReviewMode[] = ['en-to-zh', 'zh-to-en', 'py-to-en-zh', 'listen-type', 'speak'];
+
+function load(): AudioPlaybackSettings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return clone(DEFAULTS);
+    const parsed = JSON.parse(raw) as Partial<AudioPlaybackSettings>;
+    const merged = clone(DEFAULTS);
+    if (typeof parsed.masterEnabled === 'boolean') merged.masterEnabled = parsed.masterEnabled;
+    if (parsed.perMode && typeof parsed.perMode === 'object') {
+      for (const m of VALID_MODES) {
+        const v = (parsed.perMode as Record<string, unknown>)[m];
+        if (typeof v === 'boolean') merged.perMode[m] = v;
+      }
+    }
+    return merged;
+  } catch {
+    return clone(DEFAULTS);
+  }
+}
+
+function clone(s: AudioPlaybackSettings): AudioPlaybackSettings {
+  return { masterEnabled: s.masterEnabled, perMode: { ...s.perMode } };
+}
+
+function save(s: AudioPlaybackSettings) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(s));
+}
+
+interface AudioPlaybackSettingsState extends AudioPlaybackSettings {
+  setMasterEnabled: (v: boolean) => void;
+  setModeEnabled: (mode: ReviewMode, v: boolean) => void;
+}
+
+export const useAudioPlaybackSettingsStore = create<AudioPlaybackSettingsState>((set, get) => ({
+  ...load(),
+  setMasterEnabled: (masterEnabled) => {
+    if (get().masterEnabled === masterEnabled) return;
+    save({ ...get(), masterEnabled });
+    set({ masterEnabled });
+  },
+  setModeEnabled: (mode, v) => {
+    if (get().perMode[mode] === v) return;
+    const perMode = { ...get().perMode, [mode]: v };
+    save({ ...get(), perMode });
+    set({ perMode });
+  },
+}));


### PR DESCRIPTION
## Summary

Closes #170. Auto-plays the most-recent `AudioRecording` when a card is revealed, with a master toggle plus per-mode toggles in Settings.

- Defaults: **on** for `listen-type` / `zh-to-en` / `en-to-zh`; **off** for `py-to-en-zh` / `speak` (the latter would collide with the mic).
- Listen-type falls back to default Google TTS when no recording exists, preserving today's behavior.
- State persists to localStorage in a new `audioPlaybackSettingsStore`, mirroring the existing `audioCacheSettingsStore` pattern.
- Cancel-on-manual-play: if the user taps a play button before auto-play fires, the auto-play is skipped.
- Sentences with no recording (and no TTS-fallback opt-in) silently skip.

Settings UI lives in **Settings → Data → Auto-play during review** (per-mode toggles grey out when the master is off).

## Test plan

- [ ] Listen-type card with a saved recording → auto-plays the recording on mount.
- [ ] Listen-type card without a recording → auto-plays default TTS on mount (existing behavior preserved).
- [ ] zh-to-en / en-to-zh card with a recording → auto-plays after pressing **Show Answer**.
- [ ] py-to-en-zh card → no auto-play by default; toggle on in Settings → auto-plays after flip.
- [ ] Speak mode → no auto-play by default; toggle on → fires only when the mic is idle.
- [ ] Master toggle off → all per-mode rows greyed out and no auto-play across modes.
- [ ] Settings persist across reload.
- [ ] Manual play before auto-play fires cancels the auto-play (no double playback).
- [ ] No regression to manual play button or the recording UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)