### PR TITLE
Preserve default deck inside delete_all_user_data

### DIFF
--- a/supabase/migrations/012_delete_all_preserves_default_deck.sql
+++ b/supabase/migrations/012_delete_all_preserves_default_deck.sql
@@ -1,0 +1,53 @@
+-- ============================================================
+-- Patch: delete_all_user_data must leave a usable default deck.
+--
+-- The RPC previously wiped every row in `decks` for the user,
+-- including the auto-created `default-<uid>` deck created by the
+-- `handle_new_user` signup trigger. That left the account with no
+-- deck on the server. The next call to `ensureDefaultDeck` recreated
+-- a deck with the same deterministic id locally only, and the next
+-- `apply_ingest_bundle` (e.g. adding a sentence) rejected with
+-- `Unauthorized operation` because the referenced `deck_id` no
+-- longer existed server-side for this user.
+--
+-- Fix: skip the default deck in the delete pass instead of trying
+-- to re-create it. The deck row stays in place across the wipe,
+-- preserving the user's deck-level settings (newCardsPerDay,
+-- reviewsPerDay) — which Anki also preserves across a data wipe —
+-- and avoids re-emitting the same row shape that `handle_new_user`
+-- already encodes. No tombstone is emitted for it either, since
+-- the row didn't actually go away.
+-- ============================================================
+
+create or replace function delete_all_user_data()
+returns void
+language plpgsql security invoker set search_path = public
+as $func$
+declare
+  uid uuid := auth.uid();
+  now_ms bigint := (extract(epoch from now()) * 1000)::bigint;
+  default_deck_id text := 'default-' || uid::text;
+begin
+  if uid is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  set local statement_timeout = '30s';
+
+  insert into sync_graves (user_id, entity_type, entity_id, deleted_at)
+  select uid, 'sentence', id, now_ms from sentences where user_id = uid
+  union all
+  select uid, 'meaning', id, now_ms from meanings where user_id = uid
+  union all
+  select uid, 'deck', id, now_ms from decks where user_id = uid and id <> default_deck_id
+  union all
+  select uid, 'audio_recording', id, now_ms from audio_recordings where user_id = uid
+  on conflict (user_id, entity_type, entity_id)
+  do update set usn = nextval('sync_usn_seq'), deleted_at = excluded.deleted_at;
+
+  delete from audio_recordings where user_id = uid;
+  delete from sentences where user_id = uid;
+  delete from meanings where user_id = uid;
+  delete from decks where user_id = uid and id <> default_deck_id;
+end;
+$func$;


### PR DESCRIPTION
## Summary

Closes the residual sync gap left after the `handle_new_user` signup trigger landed. **Replaces #160** with a smaller, server-side-only fix.

## Problem

`delete_all_user_data` (`supabase/migrations/005_drop_meaning_fsrs.sql:318`) wipes every row in `decks` for the user, including the auto-created `default-<uid>` deck. The signup trigger doesn't re-fire (the `auth.users` row already exists), so the server is left with no deck.

Locally, the next call to `repo.ensureDefaultDeck` recreates a deck with the same deterministic id offline-only. The next `apply_ingest_bundle` (e.g., adding a sentence) then rejects with `P0001 Unauthorized operation` because the referenced `deck_id` doesn't exist on the server.

## Fix

`supabase/migrations/012_delete_all_recreates_default_deck.sql` skips the default deck in the delete pass. The row stays in place across the wipe:

- Preserves the user's deck-level settings (`newCardsPerDay`, `reviewsPerDay`). Anki preserves these across a data wipe too — they're configuration, not data.
- No row-shape duplication with `handle_new_user`. The original draft of this fix re-inserted the deck after deleting it, which duplicated the deck's default values. Skipping the delete entirely is cleaner.
- No tombstone for the default deck (the row didn't go away). Custom decks (if any) still get tombstoned and deleted as before.

## Why not #160

PR #160 added a new `upsertDeck` sync op + a heal flag. The `handle_new_user` trigger merged in the meantime makes the new-user case automatic, which removed most of #160's scope. The only remaining edge case was the delete-all-data race — patching the RPC directly is smaller and doesn't require a new client op type.

Tradeoff: this PR doesn't auto-heal devices currently stuck in the bad state from before the trigger was added. Affected users (if any) need a manual `insert into decks ...` for their account.

## Test plan

- [ ] Run the migration locally / on staging.
- [ ] In a Supabase SQL editor: `select id, user_id, name, new_cards_per_day, reviews_per_day from decks where user_id = '<uid>';` — confirm the default deck is still present after `select delete_all_user_data();`, and that any non-default user-customized values on its settings columns are preserved.
- [ ] In the app: trigger "Delete all data" from Settings, then add a new sentence — confirm sync succeeds with no `P0001 Unauthorized operation`.
- [ ] Confirm no `sync_graves` row for `(uid, 'deck', 'default-<uid>')` after the wipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)