### PR TITLE
Match Anki's reviewsPerDay cap on interday learning (#166)

### DIFF
--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -183,6 +183,13 @@ export interface FSRSSettings {
   enableShortTerm: boolean;
   learningSteps: string[];
   relearningSteps: string[];
+  /**
+   * If true, new cards are limited only by newCardsPerDay (independent of
+   * reviewsPerDay). If false (Anki default), new cards also count against
+   * reviewsPerDay — once the review bucket fills, no new cards are shown
+   * even if newCardsPerDay still has room.
+   */
+  newCardsIgnoreReviewLimit: boolean;
 }
 
 export interface Deck {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -351,7 +351,7 @@ function SRSSection() {
         </div>
         <div className="flex items-start justify-between gap-4 pt-2" style={{ borderTop: '1px solid var(--border)' }}>
           <div className="flex-1">
-            <div className="text-sm font-medium">New cards ignore review limit</div>
+            <div className="text-sm font-medium">New cards <u>ignore</u> review limit</div>
             <p className="text-xs mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
               Off (Anki default): new cards count against the reviews/day cap. Once the review bucket fills, no new cards appear even if the new-cards cap has room. Turn on to keep the two caps independent.
             </p>

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -349,6 +349,18 @@ function SRSSection() {
             hint="Maximum reviews per day"
           />
         </div>
+        <div className="flex items-start justify-between gap-4 pt-2" style={{ borderTop: '1px solid var(--border)' }}>
+          <div className="flex-1">
+            <div className="text-sm font-medium">New cards ignore review limit</div>
+            <p className="text-xs mt-0.5" style={{ color: 'var(--text-tertiary)' }}>
+              Off (Anki default): new cards count against the reviews/day cap. Once the review bucket fills, no new cards appear even if the new-cards cap has room. Turn on to keep the two caps independent.
+            </p>
+          </div>
+          <Toggle
+            checked={fsrs.newCardsIgnoreReviewLimit}
+            onChange={(v) => fsrsUpdate({ newCardsIgnoreReviewLimit: v })}
+          />
+        </div>
       </SectionCard>
 
       {/* FSRS parameters */}

--- a/src/services/srs.test.ts
+++ b/src/services/srs.test.ts
@@ -4,12 +4,24 @@ import {
   sentenceMasteryForMode,
   groupCardsBySentence,
   getFreeReviewQueue,
+  getReviewQueue,
+  getDueBreakdown,
 } from './srs';
 import type { SrsCard, ReviewMode } from '../db/schema';
 import { card } from '../test/factories';
+import { useFSRSSettingsStore } from '../stores/fsrsSettingsStore';
 
 vi.mock('../db/repo', () => ({
   getSrsCardsByDeckAndStates: vi.fn(),
+  getSrsCardsByDeckAndState: vi.fn(),
+  getSrsCardsByIds: vi.fn(),
+  getDeck: vi.fn(),
+  getReviewLogsSince: vi.fn(),
+  getSentencesByTags: vi.fn(),
+}));
+vi.mock('../lib/dailyLimits', () => ({
+  getNewLimitBumpToday: vi.fn(() => 0),
+  getReviewLimitBumpToday: vi.fn(() => 0),
 }));
 
 import * as repo from '../db/repo';
@@ -191,5 +203,177 @@ describe('getFreeReviewQueue', () => {
     });
     expect(result.length).toBeLessThanOrEqual(3);
     expect(result).toHaveLength(3);
+  });
+});
+
+describe('getReviewQueue daily-cap semantics', () => {
+  const mockedRepo = vi.mocked(repo);
+  const past = Date.now() - 1000;
+
+  function setupDeck(reviewsPerDay = 5, newCardsPerDay = 0) {
+    mockedRepo.getDeck.mockResolvedValue({
+      id: 'd1',
+      name: 'd',
+      description: '',
+      newCardsPerDay,
+      reviewsPerDay,
+      createdAt: 0,
+    });
+    mockedRepo.getReviewLogsSince.mockResolvedValue([]);
+    mockedRepo.getSrsCardsByIds.mockResolvedValue([]);
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useFSRSSettingsStore.setState({ newCardsIgnoreReviewLimit: false });
+  });
+
+  it('caps interday-learning + reviews together, leaves intraday uncapped', async () => {
+    setupDeck(5);
+    const intraday = Array.from({ length: 3 }, (_, i) =>
+      card({ id: `i${i}`, state: 1, scheduledDays: 0, due: past, lastReview: past }),
+    );
+    const interday = Array.from({ length: 4 }, (_, i) =>
+      card({ id: `r${i}`, state: 3, scheduledDays: 2, due: past, lastReview: past }),
+    );
+    const reviews = Array.from({ length: 4 }, (_, i) =>
+      card({ id: `v${i}`, state: 2, scheduledDays: 30, due: past, lastReview: past }),
+    );
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue([...intraday, ...interday]);
+    mockedRepo.getSrsCardsByDeckAndState.mockImplementation(async (_d, state) =>
+      state === 2 ? reviews : [],
+    );
+
+    const result = await getReviewQueue('d1');
+    // intraday (3, uncapped) + cap-of-5 from (interday 4 + review 4 = 8)
+    expect(result).toHaveLength(3 + 5);
+    expect(result.slice(0, 3).map((c) => c.id)).toEqual(['i0', 'i1', 'i2']);
+    expect(result.slice(3, 7).map((c) => c.id)).toEqual(['r0', 'r1', 'r2', 'r3']);
+    expect(result.slice(7).map((c) => c.id)).toEqual(['v0']);
+  });
+
+  it('relearning (state=3) with multi-day step counts against the cap', async () => {
+    setupDeck(2);
+    const relearning = Array.from({ length: 5 }, (_, i) =>
+      card({ id: `r${i}`, state: 3, scheduledDays: 2, due: past, lastReview: past }),
+    );
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue(relearning);
+    mockedRepo.getSrsCardsByDeckAndState.mockResolvedValue([]);
+
+    const result = await getReviewQueue('d1');
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.id)).toEqual(['r0', 'r1']);
+  });
+
+  it('classifies a sub-day step that crossed midnight as interday', async () => {
+    // ts-fsrs leaves scheduledDays=0 for sub-day steps even when due lands
+    // tomorrow. We detect cross-midnight via lastReview vs due calendar day.
+    setupDeck(1);
+    const yesterdayLate = new Date();
+    yesterdayLate.setHours(0, 0, 0, 0);
+    yesterdayLate.setTime(yesterdayLate.getTime() - 60 * 60 * 1000); // 11pm yesterday
+    const todayEarly = new Date();
+    todayEarly.setHours(0, 0, 0, 0);
+    todayEarly.setTime(todayEarly.getTime() + 60 * 60 * 1000); // 1am today
+    const crossMidnight = card({
+      id: 'x0',
+      state: 1,
+      scheduledDays: 0,
+      lastReview: yesterdayLate.getTime(),
+      due: todayEarly.getTime(),
+    });
+    const sameDayStep = card({
+      id: 's0',
+      state: 1,
+      scheduledDays: 0,
+      lastReview: todayEarly.getTime(),
+      due: past,
+    });
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue([crossMidnight, sameDayStep]);
+    mockedRepo.getSrsCardsByDeckAndState.mockResolvedValue([]);
+
+    const result = await getReviewQueue('d1');
+    // sameDayStep is intraday (uncapped); crossMidnight takes the only
+    // review-bucket slot.
+    expect(result.map((c) => c.id).sort()).toEqual(['s0', 'x0']);
+  });
+
+  it('shared budget: new cards stop appearing once the review bucket fills', async () => {
+    setupDeck(3, 10);
+    const reviews = Array.from({ length: 3 }, (_, i) =>
+      card({ id: `r${i}`, state: 2, scheduledDays: 30, due: past, lastReview: past }),
+    );
+    const news = Array.from({ length: 5 }, (_, i) => card({ id: `n${i}`, state: 0 }));
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue([]);
+    mockedRepo.getSrsCardsByDeckAndState.mockImplementation(async (_d, state) =>
+      state === 2 ? reviews : state === 0 ? news : [],
+    );
+
+    const result = await getReviewQueue('d1');
+    // Reviews fill the 3-slot cap; no slots left for new cards.
+    expect(result).toHaveLength(3);
+    expect(result.every((c) => c.state === 2)).toBe(true);
+  });
+
+  it('independent budgets when newCardsIgnoreReviewLimit is on', async () => {
+    setupDeck(3, 10);
+    useFSRSSettingsStore.setState({ newCardsIgnoreReviewLimit: true });
+    const reviews = Array.from({ length: 3 }, (_, i) =>
+      card({ id: `r${i}`, state: 2, scheduledDays: 30, due: past, lastReview: past }),
+    );
+    const news = Array.from({ length: 5 }, (_, i) => card({ id: `n${i}`, state: 0 }));
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue([]);
+    mockedRepo.getSrsCardsByDeckAndState.mockImplementation(async (_d, state) =>
+      state === 2 ? reviews : state === 0 ? news : [],
+    );
+
+    const result = await getReviewQueue('d1');
+    // Reviews use their full cap, AND new cards still flow up to newCardsPerDay.
+    expect(result).toHaveLength(3 + 5);
+  });
+});
+
+describe('getDueBreakdown reflects the capped queue', () => {
+  const mockedRepo = vi.mocked(repo);
+  const past = Date.now() - 1000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useFSRSSettingsStore.setState({ newCardsIgnoreReviewLimit: false });
+    mockedRepo.getDeck.mockResolvedValue({
+      id: 'd1',
+      name: 'd',
+      description: '',
+      newCardsPerDay: 0,
+      reviewsPerDay: 3,
+      createdAt: 0,
+    });
+    mockedRepo.getReviewLogsSince.mockResolvedValue([]);
+    mockedRepo.getSrsCardsByIds.mockResolvedValue([]);
+  });
+
+  it('reports learningCount as intraday-only, reviewCount as the capped bucket, and reviewBacklog accordingly', async () => {
+    const intraday = Array.from({ length: 2 }, (_, i) =>
+      card({ id: `i${i}`, state: 1, scheduledDays: 0, due: past, lastReview: past, reviewMode: 'zh-to-en' }),
+    );
+    const interday = Array.from({ length: 3 }, (_, i) =>
+      card({ id: `j${i}`, state: 3, scheduledDays: 1, due: past, lastReview: past, reviewMode: 'zh-to-en' }),
+    );
+    const reviews = Array.from({ length: 4 }, (_, i) =>
+      card({ id: `r${i}`, state: 2, scheduledDays: 10, due: past, lastReview: past, reviewMode: 'zh-to-en' }),
+    );
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue([...intraday, ...interday]);
+    mockedRepo.getSrsCardsByDeckAndState.mockImplementation(async (_d, state) =>
+      state === 2 ? reviews : [],
+    );
+
+    const breakdown = await getDueBreakdown('d1');
+    expect(breakdown.byModeAndState['all']).toMatchObject({
+      newCount: 0,
+      learningCount: 2, // intraday only
+      reviewCount: 3, // min(reviewsPerDay=3, interday 3 + review 4 = 7)
+      reviewBacklog: 4, // 7 - 3
+    });
+    expect(breakdown.byMode['zh-to-en']).toBe(5);
   });
 });

--- a/src/services/srs.test.ts
+++ b/src/services/srs.test.ts
@@ -331,6 +331,41 @@ describe('getReviewQueue daily-cap semantics', () => {
     // Reviews use their full cap, AND new cards still flow up to newCardsPerDay.
     expect(result).toHaveLength(3 + 5);
   });
+
+  it('treats a learning card with no lastReview as intraday (uncapped fallback)', async () => {
+    setupDeck(0); // hard cap blocks the review bucket entirely
+    const seeded = card({
+      id: 'l0',
+      state: 1,
+      scheduledDays: 0,
+      lastReview: null, // no review history yet
+      due: past,
+    });
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue([seeded]);
+    mockedRepo.getSrsCardsByDeckAndState.mockResolvedValue([]);
+
+    const result = await getReviewQueue('d1');
+    expect(result.map((c) => c.id)).toEqual(['l0']);
+  });
+
+  it('applies the cap after mode filtering — modeFilter scopes the bucket', async () => {
+    setupDeck(2);
+    // 3 zh-to-en interday cards + 3 en-to-zh interday cards. Cap=2 per
+    // session. Filtering to zh-to-en should yield 2 zh-to-en, not 2 of
+    // any mode.
+    const zh = Array.from({ length: 3 }, (_, i) =>
+      card({ id: `zh${i}`, state: 3, scheduledDays: 1, due: past, lastReview: past, reviewMode: 'zh-to-en' }),
+    );
+    const en = Array.from({ length: 3 }, (_, i) =>
+      card({ id: `en${i}`, state: 3, scheduledDays: 1, due: past, lastReview: past, reviewMode: 'en-to-zh' }),
+    );
+    mockedRepo.getSrsCardsByDeckAndStates.mockResolvedValue([...zh, ...en]);
+    mockedRepo.getSrsCardsByDeckAndState.mockResolvedValue([]);
+
+    const result = await getReviewQueue('d1', 'zh-to-en');
+    expect(result).toHaveLength(2);
+    expect(result.every((c) => c.reviewMode === 'zh-to-en')).toBe(true);
+  });
 });
 
 describe('getDueBreakdown reflects the capped queue', () => {

--- a/src/services/srs.ts
+++ b/src/services/srs.ts
@@ -191,16 +191,49 @@ export async function getReviewQueue(
 
   const reviewLimit = deck.reviewsPerDay + getReviewLimitBumpToday(deckId);
 
-  const duelearning = learningRelearning.filter((c) => c.due <= now && ok(c));
+  // Anki's daily-cap rule: interday learning/relearning shares the
+  // reviewsPerDay budget with state-2 reviews and gets first dibs;
+  // intraday learning bypasses the cap entirely.
+  const dueLearning = learningRelearning.filter((c) => c.due <= now && ok(c));
+  const intraday = dueLearning.filter(isIntradayLearning);
+  const interday = dueLearning.filter((c) => !isIntradayLearning(c));
+  const dueReview = reviewCards.filter((c) => c.due <= now && ok(c));
+  const reviewBucket = [...interday, ...dueReview].slice(0, reviewLimit);
 
-  const dueReview = reviewCards
-    .filter((c) => c.due <= now && ok(c))
-    .slice(0, reviewLimit);
+  // Anki default: new cards also count against reviewsPerDay (the
+  // "newCardsIgnoreReviewLimit" toggle reverts to two independent caps).
+  const ignoreReviewLimit = useFSRSSettingsStore.getState().newCardsIgnoreReviewLimit;
+  const newCap = ignoreReviewLimit
+    ? newRemaining
+    : Math.min(newRemaining, Math.max(0, reviewLimit - reviewBucket.length));
+  const dueNew = newCards.filter((c) => ok(c)).slice(0, newCap);
 
-  const dueNew = newCards.filter((c) => ok(c)).slice(0, newRemaining);
+  return [...intraday, ...reviewBucket, ...dueNew];
+}
 
-  // Priority: learning/relearning > review > new
-  return [...duelearning, ...dueReview, ...dueNew];
+/**
+ * Per Anki, a learning/relearning card is intraday only when its step both
+ * (a) is sub-day AND (b) does not cross the day boundary between
+ * lastReview and due. From the Anki docs:
+ *
+ *   "if the step crosses a day boundary, the delay is automatically
+ *   converted to days" (deck-options#day-boundaries)
+ *
+ * Anki rewrites the scheduled interval at scheduling time so a 6-hour step
+ * taken at 11pm becomes a 1-day step; ts-fsrs does not. We detect the same
+ * condition by comparing lastReview's calendar day with due's. Different
+ * days → step crossed midnight → interday.
+ */
+function isIntradayLearning(c: SrsCard): boolean {
+  if (c.scheduledDays >= 1) return false;
+  if (!c.lastReview) return true;
+  return startOfDayMs(c.lastReview) === startOfDayMs(c.due);
+}
+
+function startOfDayMs(ms: number): number {
+  const d = new Date(ms);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
 }
 
 /**
@@ -393,8 +426,11 @@ export async function getDueBreakdown(deckId: string): Promise<DueBreakdown> {
   ]);
 
   const reviewLimit = deck.reviewsPerDay + getReviewLimitBumpToday(deckId);
+  const ignoreReviewLimit = useFSRSSettingsStore.getState().newCardsIgnoreReviewLimit;
 
   const dueLearning = learningCards.filter((c) => c.due <= now);
+  const intraday = dueLearning.filter(isIntradayLearning);
+  const interday = dueLearning.filter((c) => !isIntradayLearning(c));
   const dueReview = reviewCards.filter((c) => c.due <= now);
   const futureCards = [...learningCards, ...reviewCards].filter((c) => c.due > now);
 
@@ -405,21 +441,28 @@ export async function getDueBreakdown(deckId: string): Promise<DueBreakdown> {
   for (const m of modes) {
     const modeOk = (c: SrsCard) => m === 'all' || c.reviewMode === m;
     const modeNewTotal = newCards.filter(modeOk).length;
+    const modeIntradayTotal = intraday.filter(modeOk).length;
+    const modeInterdayTotal = interday.filter(modeOk).length;
     const modeDueReviewTotal = dueReview.filter(modeOk).length;
+    const modeReviewBucketTotal = modeInterdayTotal + modeDueReviewTotal;
 
-    const nc = Math.min(modeNewTotal, newRemaining);
-    const lc = dueLearning.filter(modeOk).length;
-    const rc = Math.min(modeDueReviewTotal, reviewLimit);
+    const rc = Math.min(modeReviewBucketTotal, reviewLimit);
+    const reviewBacklog = Math.max(0, modeReviewBucketTotal - reviewLimit);
+
+    const newSlots = ignoreReviewLimit
+      ? newRemaining
+      : Math.min(newRemaining, Math.max(0, reviewLimit - rc));
+    const nc = Math.min(modeNewTotal, newSlots);
 
     byModeAndState[m] = {
       newCount: nc,
-      learningCount: lc,
+      learningCount: modeIntradayTotal,
       reviewCount: rc,
-      newBacklog: Math.max(0, modeNewTotal - newRemaining),
-      reviewBacklog: Math.max(0, modeDueReviewTotal - reviewLimit),
+      newBacklog: Math.max(0, modeNewTotal - newSlots),
+      reviewBacklog,
       futureCount: futureCards.filter(modeOk).length,
     };
-    if (m !== 'all') byMode[m] = nc + lc + rc;
+    if (m !== 'all') byMode[m] = nc + modeIntradayTotal + rc;
   }
 
   return { byMode, byModeAndState };

--- a/src/services/srs.ts
+++ b/src/services/srs.ts
@@ -190,22 +190,11 @@ export async function getReviewQueue(
   ]);
 
   const reviewLimit = deck.reviewsPerDay + getReviewLimitBumpToday(deckId);
-
-  // Anki's daily-cap rule: interday learning/relearning shares the
-  // reviewsPerDay budget with state-2 reviews and gets first dibs;
-  // intraday learning bypasses the cap entirely.
   const dueLearning = learningRelearning.filter((c) => c.due <= now && ok(c));
-  const intraday = dueLearning.filter(isIntradayLearning);
-  const interday = dueLearning.filter((c) => !isIntradayLearning(c));
+  const { intraday, interday } = partitionLearning(dueLearning);
   const dueReview = reviewCards.filter((c) => c.due <= now && ok(c));
   const reviewBucket = [...interday, ...dueReview].slice(0, reviewLimit);
-
-  // Anki default: new cards also count against reviewsPerDay (the
-  // "newCardsIgnoreReviewLimit" toggle reverts to two independent caps).
-  const ignoreReviewLimit = useFSRSSettingsStore.getState().newCardsIgnoreReviewLimit;
-  const newCap = ignoreReviewLimit
-    ? newRemaining
-    : Math.min(newRemaining, Math.max(0, reviewLimit - reviewBucket.length));
+  const newCap = newCardSlots(newRemaining, reviewLimit, reviewBucket.length);
   const dueNew = newCards.filter((c) => ok(c)).slice(0, newCap);
 
   return [...intraday, ...reviewBucket, ...dueNew];
@@ -226,8 +215,27 @@ export async function getReviewQueue(
  */
 function isIntradayLearning(c: SrsCard): boolean {
   if (c.scheduledDays >= 1) return false;
+  // No lastReview → freshly-seeded mid-step card; treat as intraday so it
+  // doesn't accidentally consume a review-bucket slot.
   if (!c.lastReview) return true;
   return startOfDayMs(c.lastReview) === startOfDayMs(c.due);
+}
+
+function partitionLearning(cards: SrsCard[]): { intraday: SrsCard[]; interday: SrsCard[] } {
+  const intraday: SrsCard[] = [];
+  const interday: SrsCard[] = [];
+  for (const c of cards) (isIntradayLearning(c) ? intraday : interday).push(c);
+  return { intraday, interday };
+}
+
+/**
+ * How many new cards to deliver after the review bucket is filled. Anki's
+ * default has the two caps share a budget; the newCardsIgnoreReviewLimit
+ * toggle reverts to independent caps.
+ */
+function newCardSlots(newRemaining: number, reviewLimit: number, reviewBucketSize: number): number {
+  if (useFSRSSettingsStore.getState().newCardsIgnoreReviewLimit) return newRemaining;
+  return Math.min(newRemaining, Math.max(0, reviewLimit - reviewBucketSize));
 }
 
 function startOfDayMs(ms: number): number {
@@ -426,11 +434,8 @@ export async function getDueBreakdown(deckId: string): Promise<DueBreakdown> {
   ]);
 
   const reviewLimit = deck.reviewsPerDay + getReviewLimitBumpToday(deckId);
-  const ignoreReviewLimit = useFSRSSettingsStore.getState().newCardsIgnoreReviewLimit;
-
   const dueLearning = learningCards.filter((c) => c.due <= now);
-  const intraday = dueLearning.filter(isIntradayLearning);
-  const interday = dueLearning.filter((c) => !isIntradayLearning(c));
+  const { intraday, interday } = partitionLearning(dueLearning);
   const dueReview = reviewCards.filter((c) => c.due <= now);
   const futureCards = [...learningCards, ...reviewCards].filter((c) => c.due > now);
 
@@ -448,10 +453,7 @@ export async function getDueBreakdown(deckId: string): Promise<DueBreakdown> {
 
     const rc = Math.min(modeReviewBucketTotal, reviewLimit);
     const reviewBacklog = Math.max(0, modeReviewBucketTotal - reviewLimit);
-
-    const newSlots = ignoreReviewLimit
-      ? newRemaining
-      : Math.min(newRemaining, Math.max(0, reviewLimit - rc));
+    const newSlots = newCardSlots(newRemaining, reviewLimit, rc);
     const nc = Math.min(modeNewTotal, newSlots);
 
     byModeAndState[m] = {

--- a/src/stores/fsrsSettingsStore.ts
+++ b/src/stores/fsrsSettingsStore.ts
@@ -13,6 +13,7 @@ const DEFAULTS: FSRSSettings = {
   enableShortTerm: true,
   learningSteps: ['1m', '10m'],
   relearningSteps: ['10m'],
+  newCardsIgnoreReviewLimit: false,
 };
 
 const SETTING_KEYS = Object.keys(DEFAULTS) as (keyof FSRSSettings)[];


### PR DESCRIPTION
## Summary

Closes #166.

> **Behavior change**: Decks with relearning cards and a tight `reviewsPerDay` will deliver fewer cards per session — that's the intended fix. Users opted into the previous "no cap on relearning" behavior implicitly, so this may be visible immediately. Custom Study (#165) is the escape hatch for clearing backlogs.

`reviewsPerDay` previously only capped mature reviews (state=2). Learning (state=1) and relearning (state=3) cards always bypassed the cap. After pressing **Again** on a mature card, FSRS routinely schedules the relearning step a day or more out, and Anki counts those against `reviewsPerDay` — this app didn't, so users with a tight cap saw more cards than configured.

Also matches Anki's default that **new cards count against `reviewsPerDay`**. Adds a `newCardsIgnoreReviewLimit` toggle (Settings → SRS → Daily Limits, syncs cross-device via the `fsrs_settings` deck blob from #180) so power users can opt back to two independent caps.

## Fix

Classify each due learning/relearning card per Anki's [day-boundary rule](https://docs.ankiweb.net/deck-options.html#day-boundaries):

- `scheduledDays >= 1` → **interday** (multi-day step)
- `scheduledDays < 1` AND `startOfDay(lastReview) === startOfDay(due)` → **intraday** (sub-day, same calendar day)
- `scheduledDays < 1` AND days differ → **interday** (sub-day step that crossed midnight)

The third bullet matters because ts-fsrs leaves `scheduledDays = 0` for cross-midnight sub-day steps; Anki rewrites them to 1 day at scheduling time. Calendar-day comparison catches that case.

Cap rule:
- Intraday: uncapped, prepended.
- Interday + state-2 reviews: share `reviewsPerDay` with interday getting first dibs.
- New cards: when `newCardsIgnoreReviewLimit` is **off** (Anki default), share the leftover slots after the review bucket fills; when **on**, fall back to the independent `newCardsPerDay` cap.

Matches the [Anki docs](https://docs.ankiweb.net/deck-options.html#daily-limits): _"The review limit also affects interday learning cards. When applying the limit, interday learning cards are gathered first, then review cards."_

`getDueBreakdown` mirrors the cap so the dashboard "Study (N cards)" label and `reviewBacklog` match the queue.

## Test plan

- [ ] Set `reviewsPerDay = 5`, fail ≥ 6 mature cards so they're relearning with multi-day steps. Press **Study** → session contains at most 5 review-bucket cards (was: all of them).
- [ ] Sub-day-step learning cards still appear regardless of cap (intraday bypass still works).
- [ ] Dashboard "Study (N cards)" label matches the actual review session size.
- [ ] Settings → SRS → Daily Limits → toggle **New cards ignore review limit** changes whether new cards share the cap or have an independent limit.
- [ ] No regression to mature reviews when there's no learning backlog.

21 unit tests in `srs.test.ts` (8 new) covering: cap interaction, intraday bypass, the relearning-backlog repro, cross-midnight classifier, shared/independent budget modes, breakdown alignment, `lastReview = null` fallback, mode-filter × cap interaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)