### PR TITLE
Sync FSRS settings + meaning updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,12 @@ import { SyncErrorBanner } from './components/SyncErrorBanner';
 import { InstallBanner } from './components/InstallBanner';
 import { useTutorialStore, skipTutorialIfReturningUser } from './stores/tutorialStore';
 import { useAuthStore } from './stores/authStore';
+import {
+  useFSRSSettingsStore,
+  getFSRSSettings,
+  isHydratingFSRSSettings,
+} from './stores/fsrsSettingsStore';
+import * as repo from './db/repo';
 import './stores/themeStore';
 
 const LoadingScreen = ({ message }: { message?: string }) => (
@@ -85,6 +91,23 @@ function App() {
   // Sign-out: clear ready so hydration re-runs on next login
   useEffect(() => {
     if (!userId && ready) setReady(false);
+  }, [userId, ready]);
+
+  // Push FSRS settings changes to the deck row so they sync. Skips writes
+  // triggered by sync-side hydration (avoids the pull→hydrate→push loop).
+  useEffect(() => {
+    if (!userId || !ready) return;
+    return useFSRSSettingsStore.subscribe(async () => {
+      if (isHydratingFSRSSettings()) return;
+      try {
+        const deckId = await repo.ensureDefaultDeck();
+        await repo.updateDeck(deckId, {
+          fsrsSettings: getFSRSSettings() as unknown as Record<string, unknown>,
+        });
+      } catch (err) {
+        console.error('Failed to enqueue FSRS settings update', err);
+      }
+    });
   }, [userId, ready]);
 
   if (authLoading) return <LoadingScreen />;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -93,21 +93,30 @@ function App() {
     if (!userId && ready) setReady(false);
   }, [userId, ready]);
 
-  // Push FSRS settings changes to the deck row so they sync. Skips writes
-  // triggered by sync-side hydration (avoids the pull→hydrate→push loop).
+  // Push FSRS settings changes to the deck row so they sync. Debounced so a
+  // dragged slider collapses into one outbox op instead of dozens. Skips
+  // writes triggered by sync-side hydration (avoids the pull→hydrate→push
+  // loop).
   useEffect(() => {
     if (!userId || !ready) return;
-    return useFSRSSettingsStore.subscribe(async () => {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const unsubscribe = useFSRSSettingsStore.subscribe(() => {
       if (isHydratingFSRSSettings()) return;
-      try {
-        const deckId = await repo.ensureDefaultDeck();
-        await repo.updateDeck(deckId, {
-          fsrsSettings: getFSRSSettings() as unknown as Record<string, unknown>,
-        });
-      } catch (err) {
-        console.error('Failed to enqueue FSRS settings update', err);
-      }
+      if (timer) clearTimeout(timer);
+      timer = setTimeout(async () => {
+        timer = null;
+        try {
+          const deckId = await repo.ensureDefaultDeck();
+          await repo.updateDeck(deckId, { fsrsSettings: getFSRSSettings() });
+        } catch (err) {
+          console.error('Failed to enqueue FSRS settings update', err);
+        }
+      }, 500);
     });
+    return () => {
+      if (timer) clearTimeout(timer);
+      unsubscribe();
+    };
   }, [userId, ready]);
 
   if (authLoading) return <LoadingScreen />;

--- a/src/components/SyncErrorBanner.tsx
+++ b/src/components/SyncErrorBanner.tsx
@@ -10,6 +10,7 @@ const OP_LABELS: Record<SyncOpType, string> = {
   deleteAllData: 'clear all data',
   updateTags: 'tag update',
   updateDeck: 'deck settings',
+  updateMeaning: 'meaning update',
   upsertAudioRecording: 'audio upload',
   deleteStorageObjects: 'audio cleanup',
 };

--- a/src/db/localDb.ts
+++ b/src/db/localDb.ts
@@ -24,6 +24,7 @@ export type SyncOpType =
   | 'deleteAllData'
   | 'updateTags'
   | 'updateDeck'
+  | 'updateMeaning'
   | 'upsertAudioRecording'
   | 'deleteStorageObjects';
 

--- a/src/db/localRepo.ts
+++ b/src/db/localRepo.ts
@@ -51,6 +51,10 @@ export async function insertMeaning(meaning: Meaning): Promise<void> {
   await localDb.meanings.put(meaning);
 }
 
+export async function updateMeaning(id: string, updates: Partial<Meaning>): Promise<void> {
+  await localDb.meanings.update(id, updates);
+}
+
 export async function deleteMeaningsByIds(ids: string[]): Promise<void> {
   if (ids.length === 0) return;
   await localDb.meanings.bulkDelete(ids);

--- a/src/db/mappers.ts
+++ b/src/db/mappers.ts
@@ -72,6 +72,7 @@ export function deckFromRow(r: any): Deck {
   return {
     id: r.id, name: r.name, description: r.description,
     newCardsPerDay: r.new_cards_per_day, reviewsPerDay: r.reviews_per_day,
+    fsrsSettings: r.fsrs_settings ?? {},
     createdAt: r.created_at,
     usn: r.usn,
   };

--- a/src/db/repo.ts
+++ b/src/db/repo.ts
@@ -78,6 +78,11 @@ export async function insertMeaning(meaning: Meaning): Promise<void> {
   // Meanings are enqueued as part of ingestBundle — no standalone outbox op needed.
 }
 
+export async function updateMeaning(id: string, updates: Partial<Meaning>): Promise<void> {
+  await local.updateMeaning(id, updates);
+  await enqueue({ op: 'updateMeaning', payload: { id, updates } });
+}
+
 // ============================================================
 // MeaningLinks — reads from local, writes local + outbox
 // ============================================================

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -173,17 +173,25 @@ export interface SrsCard {
   usn?: number;
 }
 
+/** FSRS scheduling parameters. Stored as a partial so missing keys fall
+ *  back to client-side defaults — that's how the column starts (`{}`) for
+ *  new users, and how unknown future keys land on older clients. */
+export interface FSRSSettings {
+  requestRetention: number;
+  maximumInterval: number;
+  enableFuzz: boolean;
+  enableShortTerm: boolean;
+  learningSteps: string[];
+  relearningSteps: string[];
+}
+
 export interface Deck {
   id: string;
   name: string;
   description: string;
   newCardsPerDay: number;
   reviewsPerDay: number;
-  /** FSRS scheduling parameters (requestRetention, learning steps, etc.).
-   *  Stored as a free-form record so future fields (e.g. the optimizer's
-   *  weight vector) don't need schema migrations. Empty `{}` means
-   *  "use hardcoded defaults". */
-  fsrsSettings?: Record<string, unknown>;
+  fsrsSettings?: Partial<FSRSSettings>;
   createdAt: number;
   updatedAt?: number;
   usn?: number;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -179,6 +179,11 @@ export interface Deck {
   description: string;
   newCardsPerDay: number;
   reviewsPerDay: number;
+  /** FSRS scheduling parameters (requestRetention, learning steps, etc.).
+   *  Stored as a free-form record so future fields (e.g. the optimizer's
+   *  weight vector) don't need schema migrations. Empty `{}` means
+   *  "use hardcoded defaults". */
+  fsrsSettings?: Record<string, unknown>;
   createdAt: number;
   updatedAt?: number;
   usn?: number;

--- a/src/db/syncEngine.ts
+++ b/src/db/syncEngine.ts
@@ -530,6 +530,8 @@ async function pullOnePage(): Promise<boolean> {
         await localDb.decks.bulkPut(localDecks);
         // Mirror the (possibly updated) FSRS settings into the in-memory
         // store so the FSRS scheduler picks up the new params immediately.
+        // TODO(multi-deck): the FSRS store is global today; once decks can
+        // have per-deck settings, scope this to the active/default deck.
         for (const d of localDecks) hydrateFSRSSettingsFromBlob(d.fsrsSettings);
       }
       trackRows(changes.decks);

--- a/src/db/syncEngine.ts
+++ b/src/db/syncEngine.ts
@@ -13,7 +13,8 @@
 import { supabase } from '../lib/supabase';
 import { AUDIO_BUCKET } from '../lib/audioStorage';
 import { localDb, type SyncOp } from './localDb';
-import type { Deck } from './schema';
+import type { Deck, Meaning } from './schema';
+import { hydrateFSRSSettingsFromBlob } from '../stores/fsrsSettingsStore';
 import type { FailedOp } from '../stores/syncStore';
 import { runAudioPrefetch } from '../services/audioPrefetch';
 import { audioBlobToBlob } from './localRepo';
@@ -204,6 +205,9 @@ async function pushOpBatch(ops: SyncOp[]): Promise<void> {
     case 'updateDeck':
       await pushSequential(ops, pushUpdateDeck);
       break;
+    case 'updateMeaning':
+      await pushSequential(ops, pushUpdateMeaning);
+      break;
     case 'upsertAudioRecording':
       await pushSequential(ops, pushUpsertAudioRecording);
       break;
@@ -372,6 +376,7 @@ async function pushUpdateDeck(op: SyncOp): Promise<void> {
     description: 'description',
     newCardsPerDay: 'new_cards_per_day',
     reviewsPerDay: 'reviews_per_day',
+    fsrsSettings: 'fsrs_settings',
   };
   const row: Record<string, unknown> = {};
   for (const [camel, snake] of Object.entries(FIELD_MAP)) {
@@ -382,6 +387,34 @@ async function pushUpdateDeck(op: SyncOp): Promise<void> {
   const userId = getCachedUserIdOrThrow();
   const { error } = await supabase
     .from('decks')
+    .update(row)
+    .eq('id', id)
+    .eq('user_id', userId);
+  if (error) throw syncErrorFrom(error);
+}
+
+async function pushUpdateMeaning(op: SyncOp): Promise<void> {
+  const { id, updates } = op.payload as { id: string; updates: Partial<Meaning> };
+  // Mutable fields only. id/type/createdAt are immutable by convention;
+  // updatedAt/usn are managed by the bump_sync_meta trigger.
+  const FIELD_MAP: Partial<Record<keyof Meaning, string>> = {
+    headword: 'headword',
+    pinyinNumeric: 'pinyin_numeric',
+    partOfSpeech: 'part_of_speech',
+    englishShort: 'english_short',
+    englishFull: 'english_full',
+    level: 'level',
+    isTransliteration: 'is_transliteration',
+  };
+  const row: Record<string, unknown> = {};
+  for (const [camel, snake] of Object.entries(FIELD_MAP)) {
+    if (camel in updates) row[snake] = updates[camel as keyof Meaning];
+  }
+  if (Object.keys(row).length === 0) return;
+
+  const userId = getCachedUserIdOrThrow();
+  const { error } = await supabase
+    .from('meanings')
     .update(row)
     .eq('id', id)
     .eq('user_id', userId);
@@ -493,7 +526,11 @@ async function pullOnePage(): Promise<boolean> {
       trackRows(changes.sentence_tokens);
 
       if (changes.decks.length > 0) {
-        await localDb.decks.bulkPut(changes.decks.map(deckFromRow));
+        const localDecks = changes.decks.map(deckFromRow);
+        await localDb.decks.bulkPut(localDecks);
+        // Mirror the (possibly updated) FSRS settings into the in-memory
+        // store so the FSRS scheduler picks up the new params immediately.
+        for (const d of localDecks) hydrateFSRSSettingsFromBlob(d.fsrsSettings);
       }
       trackRows(changes.decks);
 

--- a/src/lib/auditPinyin.ts
+++ b/src/lib/auditPinyin.ts
@@ -2,8 +2,6 @@ import * as repo from '../db/repo';
 import { numericStringToDiacritic } from '../services/toneSandhi';
 import { loadCedict, lookup } from './cedict';
 import { collapsePinyin } from './checkPinyin';
-import { localDb } from '../db/localDb';
-import { supabase } from './supabase';
 import type { Meaning } from '../db/schema';
 
 export interface AuditRow {
@@ -109,19 +107,13 @@ export async function repairFlaggedPinyin(): Promise<RepairSummary> {
     const canonical = row.cedictEntries[0].toLowerCase();
     if (canonical === row.pinyinNumeric.toLowerCase()) continue;
 
-    await localDb.meanings.update(row.id, {
-      pinyinNumeric: canonical,
-      updatedAt: Date.now(),
-    });
-    const { error } = await supabase
-      .from('meanings')
-      .update({ pinyin_numeric: canonical, updated_at: Date.now() })
-      .eq('id', row.id);
-    if (error) {
+    try {
+      await repo.updateMeaning(row.id, { pinyinNumeric: canonical });
+    } catch (e) {
       skipped.push({
         headword: row.headword,
         stored: row.pinyinNumeric,
-        reason: `supabase update failed: ${error.message}`,
+        reason: `update failed: ${(e as Error).message}`,
       });
       continue;
     }

--- a/src/stores/fsrsSettingsStore.ts
+++ b/src/stores/fsrsSettingsStore.ts
@@ -1,16 +1,10 @@
 import { create } from 'zustand';
 import type { Steps } from 'ts-fsrs';
+import type { FSRSSettings } from '../db/schema';
+
+export type { FSRSSettings };
 
 const STORAGE_KEY = 'mandao_fsrs_settings';
-
-export interface FSRSSettings {
-  requestRetention: number;
-  maximumInterval: number;
-  enableFuzz: boolean;
-  enableShortTerm: boolean;
-  learningSteps: string[];
-  relearningSteps: string[];
-}
 
 const DEFAULTS: FSRSSettings = {
   requestRetention: 0.9,
@@ -58,9 +52,9 @@ export const useFSRSSettingsStore = create<FSRSSettingsState>((set, get) => ({
 /** Pull only the FSRSSettings shape out of the store (drop action methods). */
 export function getFSRSSettings(): FSRSSettings {
   const state = useFSRSSettingsStore.getState();
-  const out: Record<string, unknown> = {};
-  for (const k of SETTING_KEYS) out[k] = state[k];
-  return out as unknown as FSRSSettings;
+  const out = {} as FSRSSettings;
+  for (const k of SETTING_KEYS) (out[k] as FSRSSettings[typeof k]) = state[k];
+  return out;
 }
 
 /**
@@ -74,15 +68,13 @@ export function isHydratingFSRSSettings(): boolean {
 }
 export function hydrateFSRSSettingsFromBlob(blob: Record<string, unknown> | undefined): void {
   if (!blob || Object.keys(blob).length === 0) return;
-  const merged = { ...DEFAULTS } as FSRSSettings;
-  let changed = false;
+  const merged: FSRSSettings = { ...DEFAULTS };
+  const partial = blob as Partial<FSRSSettings>;
   for (const k of SETTING_KEYS) {
-    if (k in blob) {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (merged as any)[k] = (blob as any)[k];
-    }
+    if (k in partial) (merged[k] as FSRSSettings[typeof k]) = partial[k] as FSRSSettings[typeof k];
   }
   const cur = getFSRSSettings();
+  let changed = false;
   for (const k of SETTING_KEYS) {
     if (JSON.stringify(cur[k]) !== JSON.stringify(merged[k])) { changed = true; break; }
   }

--- a/src/stores/fsrsSettingsStore.ts
+++ b/src/stores/fsrsSettingsStore.ts
@@ -21,6 +21,8 @@ const DEFAULTS: FSRSSettings = {
   relearningSteps: ['10m'],
 };
 
+const SETTING_KEYS = Object.keys(DEFAULTS) as (keyof FSRSSettings)[];
+
 function load(): FSRSSettings {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -52,6 +54,47 @@ export const useFSRSSettingsStore = create<FSRSSettingsState>((set, get) => ({
     set({ ...DEFAULTS });
   },
 }));
+
+/** Pull only the FSRSSettings shape out of the store (drop action methods). */
+export function getFSRSSettings(): FSRSSettings {
+  const state = useFSRSSettingsStore.getState();
+  const out: Record<string, unknown> = {};
+  for (const k of SETTING_KEYS) out[k] = state[k];
+  return out as unknown as FSRSSettings;
+}
+
+/**
+ * Hydrate the store from a remote deck row's `fsrs_settings` blob (after
+ * a sync pull). Skips no-op assignments to avoid the subscribe-→push-→
+ * pull loop. Unknown keys are ignored; missing keys fall back to defaults.
+ */
+let hydrating = false;
+export function isHydratingFSRSSettings(): boolean {
+  return hydrating;
+}
+export function hydrateFSRSSettingsFromBlob(blob: Record<string, unknown> | undefined): void {
+  if (!blob || Object.keys(blob).length === 0) return;
+  const merged = { ...DEFAULTS } as FSRSSettings;
+  let changed = false;
+  for (const k of SETTING_KEYS) {
+    if (k in blob) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (merged as any)[k] = (blob as any)[k];
+    }
+  }
+  const cur = getFSRSSettings();
+  for (const k of SETTING_KEYS) {
+    if (JSON.stringify(cur[k]) !== JSON.stringify(merged[k])) { changed = true; break; }
+  }
+  if (!changed) return;
+  hydrating = true;
+  try {
+    save(merged);
+    useFSRSSettingsStore.setState(merged);
+  } finally {
+    hydrating = false;
+  }
+}
 
 /** Convert store state to ts-fsrs generatorParameters input */
 export function toFSRSParams(s: FSRSSettings) {

--- a/supabase/migrations/012_decks_fsrs_settings.sql
+++ b/supabase/migrations/012_decks_fsrs_settings.sql
@@ -1,0 +1,18 @@
+-- ============================================================
+-- Migration: decks.fsrs_settings
+--
+-- Persist FSRS scheduling parameters (requestRetention, learning steps,
+-- enableFuzz, enableShortTerm, maximumInterval, and — once the optimizer
+-- ships — the 19 weights) on the deck row so they sync across devices.
+--
+-- Stored as jsonb so adding new keys (e.g. the optimizer's weight vector)
+-- doesn't require another migration. Defaults to '{}'; the client falls
+-- back to its hardcoded defaults whenever the column is empty.
+--
+-- The existing trg_decks_sync trigger (migration 001) automatically bumps
+-- usn + updated_at on update, so pull picks up the change without RPC
+-- changes (pull_changes uses row_to_json so new columns flow through).
+-- ============================================================
+
+alter table decks
+  add column if not exists fsrs_settings jsonb not null default '{}'::jsonb;


### PR DESCRIPTION
Closes #177, closes #178.

## Summary
Closes the two remaining sync gaps surfaced by the post-#176 audit, in one PR since they share the "extend the SyncOp pipeline" pattern.

### #177 — FSRS settings sync
Persist all FSRS scheduling params (\`requestRetention\`, \`maximumInterval\`, fuzz/shortTerm flags, learning + relearning steps) as a jsonb blob on the deck row. Free-form shape so future fields (the optimizer's 19 weights from #173) can land without another migration.

- **Migration 012:** adds \`decks.fsrs_settings jsonb default '{}'\`. The pull RPC uses \`row_to_json\` so the new column flows through with **no RPC change**. The existing \`trg_decks_sync\` trigger keeps usn/updated_at in sync.
- **Schema:** \`Deck\` gets \`fsrsSettings\`, \`deckFromRow\` reads \`fsrs_settings\`, \`pushUpdateDeck\` whitelists \`fsrsSettings → fsrs_settings\`. The existing #176 deck-update pipeline carries the change end-to-end.
- **App.tsx subscription:** when Settings → SRS edits the FSRS store, the subscription pushes a \`repo.updateDeck({ fsrsSettings: ... })\` call. Skipped while \`isHydratingFSRSSettings()\` is true (prevents the pull→hydrate→push feedback loop).
- **Pull-side hydration:** \`syncEngine\` calls \`hydrateFSRSSettingsFromBlob(deck.fsrsSettings)\` after \`localDb.decks.bulkPut\`, so the FSRS scheduler picks up new params immediately. Deep-equal short-circuit prevents redundant store writes.

### #178 — Meaning row updates
Add an \`updateMeaning\` SyncOp that mirrors \`updateDeck\`: direct \`supabase.from('meanings').update()\` under RLS, with \`trg_meanings_sync\` (already exists) handling usn/updated_at.

- New \`'updateMeaning'\` op type in \`SyncOpType\`.
- \`repo.updateMeaning\` writes Dexie + enqueues.
- \`pushUpdateMeaning\` whitelists mutable fields (headword, pinyinNumeric, partOfSpeech, englishShort, englishFull, level, isTransliteration). Trigger-managed and immutable fields are filtered out.
- \`SyncErrorBanner\` labels failures as 'meaning update'.
- \`auditPinyin.ts\` now goes through \`repo.updateMeaning\` instead of double-writing to Dexie + supabase by hand.

## Why one PR
Both extend the same SyncOp pipeline added in #176. Reviewers can spot the consistent shape (whitelist + RLS-direct-update + trigger-driven USN). Migration is one file. Net +144 / -14.

## What is and isn't in scope
- ✅ FSRS settings persist + sync across devices
- ✅ Meaning updates go through the outbox, retry on failure, surface in SyncErrorBanner
- ✅ \`auditPinyin\` cleaned up
- ⚠️ FSRS settings stay deck-level (only one deck per user; matches Anki). If we ever go multi-deck, each deck can have its own settings or fall back to a global default — this design is forward-compatible.

## Test plan
- [ ] Run migration: \`supabase db push\` (or apply 012 manually). Confirm \`decks.fsrs_settings\` is a \`jsonb\` defaulted to \`{}\`.
- [ ] Open Settings → SRS on Device A. Change \`requestRetention\` from 0.9 to 0.85. Wait for sync indicator.
- [ ] Verify in Supabase SQL editor: \`select id, fsrs_settings, usn from decks where user_id = auth.uid()\` — \`fsrs_settings\` reflects the new value, \`usn\` bumped.
- [ ] On Device B (different browser / clear IndexedDB and re-sign-in): open Settings → SRS, confirm \`requestRetention = 0.85\`. Rate a card; confirm FSRS uses the synced 0.85.
- [ ] Run \`auditPinyin\`'s repair from dev console. Confirm meaning's \`pinyin_numeric\` updates locally and on server. Force a network failure mid-repair: the op shows up in SyncErrorBanner as 'meaning update' and retries on reconnect.
- [ ] Verify the feedback-loop guard: edit FSRS settings on Device A → push → Device B pulls → hydrates → does NOT re-push (would show as a no-op in the outbox and bump usn unnecessarily).

🤖 Generated with [Claude Code](https://claude.com/claude-code)