### PR TITLE
Sync deck setting changes across devices

### DIFF
--- a/src/components/SyncErrorBanner.tsx
+++ b/src/components/SyncErrorBanner.tsx
@@ -9,6 +9,7 @@ const OP_LABELS: Record<SyncOpType, string> = {
   deleteEntity: 'delete',
   deleteAllData: 'clear all data',
   updateTags: 'tag update',
+  updateDeck: 'deck settings',
   upsertAudioRecording: 'audio upload',
   deleteStorageObjects: 'audio cleanup',
 };

--- a/src/db/localDb.ts
+++ b/src/db/localDb.ts
@@ -23,6 +23,7 @@ export type SyncOpType =
   | 'deleteEntity'
   | 'deleteAllData'
   | 'updateTags'
+  | 'updateDeck'
   | 'upsertAudioRecording'
   | 'deleteStorageObjects';
 

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -339,6 +339,7 @@ export async function getDeck(id: string): Promise<Deck | undefined> {
 
 export async function updateDeck(id: string, updates: Partial<Deck>): Promise<void> {
   await local.updateDeck(id, updates);
+  await enqueue({ op: 'updateDeck', payload: { id, updates } });
 }
 
 export async function getAllDecks(): Promise<Deck[]> {

--- a/src/db/syncEngine.ts
+++ b/src/db/syncEngine.ts
@@ -13,6 +13,7 @@
 import { supabase } from '../lib/supabase';
 import { AUDIO_BUCKET } from '../lib/audioStorage';
 import { localDb, type SyncOp } from './localDb';
+import type { Deck } from './schema';
 import type { FailedOp } from '../stores/syncStore';
 import { runAudioPrefetch } from '../services/audioPrefetch';
 import { audioBlobToBlob } from './localRepo';
@@ -363,23 +364,22 @@ async function pushDeleteStorageObjects(op: SyncOp): Promise<void> {
 }
 
 async function pushUpdateDeck(op: SyncOp): Promise<void> {
-  const { id, updates } = op.payload as { id: string; updates: Record<string, unknown> };
+  const { id, updates } = op.payload as { id: string; updates: Partial<Deck> };
   // Whitelist the fields that are safe to push. Anything else
   // (like timestamps managed by triggers) is filtered out.
-  const allowed: Record<string, string> = {
+  const FIELD_MAP: Partial<Record<keyof Deck, string>> = {
     name: 'name',
     description: 'description',
     newCardsPerDay: 'new_cards_per_day',
     reviewsPerDay: 'reviews_per_day',
   };
   const row: Record<string, unknown> = {};
-  for (const [camel, snake] of Object.entries(allowed)) {
-    if (camel in updates) row[snake] = updates[camel];
+  for (const [camel, snake] of Object.entries(FIELD_MAP)) {
+    if (camel in updates) row[snake] = updates[camel as keyof Deck];
   }
   if (Object.keys(row).length === 0) return;
 
-  const userId = (await supabase.auth.getSession()).data.session?.user?.id;
-  if (!userId) throw new SyncError('Not authenticated');
+  const userId = getCachedUserIdOrThrow();
   const { error } = await supabase
     .from('decks')
     .update(row)

--- a/src/db/syncEngine.ts
+++ b/src/db/syncEngine.ts
@@ -200,6 +200,9 @@ async function pushOpBatch(ops: SyncOp[]): Promise<void> {
     case 'updateTags':
       await pushSequential(ops, pushUpdateTags);
       break;
+    case 'updateDeck':
+      await pushSequential(ops, pushUpdateDeck);
+      break;
     case 'upsertAudioRecording':
       await pushSequential(ops, pushUpsertAudioRecording);
       break;
@@ -357,6 +360,32 @@ async function pushDeleteStorageObjects(op: SyncOp): Promise<void> {
     const { error } = await supabase.storage.from(AUDIO_BUCKET).remove(chunk);
     if (error) throw syncErrorFrom(error);
   }
+}
+
+async function pushUpdateDeck(op: SyncOp): Promise<void> {
+  const { id, updates } = op.payload as { id: string; updates: Record<string, unknown> };
+  // Whitelist the fields that are safe to push. Anything else
+  // (like timestamps managed by triggers) is filtered out.
+  const allowed: Record<string, string> = {
+    name: 'name',
+    description: 'description',
+    newCardsPerDay: 'new_cards_per_day',
+    reviewsPerDay: 'reviews_per_day',
+  };
+  const row: Record<string, unknown> = {};
+  for (const [camel, snake] of Object.entries(allowed)) {
+    if (camel in updates) row[snake] = updates[camel];
+  }
+  if (Object.keys(row).length === 0) return;
+
+  const userId = (await supabase.auth.getSession()).data.session?.user?.id;
+  if (!userId) throw new SyncError('Not authenticated');
+  const { error } = await supabase
+    .from('decks')
+    .update(row)
+    .eq('id', id)
+    .eq('user_id', userId);
+  if (error) throw syncErrorFrom(error);
 }
 
 async function pushUpdateTags(op: SyncOp): Promise<void> {


### PR DESCRIPTION
## Problem
\`repo.updateDeck\` wrote only to local Dexie. Bumping \`newCardsPerDay\` or \`reviewsPerDay\` in Settings on one device never propagated:

- The server's auto-created deck (defaults: 20/200 from the \`handle_new_user\` trigger in \`schema.sql:171\`) stayed at 20/200 forever.
- Other devices that synced afterward got 20/200 from the server.
- \`pull\` brings deck changes server→device, but no path went device→server.

So a user could have \`newCardsPerDay=100\` on laptop, \`50\` on phone, and \`20\` on the server — no convergence.

Discovered while auditing sync gaps after #173 / #175.

## Fix
Add an \`updateDeck\` SyncOp that mirrors the existing \`updateTags\` pattern:

- New \`'updateDeck'\` entry in the \`SyncOpType\` union (\`localDb.ts\`).
- \`repo.updateDeck\` now calls \`enqueueSync\` after the local write.
- \`pushOpBatch\` routes \`'updateDeck'\` to a new \`pushUpdateDeck\` handler that does \`supabase.from('decks').update(row).eq('id', id).eq('user_id', userId)\` under RLS. The existing \`bump_sync_meta\` trigger on the \`decks\` table handles USN/updated_at server-side.
- \`SyncErrorBanner\` gets an \`OP_LABELS\` entry so failed deck updates surface as "deck settings" in the failure list.

## Why no server migration
The decks table already has \`updated_at\` + \`usn\` columns and a \`trg_decks_sync\` BEFORE-UPDATE trigger (added in \`migrations/001_sync_metadata.sql\`). Pull already serializes the deck row in \`pull_changes\`. All the server-side machinery is in place — we were just missing the client-side push.

## Whitelist
\`pushUpdateDeck\` only sends \`name\`, \`description\`, \`new_cards_per_day\`, \`reviews_per_day\`. Trigger-managed fields (\`updated_at\`, \`usn\`) and immutable fields (\`id\`, \`user_id\`, \`created_at\`) are filtered out — defense against future \`updateDeck\` callers accidentally trying to override them.

## Test plan
- [ ] Sign in on Device A. Change \`reviewsPerDay\` to 100 in Settings → SRS. Wait for sync indicator.
- [ ] Sign in on Device B (or refresh after clearing IndexedDB). Confirm Settings shows \`reviewsPerDay = 100\`.
- [ ] Verify the \`decks.usn\` row in Supabase bumped (via SQL editor).
- [ ] Trigger a sync failure (e.g., revoke RLS or kill network) and confirm SyncErrorBanner labels the failure as "deck settings".
- [ ] Concurrent edits from two devices: last write wins (ok per current pull semantics).

## Out of scope (separate issues)
- FSRS settings sync — \`fsrsSettingsStore\` (requestRetention, learningSteps, eventually the optimizer's 19 weights) is still per-device localStorage. Filed as a follow-up.
- \`auditPinyin\` dev tool also bypasses the outbox. Filed as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)